### PR TITLE
Remove type of integrator in signature of apply_discrete_callback!

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -181,7 +181,7 @@ function apply_callback!(integrator,callback::ContinuousCallback,cb_time,prev_si
 end
 
 #Base Case: Just one
-@inline function apply_discrete_callback!(integrator::ODEIntegrator,callback::DiscreteCallback)
+@inline function apply_discrete_callback!(integrator,callback::DiscreteCallback)
   @inbounds if callback.save_positions[1]
     savevalues!(integrator)
   end
@@ -197,16 +197,16 @@ end
 end
 
 #Starting: Get bool from first and do next
-@inline function apply_discrete_callback!(integrator::ODEIntegrator,callback::DiscreteCallback,args...)
+@inline function apply_discrete_callback!(integrator,callback::DiscreteCallback,args...)
   apply_discrete_callback!(integrator,apply_discrete_callback!(integrator,callback),args...)
 end
 
-@inline function apply_discrete_callback!(integrator::ODEIntegrator,discrete_modified::Bool,callback::DiscreteCallback,args...)
+@inline function apply_discrete_callback!(integrator,discrete_modified::Bool,callback::DiscreteCallback,args...)
   bool = apply_discrete_callback!(integrator,apply_discrete_callback!(integrator,callback),args...)
   discrete_modified || bool
 end
 
-@inline function apply_discrete_callback!(integrator::ODEIntegrator,discrete_modified::Bool,callback::DiscreteCallback)
+@inline function apply_discrete_callback!(integrator,discrete_modified::Bool,callback::DiscreteCallback)
   bool = apply_discrete_callback!(integrator,callback)
   discrete_modified || bool
 end


### PR DESCRIPTION
Hi!

I wanted to use discrete callbacks with delay differential equations, similar to the [test with a continuous callback](https://github.com/JuliaDiffEq/DelayDiffEq.jl/blob/master/test/events.jl). However, therefore I had to remove some type annotations in `apply_discrete_callback!`.

Modified example (similar to the [continuous test](https://github.com/JuliaDiffEq/DelayDiffEq.jl/blob/master/test/events.jl)):
```julia
using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test, DiffEqDevTools

lags = [1]
f = function (t,u,h)
  du = - h(t-1)
end
h = (t) -> 0.0


prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
alg = MethodOfSteps(Tsit5();constrained=false)

condtion= function (t,u,integrator)
  u[1]<0
end

affect! = function (integrator)
  integrator.u = -integrator.u
end

cb = DiscreteCallback(condition,affect!)

sol = solve(prob,alg,callback=cb)
```
This results in the following error on the master branch
```julia
ERROR: MethodError: no method matching apply_discrete_callback!(::DelayDiffEq.DDEIntegrator{OrdinaryDiffEq.Tsit5,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Array{Float64,1},DiffEqBase.ODESolution{Float64,1,Array{Float64,1},Void,Void,Array{Float64,1},Array{Array{Float64,1},1},DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{DelayDiffEq.##14#18{DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}}},Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}},Float64,DelayDiffEq.##16#20{DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}}},Void,OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},OrdinaryDiffEq.ODEIntegrator{OrdinaryDiffEq.Tsit5,Float64,Float64,Float64,Float64,Array{Float64,1},DiffEqBase.ODESolution{Float64,1,Array{Float64,1},Void,Void,Array{Float64,1},Array{Array{Float64,1},1},DiffEqBase.ODEProblem{Float64,Float64,false,##1#2,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{##1#2,Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}},Float64,##1#2,Void,OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{DiffEqBase.DiscreteCallback{##5#6,##7#8,DiffEqBase.#INITIALIZE_DEFAULT}}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void},Float64},DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}},DiffEqBase.#ODE_DEFAULT_NORM,OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{DiffEqBase.DiscreteCallback{##5#6,##7#8,DiffEqBase.#INITIALIZE_DEFAULT}}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void}}, ::DiffEqBase.DiscreteCallback{##5#6,##7#8,DiffEqBase.#INITIALIZE_DEFAULT})                                                        
Closest candidates are:
  apply_discrete_callback!(::OrdinaryDiffEq.ODEIntegrator, ::DiffEqBase.DiscreteCallback) at /home/david/.julia/v0.6/OrdinaryDiffEq/src/callbacks.jl:185
  apply_discrete_callback!(::OrdinaryDiffEq.ODEIntegrator, ::DiffEqBase.DiscreteCallback, ::Any...) at /home/david/.julia/v0.6/OrdinaryDiffEq/src/callbacks.jl:201
Stacktrace:
 [1] handle_callbacks! at /home/david/.julia/v0.6/OrdinaryDiffEq/src/integrators/integrator_utils.jl:217 [inlined]
 [2] loopfooter! at /home/david/.julia/v0.6/OrdinaryDiffEq/src/integrators/integrator_utils.jl:186 [inlined]
 [3] solve!(::DelayDiffEq.DDEIntegrator{OrdinaryDiffEq.Tsit5,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Array{Float64,1},DiffEqBase.ODESolution{Float64,1,Array{Float64,1},Void,Void,Array{Float64,1},Array{Array{Float64,1},1},DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{DelayDiffEq.##14#18{DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}}},Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}},Float64,DelayDiffEq.##16#20{DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}}},Void,OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},OrdinaryDiffEq.ODEIntegrator{OrdinaryDiffEq.Tsit5,Float64,Float64,Float64,Float64,Array{Float64,1},DiffEqBase.ODESolution{Float64,1,Array{Float64,1},Void,Void,Array{Float64,1},Array{Array{Float64,1},1},DiffEqBase.ODEProblem{Float64,Float64,false,##1#2,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{##1#2,Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}},Float64,##1#2,Void,OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{DiffEqBase.DiscreteCallback{##5#6,##7#8,DiffEqBase.#INITIALIZE_DEFAULT}}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void},Float64},DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}},DiffEqBase.#ODE_DEFAULT_NORM,OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{DiffEqBase.DiscreteCallback{##5#6,##7#8,DiffEqBase.#INITIALIZE_DEFAULT}}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void}}) at /home/david/.julia/v0.6/DelayDiffEq/src/solve.jl:137
 [4] #solve#23(::Array{Any,1}, ::Function, ::DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}}, ::DelayDiffEq.MethodOfSteps{OrdinaryDiffEq.Tsit5,Void,Void,Void,false}, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Any,1}) at /home/david/.julia/v0.6/DelayDiffEq/src/solve.jl:164
 [5] (::DiffEqBase.#kw##solve)(::Array{Any,1}, ::DiffEqBase.#solve, ::DiffEqBase.ConstantLagDDEProblem{Float64,Float64,Array{Int64,1},false,##1#2,##3#4,Void,UniformScaling{Int64}}, ::DelayDiffEq.MethodOfSteps{OrdinaryDiffEq.Tsit5,Void,Void,Void,false}, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Any,1}) at ./<missing>:0 (repeats 2 times)
```
whereas it successfully computes a solution after removing the type annotations.