### PR TITLE
Add dense SSP output for `SSPRK22` and `SSPRK33`

### DIFF
--- a/src/dense/interpolants.jl
+++ b/src/dense/interpolants.jl
@@ -118,30 +118,28 @@ end
 end
 
 """
-Second order strong stability preserving (SSP) interpolant for the
-two stage, second order SSP Runge-Kutta method.
+Second order strong stability preserving (SSP) interpolant.
 
 Ketcheson, Lóczi, Jangabylova, Kusmanov: Dense output for SSP RK methods (2017).
 """
-@inline function ode_interpolant(Θ,dt,y₀,y₁,k,cache::SSPRK22ConstantCache,idxs,T::Type{Val{0}})
-  Θ1 = 1-Θ
-  #@. Θ1*y₀ + Θ*Θ1*(y₀ + dt*k[1]) + Θ^2*y₁
-  Θ1*y₀ + Θ*Θ1*(y₀ + dt*k[1]) + Θ^2*y₁
+@inline function ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK33ConstantCache},idxs,T::Type{Val{0}})
+  #@. (1-Θ^2)*y₀ + Θ^2*y₁ + Θ*(1-Θ)*dt*k[1]
+  (1-Θ^2)*y₀ + Θ^2*y₁ + Θ*(1-Θ)*dt*k[1]
 end
 
-@inline function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::SSPRK22Cache,idxs,T::Type{Val{0}})
+@inline function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{SSPRK22Cache,SSPRK33Cache},idxs,T::Type{Val{0}})
   Θ1 = 1-Θ
   if out == nothing
-    return @. Θ1*y₀[idxs] + Θ*Θ1*(y₀[idxs] + dt*k[1][idxs]) + Θ^2*y₁[idxs]
+    return @. (1-Θ^2)*y₀[idxs] + Θ^2*y₁[idxs] + Θ*(1-Θ)*dt*k[1][idxs]
   elseif idxs == nothing
-    #@. out = Θ1*y₀ + Θ*(1-Θ)*(y₀ + dt*k[1]) + Θ^2*y₁
+    #@. out = (1-Θ^2)*y₀ + Θ^2*y₁ + Θ*(1-Θ)*dt*k[1]
     @inbounds for i in eachindex(out)
-      out[i] = Θ1*y₀[i] + Θ*(1-Θ)*(y₀[i] + dt*k[1][i]) + Θ^2*y₁[i]
+      out[i] = (1-Θ^2)*y₀[i] + Θ^2*y₁[i] + Θ*(1-Θ)*dt*k[1][i]
     end
   else
-    #@views @. out = Θ1*y₀[idxs] + Θ*(1-Θ)*(y₀[idxs] + dt*k[1][idxs]) + Θ^2*y₁[idxs]
+    #@views @. out = (1-Θ^2)*y₀[idxs] + Θ^2*y₁[idxs] + Θ*(1-Θ)*dt*k[1][idxs]
     @inbounds for (j,i) in enumerate(idxs)
-      out[j] = Θ1*y₀[i] + Θ*(1-Θ)*(y₀[i] + dt*k[1][i]) + Θ^2*y₁[i]
+      out[j] = (1-Θ^2)*y₀[i] + Θ^2*y₁[i] + Θ*(1-Θ)*dt*k[1][i]
     end
   end
 end

--- a/src/integrators/ssprk_integrators.jl
+++ b/src/integrators/ssprk_integrators.jl
@@ -55,7 +55,7 @@ end
 
 @inline function initialize!(integrator,cache::SSPRK33ConstantCache,f=integrator.f)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
-  integrator.kshortsize = 2
+  integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
 end
 
@@ -69,7 +69,6 @@ end
   u = (uprev + 2*tmp + 2*dt*k) / 3
   integrator.fsallast = f(t+dt,u) # For interpolation, then FSAL'd
   integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
   @pack integrator = t,dt,u
 end
 
@@ -77,10 +76,9 @@ end
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.kshortsize = 2
+  integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
   f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
 

--- a/src/integrators/ssprk_integrators.jl
+++ b/src/integrators/ssprk_integrators.jl
@@ -1,6 +1,6 @@
 @inline function initialize!(integrator,cache::SSPRK22ConstantCache,f=integrator.f)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
-  integrator.kshortsize = 2
+  integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
 end
 
@@ -12,7 +12,6 @@ end
   u = @. (uprev + tmp + dt*k) / 2
   integrator.fsallast = f(t+dt,u) # For interpolation, then FSAL'd
   integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
   @pack integrator = t,dt,u
 end
 
@@ -20,10 +19,9 @@ end
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.kshortsize = 2
+  integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
   f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
 

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -81,6 +81,11 @@ for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
   @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
 end
+# test SSP property of dense output
+sol = solve(test_problem_ssp, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, true, linspace(0,8))
+sol = solve(test_problem_ssp_inplace, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, true, linspace(0,8))
 
 
 alg = SSPRK104()

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -19,6 +19,16 @@ f = (t,u,du)->du[1]=sin(u[1])
 (p::typeof(f))(::Type{Val{:analytic}},t,u0) = [2*acot(exp(-t)*cot(0.5))]
 prob_ode_nonlinear_inplace = ODEProblem(f,[1.],(0.,0.5))
 
+const linear_bigα = parse(BigFloat,"1.01")
+f_2dlinearbig = (t,u,du) -> begin
+  for i in 1:length(u)
+    du[i] = linear_bigα*u[i]
+  end
+end
+(f::typeof(f_2dlinearbig))(::Type{Val{:analytic}},t,u0) = u0*exp.(1.01*t)
+prob_ode_bigfloat2Dlinear = ODEProblem(f_2dlinearbig,map(BigFloat,rand(4,2)).*ones(4,2)/2,(0.0,1.0))
+
+
 test_problems_only_time = [prob_ode_sin, prob_ode_sin_inplace]
 test_problems_linear = [prob_ode_linear, prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear]
 test_problems_nonlinear = [prob_ode_nonlinear, prob_ode_nonlinear_inplace]

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -1,5 +1,7 @@
 using DiffEqBase, OrdinaryDiffEq, DiffEqProblemLibrary, DiffEqDevTools, Base.Test
 
+srand(100)
+
 dts = 1.//2.^(8:-1:4)
 testTol = 0.25
 
@@ -33,6 +35,16 @@ test_problems_only_time = [prob_ode_sin, prob_ode_sin_inplace]
 test_problems_linear = [prob_ode_linear, prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear]
 test_problems_nonlinear = [prob_ode_nonlinear, prob_ode_nonlinear_inplace]
 
+f_ssp = (t,u) -> begin
+  sin(10t) * u * (1-u)
+end
+test_problem_ssp = ODEProblem(f_ssp, 0.1, (0., 8.))
+
+f_ssp_inplace = (t,u,du) -> begin
+  @. du = sin(10t) * u * (1-u)
+end
+test_problem_ssp_inplace = ODEProblem(f_ssp_inplace, rand(3,3), (0., 8.))
+
 
 alg = SSPRK22()
 for prob in test_problems_only_time
@@ -47,6 +59,11 @@ for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
   @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
 end
+# test SSP property of dense output
+sol = solve(test_problem_ssp, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, true, linspace(0,8))
+sol = solve(test_problem_ssp_inplace, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, true, linspace(0,8))
 
 
 alg = SSPRK33()


### PR DESCRIPTION
This adds dense SSP output for the SSP methods `SSPRK22` and `SSPRK33` as described by Ketcheson, Lóczi, Jangabylova, Kusmanov: Dense output for SSP RK methods (2017).

See #39.