### PR TITLE
Sanitize tstops

### DIFF
--- a/test/ode/ode_tstops_tests.jl
+++ b/test/ode/ode_tstops_tests.jl
@@ -13,6 +13,10 @@ sol =solve(prob,RK4(),dt=1//3,tstops=[1/2])
 
 @test sol.t == [0,1/3,1/2,1/3+1/2,1]
 
+sol =solve(prob,RK4(),dt=1//3,tstops=[1/2],d_discontinuities=[-1/2,1/2,3/2])
+
+@test sol.t == [0,1/3,1/2,1/3+1/2,1]
+
 integrator = init(prob,RK4(),tstops=[1/5,1/4,1/3,1/2,3/4])
 
 sol =solve(prob,RK4(),tstops=[1/5,1/4,1/3,1/2,3/4])


### PR DESCRIPTION
Hi!

This is fixes the problem with initial discontinuities occurring after the final time point, as mentioned in https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/11. An example would be
```julia
julia> using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
julia> lags = [.2]
julia> f = function (t,u,h,du)
         du[1] = -h(t-.2)[1] + u[1]
       end
julia> h = (t) -> [0.0]
julia> prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,0.8))
julia> alg = MethodOfSteps(Tsit5(),constrained=false)
julia> sol = solve(prob,alg)
```
which yields time steps
```julia
julia> sol.t
16-element Array{Float64,1}:
 0.0     
 0.10002 
 0.153761
 0.18164 
 0.194284
 0.198926
 0.2     
 0.200528
 0.205805
 0.258583
 0.4     
 0.48159 
 0.6     
 0.760701
 0.8     
 1.0  
```

A simpler (and quite absurd) example with ODEs where the current definition of `tstops_internal` leads to problems is shown in the test file.