### PR TITLE
Compat.Iterators needs 0.18 minimum

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,6 @@ DiffEqBase 1.1.0
 Parameters 0.5.0
 ForwardDiff 0.2.4
 GenericSVD 0.0.2
-Compat 0.8.8
 InplaceOps 0.0.5
 NLsolve 0.9.1
 RecursiveArrayTools 0.2.0
@@ -12,4 +11,4 @@ Calculus 0.1.15
 Roots 0.2.1
 DataStructures 0.4.6
 Iterators
-Compat 0.17.0
+Compat 0.18.0

--- a/test/iterator_tests.jl
+++ b/test/iterator_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test, DiffEqBase
+using OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test, DiffEqBase, Compat
 prob = prob_ode_linear
 
 sol = solve(prob,BS3();dt=1//2^(4),tstops=[0.5],saveat=0.01,save_everystep=true)


### PR DESCRIPTION
should have mentioned that bit https://github.com/JuliaLang/Compat.jl/commit/a53f1023da52c5098e5ddb70ef49379fcfee1c87

remove duplicate less strict Compat entry
and import Compat in the test that uses it