### PR TITLE
Avoid undefined entries if k is array of arrays

### DIFF
--- a/src/integrators/explicit_rk_integrator.jl
+++ b/src/integrators/explicit_rk_integrator.jl
@@ -2,6 +2,11 @@
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::ExplicitRKConstantCache,f=integrator.f)

--- a/src/integrators/exponential_rk_integrators.jl
+++ b/src/integrators/exponential_rk_integrators.jl
@@ -3,6 +3,11 @@
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   rtmp = f[2]
   integrator.fsalfirst = rtmp # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = zero(integrator.fsalfirst)
 end
 
 @inline function perform_step!(integrator,cache::LawsonEulerConstantCache,f=integrator.f)
@@ -50,6 +55,11 @@ end
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   rtmp = f[2](integrator.t,integrator.uprev)
   integrator.fsalfirst = rtmp # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = zero(integrator.fsalfirst)
 end
 
 @inline function perform_step!(integrator,cache::NorsettEulerConstantCache,f=integrator.f)

--- a/src/integrators/feagin_rk_integrators.jl
+++ b/src/integrators/feagin_rk_integrators.jl
@@ -2,6 +2,11 @@
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::Feagin10ConstantCache,f=integrator.f)
@@ -218,6 +223,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::Feagin12ConstantCache,f=integrator.f)
@@ -500,6 +510,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 #=

--- a/src/integrators/fixed_timestep_integrators.jl
+++ b/src/integrators/fixed_timestep_integrators.jl
@@ -58,6 +58,11 @@ end
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::EulerConstantCache,f=integrator.f)
@@ -107,6 +112,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::MidpointConstantCache,f=integrator.f)
@@ -166,6 +176,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::RK4ConstantCache,f=integrator.f)

--- a/src/integrators/general_rosenbrock_integrator.jl
+++ b/src/integrators/general_rosenbrock_integrator.jl
@@ -2,6 +2,11 @@
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::GenRosen4ConstantCache,f=integrator.f)

--- a/src/integrators/high_order_rk_integrators.jl
+++ b/src/integrators/high_order_rk_integrators.jl
@@ -2,6 +2,11 @@
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 #=
@@ -169,6 +174,12 @@ end
   integrator.kshortsize = 7
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  @inbounds for i in eachindex(integrator.k)
+    integrator.k[i] = zero(integrator.fsalfirst)
+  end
 end
 
 #=
@@ -453,6 +464,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 #=

--- a/src/integrators/iif_integrators.jl
+++ b/src/integrators/iif_integrators.jl
@@ -26,6 +26,11 @@ end
   A = integrator.f[1](integrator.t,integrator.u)
   cache.uhold[1] = f[2](integrator.t,integrator.uprev)
   integrator.fsalfirst = A*integrator.uprev + cache.uhold[1]
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsalfirst
 end
 
 @inline function perform_step!(integrator,cache::Union{IIF1ConstantCache,IIF2ConstantCache},f=integrator.f)

--- a/src/integrators/implicit_integrators.jl
+++ b/src/integrators/implicit_integrators.jl
@@ -14,6 +14,11 @@ end
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::ImplicitEulerConstantCache,f=integrator.f)
@@ -148,6 +153,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::TrapezoidConstantCache,f=integrator.f)

--- a/src/integrators/low_order_rk_integrators.jl
+++ b/src/integrators/low_order_rk_integrators.jl
@@ -2,6 +2,11 @@
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 #=
@@ -112,6 +117,14 @@ end
   integrator.kshortsize = 8
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  @inbounds for i in 2:integrator.kshortsize-1
+    integrator.k[i] = zero(integrator.fsalfirst)
+  end
+  integrator.k[integrator.kshortsize] = integrator.fsallast
 end
 
 #=
@@ -166,7 +179,6 @@ end
 
 @inline function initialize!(integrator,cache::BS5Cache,f=integrator.f)
   integrator.kshortsize = 8
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1]=cache.k1; integrator.k[2]=cache.k2;
   integrator.k[3]=cache.k3; integrator.k[4]=cache.k4;
@@ -262,6 +274,14 @@ end
   integrator.kshortsize = 7
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  @inbounds for i in 2:integrator.kshortsize-1
+    integrator.k[i] = zero(integrator.fsalfirst)
+  end
+  integrator.k[integrator.kshortsize] = integrator.fsallast
 end
 
 #=
@@ -406,6 +426,12 @@ end
   integrator.kshortsize = 4
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  @inbounds for i in eachindex(integrator.k)
+    integrator.k[i] = zero(integrator.fsalfirst)
+  end
 end
 
 #=

--- a/src/integrators/rosenbrock_integrators.jl
+++ b/src/integrators/rosenbrock_integrators.jl
@@ -229,6 +229,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = zero(integrator.fsalfirst)
+  integrator.k[2] = zero(integrator.fsalfirst)
 end
 
 @inline function perform_step!(integrator,cache::Rosenbrock23ConstantCache,f=integrator.f)
@@ -267,6 +272,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = zero(integrator.fsalfirst)
+  integrator.k[2] = zero(integrator.fsalfirst)
 end
 
 @inline function perform_step!(integrator,cache::Rosenbrock32ConstantCache,f=integrator.f)
@@ -307,6 +317,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::Rosenbrock33ConstantCache,f=integrator.f)
@@ -486,6 +501,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::Rosenbrock34ConstantCache,f=integrator.f)
@@ -688,6 +708,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::Rosenbrock4ConstantCache,f=integrator.f)
@@ -885,6 +910,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = zero(integrator.fsalfirst)
+  integrator.k[2] = zero(integrator.fsalfirst)
 end
 
 @inline function perform_step!(integrator,cache::Rodas4ConstantCache,f=integrator.f)
@@ -1188,6 +1218,11 @@ end
   k = eltype(integrator.sol.k)(2)
   integrator.k = k
   integrator.fsalfirst = f(integrator.t,integrator.uprev)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::Rosenbrock5ConstantCache,f=integrator.f)

--- a/src/integrators/split_integrators.jl
+++ b/src/integrators/split_integrators.jl
@@ -2,6 +2,11 @@
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f[1](integrator.t,integrator.uprev) + f[2](integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::SplitEulerConstantCache,f=integrator.f)

--- a/src/integrators/ssprk_integrators.jl
+++ b/src/integrators/ssprk_integrators.jl
@@ -2,6 +2,10 @@
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
 end
 
 @inline function perform_step!(integrator,cache::SSPRK22ConstantCache,f=integrator.f)
@@ -57,6 +61,10 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
 end
 
 @inline function perform_step!(integrator,cache::SSPRK33ConstantCache,f=integrator.f)
@@ -121,6 +129,10 @@ end
   integrator.kshortsize = 1
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
 end
 
 @inline function perform_step!(integrator,cache::SSPRK432ConstantCache,f=integrator.f)
@@ -205,6 +217,11 @@ end
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
 end
 
 @inline function perform_step!(integrator,cache::SSPRK104ConstantCache,f=integrator.f)

--- a/src/integrators/verner_rk_integrators.jl
+++ b/src/integrators/verner_rk_integrators.jl
@@ -163,9 +163,8 @@ end
   integrator.k = k
 
   # Avoid undefined entries if k is an array of arrays
-  prototype = f(integrator.t, integrator.uprev)
   @inbounds for i in eachindex(integrator.k)
-    integrator.k[i] = zero(prototype)
+    integrator.k[i] = zero(integrator.uprev)./oneunit(integrator.t)
   end
 end
 
@@ -331,9 +330,8 @@ end
   integrator.k = k
 
   # Avoid undefined entries if k is an array of arrays
-  prototype = f(integrator.t, integrator.uprev)
   @inbounds for i in eachindex(integrator.k)
-    integrator.k[i] = zero(prototype)
+    integrator.k[i] = zero(integrator.uprev)./oneunit(integrator.t)
   end
 end
 
@@ -527,9 +525,8 @@ end
   integrator.k = k
 
   # Avoid undefined entries if k is an array of arrays
-  prototype = f(integrator.t, integrator.uprev)
   @inbounds for i in eachindex(integrator.k)
-    integrator.k[i] = zero(prototype)
+    integrator.k[i] = zero(integrator.uprev)./oneunit(integrator.t)
   end
 end
 

--- a/src/integrators/verner_rk_integrators.jl
+++ b/src/integrators/verner_rk_integrators.jl
@@ -2,6 +2,14 @@
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 9
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  @inbounds for i in 2:integrator.kshortsize-1
+    integrator.k[i] = zero(integrator.fsalfirst)
+  end
+  integrator.k[integrator.kshortsize] = integrator.fsallast
 end
 
 #=
@@ -153,6 +161,12 @@ end
   integrator.kshortsize = 10
   k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k = k
+
+  # Avoid undefined entries if k is an array of arrays
+  prototype = f(integrator.t, integrator.uprev)
+  @inbounds for i in eachindex(integrator.k)
+    integrator.k[i] = zero(prototype)
+  end
 end
 
 #=
@@ -315,6 +329,12 @@ end
   integrator.kshortsize = 13
   k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k = k
+
+  # Avoid undefined entries if k is an array of arrays
+  prototype = f(integrator.t, integrator.uprev)
+  @inbounds for i in eachindex(integrator.k)
+    integrator.k[i] = zero(prototype)
+  end
 end
 
 #=
@@ -505,6 +525,12 @@ end
   integrator.kshortsize = 16
   k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k = k
+
+  # Avoid undefined entries if k is an array of arrays
+  prototype = f(integrator.t, integrator.uprev)
+  @inbounds for i in eachindex(integrator.k)
+    integrator.k[i] = zero(prototype)
+  end
 end
 
 #=


### PR DESCRIPTION
As discussed in https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/15#issuecomment-315132474, this prevents initialization of arrays `k` with undefined elements in the case of not in-place functions with not scalar `u`.