### PR TITLE
WIP: change to new @muladd

### DIFF
--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -1,4 +1,4 @@
-function ode_determine_initdt{tType,uType}(u0,t::tType,tdir,dtmax,abstol,reltol,internalnorm,prob::AbstractODEProblem{uType,tType,true},order)
+@muladd function ode_determine_initdt{tType,uType}(u0,t::tType,tdir,dtmax,abstol,reltol,internalnorm,prob::AbstractODEProblem{uType,tType,true},order)
   f = prob.f
   f₀ = zeros(u0./t); f₁ = zeros(u0./t); u₁ = zeros(u0); sk = zeros(u0);
   # Hack to  make a generic u0 with no units, https://github.com/JuliaLang/julia/issues/22216
@@ -35,14 +35,14 @@ function ode_determine_initdt{tType,uType}(u0,t::tType,tdir,dtmax,abstol,reltol,
 
   #@. u₁ = @muladd u0 + tdir*dt₀*f₀
   @tight_loop_macros for i in uidx
-    @inbounds u₁[i] = u0[i] + tdir*dt₀*f₀[i]
+    @inbounds u₁[i] = u0[i] + (tdir*dt₀)*f₀[i]
   end
 
   f(t+tdir*dt₀,u₁,f₁)
 
   #tmp = (f₁.-f₀)./(abstol+abs.(u0).*reltol)*tType(1)
   @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(abstol),Iterators.cycle(reltol))
-    tmp[i] = (f₁[i]-f₀[i])./(atol+abs(u0[i])*rtol)*tType(1)
+    tmp[i] = (f₁[i]-f₀[i])/(atol+abs(u0[i])*rtol)*tType(1)
   end
 
   d₂ = internalnorm(tmp)/dt₀
@@ -56,9 +56,9 @@ function ode_determine_initdt{tType,uType}(u0,t::tType,tdir,dtmax,abstol,reltol,
   dt = tdir*min(100dt₀,dt₁,tdir*dtmax)
 end
 
-function ode_determine_initdt{uType,tType}(u0::uType,t,tdir,dtmax,abstol,reltol,internalnorm,prob::AbstractODEProblem{uType,tType,false},order)
+@muladd function ode_determine_initdt{uType,tType}(u0::uType,t,tdir,dtmax,abstol,reltol,internalnorm,prob::AbstractODEProblem{uType,tType,false},order)
   f = prob.f
-  sk = abstol+abs.(u0).*reltol
+  sk = @. abstol+abs(u0)*reltol
   d₀ = internalnorm(u0./sk)
   f₀ = f(t,u0)
   if any((isnan(x) for x in f₀))
@@ -73,9 +73,9 @@ function ode_determine_initdt{uType,tType}(u0::uType,t,tdir,dtmax,abstol,reltol,
     dt₀ = tType((d₀/d₁)/100)
   end
   dt₀ = min(dt₀,tdir*dtmax)
-  u₁ = u0 + tdir*dt₀*f₀
+  u₁ = @. u0 + (tdir*dt₀)*f₀
   f₁ = f(t+tdir*dt₀,u₁)
-  d₂ = internalnorm((f₁-f₀)./(abstol+abs.(u0).*reltol))/dt₀*tType(1)
+  d₂ = internalnorm(@. (f₁-f₀)/(abstol+abs(u0)*reltol))/dt₀*tType(1)
   if max(d₁,d₂) <= T1(1//10^(15))
     dt₁ = max(tType(1//10^(6)),dt₀*1//10^(3))
   else

--- a/src/integrators/explicit_rk_integrator.jl
+++ b/src/integrators/explicit_rk_integrator.jl
@@ -9,7 +9,7 @@
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::ExplicitRKConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::ExplicitRKConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u = integrator
   @unpack A,c,α,αEEst,stages = cache
   @unpack kk = cache
@@ -19,72 +19,28 @@ end
   for i = 2:stages-1
     utilde = zero(kk[1])
     for j = 1:i-1
-      utilde = @muladd utilde + A[j,i]*kk[j]
+      utilde = @. utilde + A[j,i]*kk[j]
     end
-    kk[i] = f(@muladd(t+c[i]*dt),@muladd(uprev+dt*utilde));
+    kk[i] = f(t+c[i]*dt, @. uprev + dt*utilde);
   end
   #Calc Last
   utilde = zero(kk[1])
   for j = 1:stages-1
-    utilde = @muladd utilde + A[j,end]*kk[j]
+    utilde = @. utilde + A[j,end]*kk[j]
   end
-  kk[end] = f(@muladd(t+c[end]*dt),@muladd(uprev+dt*utilde)); integrator.fsallast = kk[end] # Uses fsallast as temp even if not fsal
+  kk[end] = f(t+c[end]*dt, @. uprev + dt*utilde); integrator.fsallast = kk[end] # Uses fsallast as temp even if not fsal
   # Accumulate Result
   utilde = α[1]*kk[1]
   for i = 2:stages
-    utilde = @muladd utilde + α[i]*kk[i]
+    utilde = @. utilde + α[i]*kk[i]
   end
-  u = @muladd uprev + dt*utilde
+  u = @. uprev + dt*utilde
   if integrator.opts.adaptive
     uEEst = αEEst[1]*kk[1]
     for i = 2:stages
-      uEEst = @muladd uEEst + αEEst[i]*kk[i]
+      uEEst = @. uEEst + αEEst[i]*kk[i]
     end
-    integrator.EEst = integrator.opts.internalnorm( dt*(utilde-uEEst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
-  end
-  if isfsal(integrator.alg.tableau)
-    integrator.fsallast = kk[end]
-  else
-    integrator.fsallast = f(t+dt,u)
-  end
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-
-#=
-@inline function perform_step!(integrator,cache::ExplicitRKConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack A,c,α,αEEst,stages = cache
-  @unpack kk = cache
-  # Calc First
-  kk[1] = integrator.fsalfirst
-  # Calc Middle
-  for i = 2:stages-1
-    utilde = zero(kk[1])
-    for j = 1:i-1
-      utilde = @. @muladd utilde + A[j,i]*kk[j]
-    end
-    kk[i] = f(@muladd(t+c[i]*dt),@muladd(uprev+dt*utilde));
-  end
-  #Calc Last
-  utilde = zero(kk[1])
-  for j = 1:stages-1
-    utilde = @. @muladd utilde + A[j,end]*kk[j]
-  end
-  kk[end] = f(@muladd(t+c[end]*dt),@muladd(uprev+dt*utilde)); integrator.fsallast = kk[end] # Uses fsallast as temp even if not fsal
-  # Accumulate Result
-  utilde = α[1]*kk[1]
-  for i = 2:stages
-    utilde = @. @muladd utilde + α[i]*kk[i]
-  end
-  u = @. @muladd uprev + dt*utilde
-  if integrator.opts.adaptive
-    uEEst = αEEst[1]*kk[1]
-    for i = 2:stages
-      uEEst = @. @muladd uEEst + αEEst[i]*kk[i]
-    end
-    tmp = @. dt*(utilde-uEEst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. dt*(utilde-uEEst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
   if isfsal(integrator.alg.tableau)
@@ -96,7 +52,6 @@ end
   integrator.k[2] = integrator.fsallast
   @pack integrator = t,dt,u
 end
-=#
 
 @inline function initialize!(integrator,cache::ExplicitRKCache,f=integrator.f)
   integrator.kshortsize = 2
@@ -109,7 +64,7 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::ExplicitRKCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::ExplicitRKCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack A,c,α,αEEst,stages = cache.tab
   @unpack kk,utilde,tmp,atmp,uEEst = cache
@@ -117,32 +72,32 @@ end
   for i = 2:stages-1
     @. utilde = zero(kk[1][1])
     for j = 1:i-1
-      @. utilde = @muladd utilde + A[j,i]*kk[j]
+      @. utilde = utilde + A[j,i]*kk[j]
     end
-    @. tmp = @muladd uprev+dt*utilde
-    f(@muladd(t+c[i]*dt),tmp,kk[i])
+    @. tmp = uprev+dt*utilde
+    f(t+c[i]*dt,tmp,kk[i])
   end
   #Last
   @. utilde = zero(kk[1][1])
   for j = 1:stages-1
-    @. utilde = @muladd utilde + A[j,end]*kk[j]
+    @. utilde = utilde + A[j,end]*kk[j]
   end
-  @. u = @muladd uprev+dt*utilde
-  f(@muladd(t+c[end]*dt),u,kk[end]) #fsallast is tmp even if not fsal
+  @. u = uprev+dt*utilde
+  f(t+c[end]*dt),u,kk[end]) #fsallast is tmp even if not fsal
   #Accumulate
   if !isfsal(integrator.alg.tableau)
     @. utilde = α[1]*kk[1]
     for i = 2:stages
-      @. utilde = @muladd utilde + α[i]*kk[i]
+      @. utilde = utilde + α[i]*kk[i]
     end
-    @. u = @muladd uprev + dt*utilde
+    @. u = uprev + dt*utilde
   end
   if integrator.opts.adaptive
     @. uEEst = αEEst[1]*kk[1]
     for i = 2:stages
-      @. uEEst = @muladd uEEst + αEEst[i]*kk[i]
+      @. uEEst = uEEst + αEEst[i]*kk[i]
     end
-    @. atmp = (dt*(utilde-uEEst)/@muladd(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+    @. atmp = (dt*(utilde-uEEst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   if !isfsal(integrator.alg.tableau)
@@ -152,7 +107,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::ExplicitRKCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::ExplicitRKCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack A,c,α,αEEst,stages = cache.tab
@@ -164,13 +119,13 @@ end
     end
     for j = 1:i-1
       @tight_loop_macros for l in uidx
-        @inbounds utilde[l] = @muladd utilde[l] + A[j,i]*kk[j][l]
+        @inbounds utilde[l] = utilde[l] + A[j,i]*kk[j][l]
       end
     end
     @tight_loop_macros for l in uidx
-      @inbounds tmp[l] = @muladd uprev[l]+dt*utilde[l]
+      @inbounds tmp[l] = uprev[l]+dt*utilde[l]
     end
-    f(@muladd(t+c[i]*dt),tmp,kk[i])
+    f(t+c[i]*dt,tmp,kk[i])
   end
   #Last
   @tight_loop_macros for l in uidx
@@ -178,13 +133,13 @@ end
   end
   for j = 1:stages-1
     @tight_loop_macros for l in uidx
-      @inbounds utilde[l] = @muladd utilde[l] + A[j,end]*kk[j][l]
+      @inbounds utilde[l] = utilde[l] + A[j,end]*kk[j][l]
     end
   end
   @tight_loop_macros for l in uidx
-    @inbounds u[l] = @muladd uprev[l]+dt*utilde[l]
+    @inbounds u[l] = uprev[l]+dt*utilde[l]
   end
-  f(@muladd(t+c[end]*dt),u,kk[end]) #fsallast is tmp even if not fsal
+  f(t+c[end]*dt,u,kk[end]) #fsallast is tmp even if not fsal
   #Accumulate
   if !isfsal(integrator.alg.tableau)
     @tight_loop_macros for i in uidx
@@ -192,11 +147,11 @@ end
     end
     for i = 2:stages
       @tight_loop_macros for l in uidx
-        @inbounds utilde[l] = @muladd utilde[l] + α[i]*kk[i][l]
+        @inbounds utilde[l] = utilde[l] + α[i]*kk[i][l]
       end
     end
     @tight_loop_macros for i in uidx
-      @inbounds u[i] = @muladd uprev[i] + dt*utilde[i]
+      @inbounds u[i] = uprev[i] + dt*utilde[i]
     end
   end
   if integrator.opts.adaptive
@@ -205,11 +160,11 @@ end
     end
     for i = 2:stages
       @tight_loop_macros for j in uidx
-        @inbounds uEEst[j] = @muladd uEEst[j] + αEEst[i]*kk[i][j]
+        @inbounds uEEst[j] = uEEst[j] + αEEst[i]*kk[i][j]
       end
     end
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds atmp[i] = (dt*(utilde[i]-uEEst[i])./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds atmp[i] = dt*(utilde[i]-uEEst[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end

--- a/src/integrators/feagin_rk_integrators.jl
+++ b/src/integrators/feagin_rk_integrators.jl
@@ -9,63 +9,30 @@
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::Feagin10ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin10ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache
   k1  = integrator.fsalfirst
   a = dt*a0100
-  k2  = f(@muladd(@muladd(t + c1*dt)),@muladd(uprev  + a*k1))
-  k3  = f(@muladd(@muladd(t + c2*dt)),@muladd(uprev + dt*(a0200*k1 + a0201*k2)))
-  k4  = f(@muladd(@muladd(t + c3*dt)),@muladd(uprev  + dt*(a0300*k1              + a0302*k3)))
-  k5  = f(@muladd(@muladd(t + c4*dt)),@muladd(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4)))
-  k6  = f(@muladd(@muladd(t + c5*dt)),@muladd(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5)))
-  k7  = f(@muladd(@muladd(t + c6*dt)),@muladd(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6)))
-  k8  = f(@muladd(@muladd(t + c7*dt)),@muladd(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7)))
-  k9  = f(@muladd(@muladd(t + c8*dt)),@muladd(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8)))
-  k10 = f(@muladd(@muladd(t + c9*dt)),@muladd(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)))
-  k11 = f(@muladd(@muladd(t + c10*dt)),@muladd(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)))
-  k12 = f(@muladd(@muladd(t + c11*dt)),@muladd(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)))
-  k13 = f(@muladd(@muladd(t + c12*dt)),@muladd(uprev + dt*(a1200*k1                           + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)))
-  k14 = f(@muladd(@muladd(t + c13*dt)),@muladd(uprev + dt*(a1300*k1              + a1302*k3 + a1303*k4              + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)))
-  k15 = f(@muladd(@muladd(t + c14*dt)),@muladd(uprev + dt*(a1400*k1 + a1401*k2                           + a1404*k5              + a1406*k7 +                                                                     a1412*k13 + a1413*k14)))
-  k16 = f(@muladd(@muladd(t + c15*dt)),@muladd(uprev + dt*(a1500*k1              + a1502*k3                                                                                                                                                     + a1514*k15)))
-  k17 = f(@muladd(@muladd(t + c16*dt)),@muladd(uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3              + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)))
-  u = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
+  k2  = f(t + c1*dt, @. uprev  + a*k1)
+  k3  = f(t + c2*dt, @. uprev + dt*(a0200*k1 + a0201*k2))
+  k4  = f(t + c3*dt, @. uprev  + dt*(a0300*k1              + a0302*k3))
+  k5  = f(t + c4*dt, @. uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4))
+  k6  = f(t + c5*dt, @. uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5))
+  k7  = f(t + c6*dt, @. uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6))
+  k8  = f(t + c7*dt, @. uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7))
+  k9  = f(t + c8*dt, @. uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8))
+  k10 = f(t + c9*dt, @. uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9))
+  k11 = f(t + c10*dt, @. uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10))
+  k12 = f(t + c11*dt, @. uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11))
+  k13 = f(t + c12*dt, @. uprev + dt*(a1200*k1                           + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12))
+  k14 = f(t + c13*dt, @. uprev + dt*(a1300*k1              + a1302*k3 + a1303*k4              + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13))
+  k15 = f(t + c14*dt, @. uprev + dt*(a1400*k1 + a1401*k2                           + a1404*k5              + a1406*k7 +                                                                     a1412*k13 + a1413*k14))
+  k16 = f(t + c15*dt, @. uprev + dt*(a1500*k1              + a1502*k3                                                                                                                                                     + a1514*k15))
+  k17 = f(t + c16*dt, @. uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3              + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16))
+  u = @. uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
   if integrator.opts.adaptive
-    integrator.EEst = integrator.opts.internalnorm((dt*(k2 - k16) * adaptiveConst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
-  end
-  k = f(t+dt,u) # For the interpolation, needs k at the updated point
-  integrator.fsallast = k
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-
-#=
-@inline function perform_step!(integrator,cache::Feagin10ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache
-  k1  = integrator.fsalfirst
-  a = dt*a0100
-  k2  = f(@muladd(t + c1*dt),@.(@muladd(uprev  + a*k1)))
-  k3  = f(@muladd(t + c2*dt),@.(@muladd(uprev  + dt*(a0200*k1 + a0201*k2))))
-  k4  = f(@muladd(t + c3*dt),@.(@muladd(uprev  + dt*(a0300*k1              + a0302*k3))))
-  k5  = f(@muladd(t + c4*dt),@.(@muladd(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4))))
-  k6  = f(@muladd(t + c5*dt),@.(@muladd(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5))))
-  k7  = f(@muladd(t + c6*dt),@.(@muladd(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6))))
-  k8  = f(@muladd(t + c7*dt),@.(@muladd(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7))))
-  k9  = f(@muladd(t + c8*dt),@.(@muladd(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8))))
-  k10 = f(@muladd(t + c9*dt),@.(@muladd(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9))))
-  k11 = f(@muladd(t + c10*dt),@.(@muladd(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10))))
-  k12 = f(@muladd(t + c11*dt),@.(@muladd(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11))))
-  k13 = f(@muladd(t + c12*dt),@.(@muladd(uprev + dt*(a1200*k1                           + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12))))
-  k14 = f(@muladd(t + c13*dt),@.(@muladd(uprev + dt*(a1300*k1              + a1302*k3 + a1303*k4              + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13))))
-  k15 = f(@muladd(t + c14*dt),@.(@muladd(uprev + dt*(a1400*k1 + a1401*k2                           + a1404*k5              + a1406*k7 +                                                                     a1412*k13 + a1413*k14))))
-  k16 = f(@muladd(t + c15*dt),@.(@muladd(uprev + dt*(a1500*k1              + a1502*k3                                                                                                                                                     + a1514*k15))))
-  k17 = f(@muladd(t + c16*dt),@.(@muladd(uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3              + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16))))
-  u = @. @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
-  if integrator.opts.adaptive
-    tmp = @. (dt*(k2 - k16) * adaptiveConst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. (dt*(k2 - k16) * adaptiveConst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
   k = f(t+dt,u) # For the interpolation, needs k at the updated point
@@ -74,7 +41,6 @@ end
   integrator.k[2] = integrator.fsallast
   @pack integrator = t,dt,u
 end
-=#
 
 @inline function initialize!(integrator,cache::Feagin10Cache,f=integrator.f)
   integrator.fsalfirst = cache.fsalfirst
@@ -87,47 +53,47 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::Feagin10Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin10Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
   a =  dt*a0100
-  @. tmp = @muladd uprev + a*k1
-  f(@muladd(t + c1*dt),tmp,k2)
-  @. tmp = @muladd uprev + dt*(a0200*k1 + a0201*k2)
-  f(@muladd(t + c2*dt) ,tmp,k3)
-  @. tmp = @muladd uprev + dt*(a0300*k1 + a0302*k3)
-  f(@muladd(t + c3*dt),tmp,k4)
-  @. tmp = @muladd uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
-  f(@muladd(t + c4*dt),tmp,k5)
-  @. tmp = @muladd uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
-  f(@muladd(t + c5*dt),tmp,k6)
-  @. tmp = @muladd uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
-  f(@muladd(t + c6*dt),tmp,k7)
-  @. tmp = @muladd uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
-  f(@muladd(t + c7*dt),tmp,k8)
-  @. tmp = @muladd uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
-  f(@muladd(t + c8*dt),tmp,k9)
-  @. tmp = @muladd uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
-  f(@muladd(t + c9*dt),tmp,k10)
-  @. tmp = @muladd uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
-  f(@muladd(t + c10*dt),tmp,k11)
-  @. tmp = @muladd uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
-  f(@muladd(t + c11*dt),tmp,k12)
-  @.  tmp = @muladd uprev + dt*(a1200*k1 + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
-  f(@muladd(t + c12*dt),tmp,k13)
-  @. tmp = @muladd uprev + dt*(a1300*k1 + a1302*k3 + a1303*k4 + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
-  f(@muladd(t + c13*dt),tmp,k14)
-  @. tmp = @muladd uprev + dt*(a1400*k1 + a1401*k2 + a1404*k5 + a1406*k7 + a1412*k13 + a1413*k14)
-  f(@muladd(t + c14*dt),tmp,k15)
-  @. tmp = @muladd uprev + dt*(a1500*k1 + a1502*k3 + a1514*k15)
-  f(@muladd(t + c15*dt),tmp,k16)
-  @. tmp = @muladd uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3 + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)
-  f(@muladd(t + c16*dt),tmp,k17)
-  @. u = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
+  @. tmp = uprev + a*k1
+  f(t + c1*dt,tmp,k2)
+  @. tmp = uprev + dt*(a0200*k1 + a0201*k2)
+  f(t + c2*dt ,tmp,k3)
+  @. tmp = uprev + dt*(a0300*k1 + a0302*k3)
+  f(t + c3*dt,tmp,k4)
+  @. tmp = uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
+  f(t + c4*dt,tmp,k5)
+  @. tmp = uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
+  f(t + c5*dt,tmp,k6)
+  @. tmp = uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
+  f(t + c6*dt,tmp,k7)
+  @. tmp = uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
+  f(t + c7*dt,tmp,k8)
+  @. tmp = uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
+  f(t + c8*dt,tmp,k9)
+  @. tmp = uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
+  f(t + c9*dt,tmp,k10)
+  @. tmp = uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
+  f(t + c10*dt,tmp,k11)
+  @. tmp = uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
+  f(t + c11*dt,tmp,k12)
+  @.  tmp = uprev + dt*(a1200*k1 + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
+  f(t + c12*dt,tmp,k13)
+  @. tmp = uprev + dt*(a1300*k1 + a1302*k3 + a1303*k4 + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
+  f(t + c13*dt,tmp,k14)
+  @. tmp = uprev + dt*(a1400*k1 + a1401*k2 + a1404*k5 + a1406*k7 + a1412*k13 + a1413*k14)
+  f(t + c14*dt,tmp,k15)
+  @. tmp = uprev + dt*(a1500*k1 + a1502*k3 + a1514*k15)
+  f(t + c15*dt,tmp,k16)
+  @. tmp = uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3 + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)
+  f(t + c16*dt,tmp,k17)
+  @. u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
   if integrator.opts.adaptive
-    @. atmp = (dt*(k2 - k16) * adaptiveConst)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol)
+    @. atmp = (dt*(k2 - k16) * adaptiveConst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   f(t+dt,u,integrator.fsallast) # For the interpolation, needs k at the updated point
@@ -135,7 +101,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::Feagin10Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin10Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache.tab
@@ -143,75 +109,75 @@ end
   k1 = cache.fsalfirst
   a =  dt*a0100
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + a*k1[i]
+    @inbounds tmp[i] = uprev[i] + a*k1[i]
   end
   f(@muladd(t + c1*dt),tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
   end
-  f(@muladd(t + c2*dt) ,tmp,k3)
+  f(t + c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
   end
-  f(@muladd(t + c3*dt),tmp,k4)
+  f(t + c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
   end
-  f(@muladd(t + c4*dt),tmp,k5)
+  f(t + c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
   end
-  f(@muladd(t + c5*dt),tmp,k6)
+  f(t + c5*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
   end
-  f(@muladd(t + c6*dt),tmp,k7)
+  f(t + c6*dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
   end
-  f(@muladd(t + c7*dt),tmp,k8)
+  f(t + c7*dt,tmp,k8)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
   end
-  f(@muladd(t + c8*dt),tmp,k9)
+  f(t + c8*dt,tmp,k9)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
   end
-  f(@muladd(t + c9*dt),tmp,k10)
+  f(t + c9*dt,tmp,k10)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
   end
-  f(@muladd(t + c10*dt),tmp,k11)
+  f(t + c10*dt,tmp,k11)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
   end
-  f(@muladd(t + c11*dt),tmp,k12)
+  f(t + c11*dt,tmp,k12)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1200*k1[i] + a1203*k4[i] + a1204*k5[i] + a1205*k6[i] + a1206*k7[i] + a1207*k8[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1200*k1[i] + a1203*k4[i] + a1204*k5[i] + a1205*k6[i] + a1206*k7[i] + a1207*k8[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
   end
-  f(@muladd(t + c12*dt),tmp,k13)
+  f(t + c12*dt,tmp,k13)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1300*k1[i] + a1302*k3[i] + a1303*k4[i] + a1305*k6[i] + a1306*k7[i] + a1307*k8[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1300*k1[i] + a1302*k3[i] + a1303*k4[i] + a1305*k6[i] + a1306*k7[i] + a1307*k8[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
   end
-  f(@muladd(t + c13*dt),tmp,k14)
+  f(t + c13*dt,tmp,k14)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1400*k1[i] + a1401*k2[i] + a1404*k5[i] + a1406*k7[i] + a1412*k13[i] + a1413*k14[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1400*k1[i] + a1401*k2[i] + a1404*k5[i] + a1406*k7[i] + a1412*k13[i] + a1413*k14[i])
   end
-  f(@muladd(t + c14*dt),tmp,k15)
+  f(t + c14*dt,tmp,k15)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1500*k1[i] + a1502*k3[i] + a1514*k15[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1500*k1[i] + a1502*k3[i] + a1514*k15[i])
   end
-  f(@muladd(t + c15*dt),tmp,k16)
+  f(t + c15*dt,tmp,k16)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1600*k1[i] + a1601*k2[i] + a1602*k3[i] + a1604*k5[i] + a1605*k6[i] + a1606*k7[i] + a1607*k8[i] + a1608*k9[i] + a1609*k10[i] + a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i] + a1614*k15[i] + a1615*k16[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1600*k1[i] + a1601*k2[i] + a1602*k3[i] + a1604*k5[i] + a1605*k6[i] + a1606*k7[i] + a1607*k8[i] + a1608*k9[i] + a1609*k10[i] + a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i] + a1614*k15[i] + a1615*k16[i])
   end
-  f(@muladd(t + c16*dt),tmp,k17)
+  f(t + c16*dt,tmp,k17)
   @tight_loop_macros for i in uidx
-    u[i] = @muladd uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b9*k9[i] + b10*k10[i] + b11*k11[i] + b12*k12[i] + b13*k13[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b17*k17[i])
+    u[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b9*k9[i] + b10*k10[i] + b11*k11[i] + b12*k12[i] + b13*k13[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b17*k17[i])
   end
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds atmp[i] =  (dt*(k2[i] - k16[i]) * adaptiveConst)./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol)
+      @inbounds atmp[i] = (dt*(k2[i] - k16[i]) * adaptiveConst)/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
@@ -230,90 +196,47 @@ end
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::Feagin12ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin12ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache
   k1   = integrator.fsalfirst
   a =  dt*a0100
-  k2  = f(@muladd(t + c1*dt),@muladd(uprev  + a*k1))
-  k3  = f(@muladd(t + c2*dt),@muladd(uprev + dt*(a0200*k1 + a0201*k2)))
-  k4  = f(@muladd(t + c3*dt),@muladd(uprev  + dt*(a0300*k1              + a0302*k3)))
-  k5  = f(@muladd(t + c4*dt),@muladd(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4)))
-  k6  = f(@muladd(t + c5*dt),@muladd(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5)))
-  k7  = f(@muladd(t + c6*dt),@muladd(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6)))
-  k8  = f(@muladd(t + c7*dt),@muladd(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7)))
-  k9  = f(@muladd(t + c8*dt),@muladd(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8)))
-  k10 = f(@muladd(t + c9*dt),@muladd(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)))
-  k11 = f(@muladd(t + c10*dt),@muladd(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)))
-  k12 = f(@muladd(t + c11*dt),@muladd(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)))
-  k13 = f(@muladd(t + c12*dt),@muladd(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)))
-  k14 = f(@muladd(t + c13*dt),@muladd(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)))
-  k15 = f(@muladd(t + c14*dt),@muladd(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)))
-  k16 = f(@muladd(t + c15*dt),@muladd(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)))
-  k17 = f(@muladd(t + c16*dt),@muladd(uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)))
-  k18 = f(@muladd(t + c17*dt),@muladd(uprev + dt*(a1700*k1                                                     + a1705*k6 + a1706*k7 + a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11 + a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17)))
-  k19 = f(@muladd(t + c18*dt),@muladd(uprev + dt*(a1800*k1                                                     + a1805*k6 + a1806*k7 + a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11 + a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18)))
-  k20 = f(@muladd(t + c19*dt),@muladd(uprev + dt*(a1900*k1                                        + a1904*k5 + a1905*k6 + a1906*k7              + a1908*k9 + a1909*k10 + a1910*k11 + a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)))
-  k21 = f(@muladd(t + c20*dt),@muladd(uprev + dt*(a2000*k1                           + a2003*k4 + a2004*k5 + a2005*k6              + a2007*k8              + a2009*k10 + a2010*k11                                                                                     + a2017*k18 + a2018*k19 + a2019*k20)))
-  k22 = f(@muladd(t + c21*dt),@muladd(uprev + dt*(a2100*k1              + a2102*k3 + a2103*k4                           + a2106*k7 + a2107*k8              + a2109*k10 + a2110*k11                                                                                     + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)))
-  k23 = f(@muladd(t + c22*dt),@muladd(uprev + dt*(a2200*k1 + a2201*k2                           + a2204*k5              + a2206*k7                                                                                                                                                                                     + a2220*k21 + a2221*k22)))
-  k24 = f(@muladd(t + c23*dt),@muladd(uprev + dt*(a2300*k1              + a2302*k3                                                                                                                                                                                                                                                                     + a2322*k23)))
-  k25 = f(@muladd(t + c24*dt),@muladd(uprev + dt*(a2400*k1 + a2401*k2 + a2402*k3              + a2404*k5              + a2406*k7 + a2407*k8 + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24)))
+  k2  = f(t + c1*dt, @. uprev  + a*k1)
+  k3  = f(t + c2*dt, @. uprev + dt*(a0200*k1 + a0201*k2))
+  k4  = f(t + c3*dt, @. uprev  + dt*(a0300*k1              + a0302*k3))
+  k5  = f(t + c4*dt, @. uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4))
+  k6  = f(t + c5*dt, @. uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5))
+  k7  = f(t + c6*dt, @. uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6))
+  k8  = f(t + c7*dt, @. uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7))
+  k9  = f(t + c8*dt, @. uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8))
+  k10 = f(t + c9*dt, @. uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9))
+  k11 = f(t + c10*dt, @. uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10))
+  k12 = f(t + c11*dt, @. uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11))
+  k13 = f(t + c12*dt, @. uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12))
+  k14 = f(t + c13*dt, @. uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13))
+  k15 = f(t + c14*dt, @. uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14))
+  k16 = f(t + c15*dt, @. uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15))
+  k17 = f(t + c16*dt, @. uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16))
+  k18 = f(t + c17*dt, @. uprev + dt*(a1700*k1                                                     + a1705*k6 + a1706*k7 + a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11 + a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17))
+  k19 = f(t + c18*dt, @. uprev + dt*(a1800*k1                                                     + a1805*k6 + a1806*k7 + a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11 + a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18))
+  k20 = f(t + c19*dt, @. uprev + dt*(a1900*k1                                        + a1904*k5 + a1905*k6 + a1906*k7              + a1908*k9 + a1909*k10 + a1910*k11 + a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))
+  k21 = f(t + c20*dt, @. uprev + dt*(a2000*k1                           + a2003*k4 + a2004*k5 + a2005*k6              + a2007*k8              + a2009*k10 + a2010*k11                                                                                     + a2017*k18 + a2018*k19 + a2019*k20))
+  k22 = f(t + c21*dt, @. uprev + dt*(a2100*k1              + a2102*k3 + a2103*k4                           + a2106*k7 + a2107*k8              + a2109*k10 + a2110*k11                                                                                     + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))
+  k23 = f(t + c22*dt, @. uprev + dt*(a2200*k1 + a2201*k2                           + a2204*k5              + a2206*k7                                                                                                                                                                                     + a2220*k21 + a2221*k22))
+  k24 = f(t + c23*dt, @. uprev + dt*(a2300*k1              + a2302*k3                                                                                                                                                                                                                                                                     + a2322*k23))
+  k25 = f(t + c24*dt, @. uprev + dt*(a2400*k1 + a2401*k2 + a2402*k3              + a2404*k5              + a2406*k7 + a2407*k8 + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24))
 
-  u = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25)
+  u = @. uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25)
   k = f(t+dt,u)
   integrator.fsallast = k
   if integrator.opts.adaptive
-    integrator.EEst = integrator.opts.internalnorm((dt*(k2 - k24) * adaptiveConst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
-  end
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-
-#=
-@inline function perform_step!(integrator,cache::Feagin12ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache
-  k1   = integrator.fsalfirst
-  a =  dt*a0100
-  k2  = f(@muladd(t + c1*dt),@.(@muladd(uprev  + a*k1)))
-  k3  = f(@muladd(t + c2*dt),@.(@muladd(uprev  + dt*(a0200*k1 + a0201*k2))))
-  k4  = f(@muladd(t + c3*dt),@.(@muladd(uprev  + dt*(a0300*k1              + a0302*k3))))
-  k5  = f(@muladd(t + c4*dt),@.(@muladd(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4))))
-  k6  = f(@muladd(t + c5*dt),@.(@muladd(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5))))
-  k7  = f(@muladd(t + c6*dt),@.(@muladd(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6))))
-  k8  = f(@muladd(t + c7*dt),@.(@muladd(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7))))
-  k9  = f(@muladd(t + c8*dt),@.(@muladd(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8))))
-  k10 = f(@muladd(t + c9*dt),@.(@muladd(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9))))
-  k11 = f(@muladd(t + c10*dt),@.(@muladd(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10))))
-  k12 = f(@muladd(t + c11*dt),@.(@muladd(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11))))
-  k13 = f(@muladd(t + c12*dt),@.(@muladd(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12))))
-  k14 = f(@muladd(t + c13*dt),@.(@muladd(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13))))
-  k15 = f(@muladd(t + c14*dt),@.(@muladd(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14))))
-  k16 = f(@muladd(t + c15*dt),@.(@muladd(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15))))
-  k17 = f(@muladd(t + c16*dt),@.(@muladd(uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16))))
-  k18 = f(@muladd(t + c17*dt),@.(@muladd(uprev + dt*(a1700*k1                                                     + a1705*k6 + a1706*k7 + a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11 + a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17))))
-  k19 = f(@muladd(t + c18*dt),@.(@muladd(uprev + dt*(a1800*k1                                                     + a1805*k6 + a1806*k7 + a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11 + a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18))))
-  k20 = f(@muladd(t + c19*dt),@.(@muladd(uprev + dt*(a1900*k1                                        + a1904*k5 + a1905*k6 + a1906*k7              + a1908*k9 + a1909*k10 + a1910*k11 + a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))))
-  k21 = f(@muladd(t + c20*dt),@.(@muladd(uprev + dt*(a2000*k1                           + a2003*k4 + a2004*k5 + a2005*k6              + a2007*k8              + a2009*k10 + a2010*k11                                                                                     + a2017*k18 + a2018*k19 + a2019*k20))))
-  k22 = f(@muladd(t + c21*dt),@.(@muladd(uprev + dt*(a2100*k1              + a2102*k3 + a2103*k4                           + a2106*k7 + a2107*k8              + a2109*k10 + a2110*k11                                                                                     + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))))
-  k23 = f(@muladd(t + c22*dt),@.(@muladd(uprev + dt*(a2200*k1 + a2201*k2                           + a2204*k5              + a2206*k7                                                                                                                                                                                     + a2220*k21 + a2221*k22))))
-  k24 = f(@muladd(t + c23*dt),@.(@muladd(uprev + dt*(a2300*k1              + a2302*k3                                                                                                                                                                                                                                                                     + a2322*k23))))
-  k25 = f(@muladd(t + c24*dt),@.(@muladd(uprev + dt*(a2400*k1 + a2401*k2 + a2402*k3              + a2404*k5              + a2406*k7 + a2407*k8 + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24))))
-
-  u = @. @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25)
-  k = f(t+dt,u)
-  integrator.fsallast = k
-  if integrator.opts.adaptive
-    tmp = @. (dt*(k2 - k24) * adaptiveConst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. (dt*(k2 - k24) * adaptiveConst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   @pack integrator = t,dt,u
 end
-=#
 
 @inline function initialize!(integrator,cache::Feagin12Cache,f=integrator.f)
   integrator.fsalfirst = cache.fsalfirst
@@ -326,63 +249,63 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::Feagin12Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin12Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k18,k19,k20,k21,k22,k23,k24,k25,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
   a = dt*a0100
-  @. tmp = @muladd uprev + a*k1
-  f(@muladd(t + c1*dt),tmp,k2)
-  @. tmp = @muladd uprev + dt*(a0200*k1 + a0201*k2)
-  f(@muladd(t + c2*dt) ,tmp,k3)
-  @. tmp = @muladd uprev + dt*(a0300*k1 + a0302*k3)
-  f(@muladd(t + c3*dt),tmp,k4)
-  @. tmp = @muladd uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
-  f(@muladd(t + c4*dt),tmp,k5)
-  @. tmp = @muladd uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
-  f(@muladd(t + c5*dt),tmp,k6)
-  @. tmp = @muladd uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
-  f(@muladd(t + c6*dt),tmp,k7)
-  @. tmp = @muladd uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
-  f(@muladd(t + c7*dt),tmp,k8)
-  @. tmp = @muladd uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
-  f(@muladd(t + c8*dt),tmp,k9)
-  @. tmp = @muladd uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
-  f(@muladd(t + c9*dt),tmp,k10)
-  @. tmp = @muladd uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
-  f(@muladd(t + c10*dt),tmp,k11)
-  @. tmp = @muladd uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
-  f(@muladd(t + c11*dt),tmp,k12)
-  @. tmp = @muladd uprev + dt*(a1200*k1 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
-  f(@muladd(t + c12*dt),tmp,k13)
-  @. tmp = @muladd uprev + dt*(a1300*k1 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
-  f(@muladd(t + c13*dt),tmp,k14)
-  @. tmp = @muladd uprev + dt*(a1400*k1 + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)
-  f(@muladd(t + c14*dt),tmp,k15)
-  @. tmp = @muladd uprev + dt*(a1500*k1 + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)
-  f(@muladd(t + c15*dt),tmp,k16)
-  @. tmp = @muladd uprev + dt*((a1600*k1 + a1608*k9 + a1609*k10) + (a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14) + (a1614*k15 + a1615*k16))
-  f(@muladd(t + c16*dt),tmp,k17)
-  @. tmp = @muladd uprev + dt*((a1700*k1 + a1705*k6 + a1706*k7) + (a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11) + (a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15) + (a1715*k16 + a1716*k17))
-  f(@muladd(t + c17*dt),tmp,k18)
-  @. tmp = @muladd uprev + dt*((a1800*k1 + a1805*k6 + a1806*k7) + (a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11) + (a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15) + (a1815*k16 + a1816*k17 + a1817*k18))
-  f(@muladd(t + c18*dt),tmp,k19)
-  @. tmp = @muladd uprev + dt*((a1900*k1 + a1904*k5 + a1905*k6) + (a1906*k7 + a1908*k9 + a1909*k10 + a1910*k11) + (a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15) + (a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))
-  f(@muladd(t + c19*dt),tmp,k20)
-  @. tmp = @muladd uprev + dt*((a2000*k1 + a2003*k4 + a2004*k5) + (a2005*k6 + a2007*k8 + a2009*k10 + a2010*k11) + (a2017*k18 + a2018*k19 + a2019*k20))
-  f(@muladd(t + c20*dt),tmp,k21)
-  @. tmp = @muladd uprev + dt*((a2100*k1 + a2102*k3 + a2103*k4) + (a2106*k7 + a2107*k8 + a2109*k10 + a2110*k11) + (a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))
-  f(@muladd(t + c21*dt),tmp,k22)
-  @. tmp = @muladd uprev + dt*((a2200*k1 + a2201*k2 + a2204*k5) + (a2206*k7 + a2220*k21 + a2221*k22))
-  f(@muladd(t + c22*dt),tmp,k23)
-  @. tmp = @muladd uprev + dt*(a2300*k1 + a2302*k3 + a2322*k23)
-  f(@muladd(t + c23*dt),tmp,k24)
-  @. tmp = @muladd uprev + dt*((a2400*k1 + a2401*k2 + a2402*k3) + (a2404*k5 + a2406*k7 + a2407*k8 + a2408*k9) + (a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13) + (a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17) + (a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21) + (a2421*k22 + a2422*k23 + a2423*k24))
-  f(@muladd(t + c24*dt),tmp,k25)
-  @. u = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25)
+  @. tmp = uprev + a*k1
+  f(t + c1*dt,tmp,k2)
+  @. tmp = uprev + dt*(a0200*k1 + a0201*k2)
+  f(t + c2*dt ,tmp,k3)
+  @. tmp = uprev + dt*(a0300*k1 + a0302*k3)
+  f(t + c3*dt,tmp,k4)
+  @. tmp = uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
+  f(t + c4*dt,tmp,k5)
+  @. tmp = uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
+  f(t + c5*dt,tmp,k6)
+  @. tmp = uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
+  f(t + c6*dt,tmp,k7)
+  @. tmp = uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
+  f(t + c7*dt,tmp,k8)
+  @. tmp = uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
+  f(t + c8*dt,tmp,k9)
+  @. tmp = uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
+  f(t + c9*dt,tmp,k10)
+  @. tmp = uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
+  f(t + c10*dt,tmp,k11)
+  @. tmp = uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
+  f(t + c11*dt,tmp,k12)
+  @. tmp = uprev + dt*(a1200*k1 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
+  f(t + c12*dt,tmp,k13)
+  @. tmp = uprev + dt*(a1300*k1 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
+  f(t + c13*dt,tmp,k14)
+  @. tmp = uprev + dt*(a1400*k1 + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)
+  f(t + c14*dt,tmp,k15)
+  @. tmp = uprev + dt*(a1500*k1 + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)
+  f(t + c15*dt,tmp,k16)
+  @. tmp = uprev + dt*((a1600*k1 + a1608*k9 + a1609*k10) + (a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14) + (a1614*k15 + a1615*k16))
+  f(t + c16*dt,tmp,k17)
+  @. tmp = uprev + dt*((a1700*k1 + a1705*k6 + a1706*k7) + (a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11) + (a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15) + (a1715*k16 + a1716*k17))
+  f(t + c17*dt,tmp,k18)
+  @. tmp = uprev + dt*((a1800*k1 + a1805*k6 + a1806*k7) + (a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11) + (a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15) + (a1815*k16 + a1816*k17 + a1817*k18))
+  f(t + c18*dt,tmp,k19)
+  @. tmp = uprev + dt*((a1900*k1 + a1904*k5 + a1905*k6) + (a1906*k7 + a1908*k9 + a1909*k10 + a1910*k11) + (a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15) + (a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))
+  f(t + c19*dt,tmp,k20)
+  @. tmp = uprev + dt*((a2000*k1 + a2003*k4 + a2004*k5) + (a2005*k6 + a2007*k8 + a2009*k10 + a2010*k11) + (a2017*k18 + a2018*k19 + a2019*k20))
+  f(t + c20*dt,tmp,k21)
+  @. tmp = uprev + dt*((a2100*k1 + a2102*k3 + a2103*k4) + (a2106*k7 + a2107*k8 + a2109*k10 + a2110*k11) + (a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))
+  f(t + c21*dt,tmp,k22)
+  @. tmp = uprev + dt*((a2200*k1 + a2201*k2 + a2204*k5) + (a2206*k7 + a2220*k21 + a2221*k22))
+  f(t + c22*dt,tmp,k23)
+  @. tmp = uprev + dt*(a2300*k1 + a2302*k3 + a2322*k23)
+  f(t + c23*dt,tmp,k24)
+  @. tmp = uprev + dt*((a2400*k1 + a2401*k2 + a2402*k3) + (a2404*k5 + a2406*k7 + a2407*k8 + a2408*k9) + (a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13) + (a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17) + (a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21) + (a2421*k22 + a2422*k23 + a2423*k24))
+  f(t + c24*dt,tmp,k25)
+  @. u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25)
   if integrator.opts.adaptive
-    @. atmp = (dt*(k2 - k24) * adaptiveConst)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol)
+    @. atmp = (dt*(k2 - k24) * adaptiveConst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   f(t+dt,u,k)
@@ -390,7 +313,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::Feagin12Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin12Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache.tab
@@ -398,107 +321,107 @@ end
   k1 = cache.fsalfirst
   a = dt*a0100
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + a*k1[i]
+    @inbounds tmp[i] = uprev[i] + a*k1[i]
   end
-  f(@muladd(t + c1*dt),tmp,k2)
+  f(t + c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
   end
-  f(@muladd(t + c2*dt) ,tmp,k3)
+  f(t + c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
   end
-  f(@muladd(t + c3*dt),tmp,k4)
+  f(t + c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
   end
-  f(@muladd(t + c4*dt),tmp,k5)
+  f(t + c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
   end
-  f(@muladd(t + c5*dt),tmp,k6)
+  f(t + c5*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
   end
-  f(@muladd(t + c6*dt),tmp,k7)
+  f(t + c6*dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
   end
-  f(@muladd(t + c7*dt),tmp,k8)
+  f(t + c7*dt,tmp,k8)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
   end
-  f(@muladd(t + c8*dt),tmp,k9)
+  f(t + c8*dt,tmp,k9)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
   end
-  f(@muladd(t + c9*dt),tmp,k10)
+  f(t + c9*dt,tmp,k10)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
   end
-  f(@muladd(t + c10*dt),tmp,k11)
+  f(t + c10*dt,tmp,k11)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
   end
-  f(@muladd(t + c11*dt),tmp,k12)
+  f(t + c11*dt,tmp,k12)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1200*k1[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1200*k1[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
   end
-  f(@muladd(t + c12*dt),tmp,k13)
+  f(t + c12*dt,tmp,k13)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1300*k1[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1300*k1[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
   end
-  f(@muladd(t + c13*dt),tmp,k14)
+  f(t + c13*dt,tmp,k14)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1400*k1[i] + a1408*k9[i] + a1409*k10[i] + a1410*k11[i] + a1411*k12[i] + a1412*k13[i] + a1413*k14[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1400*k1[i] + a1408*k9[i] + a1409*k10[i] + a1410*k11[i] + a1411*k12[i] + a1412*k13[i] + a1413*k14[i])
   end
-  f(@muladd(t + c14*dt),tmp,k15)
+  f(t + c14*dt,tmp,k15)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1500*k1[i] + a1508*k9[i] + a1509*k10[i] + a1510*k11[i] + a1511*k12[i] + a1512*k13[i] + a1513*k14[i] + a1514*k15[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1500*k1[i] + a1508*k9[i] + a1509*k10[i] + a1510*k11[i] + a1511*k12[i] + a1512*k13[i] + a1513*k14[i] + a1514*k15[i])
   end
-  f(@muladd(t + c15*dt),tmp,k16)
+  f(t + c15*dt,tmp,k16)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a1600*k1[i] + a1608*k9[i] + a1609*k10[i]) + (a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i]) + (a1614*k15[i] + a1615*k16[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a1600*k1[i] + a1608*k9[i] + a1609*k10[i]) + (a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i]) + (a1614*k15[i] + a1615*k16[i]))
   end
-  f(@muladd(t + c16*dt),tmp,k17)
+  f(t + c16*dt,tmp,k17)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a1700*k1[i] + a1705*k6[i] + a1706*k7[i]) + (a1707*k8[i] + a1708*k9[i] + a1709*k10[i] + a1710*k11[i]) + (a1711*k12[i] + a1712*k13[i] + a1713*k14[i] + a1714*k15[i]) + (a1715*k16[i] + a1716*k17[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a1700*k1[i] + a1705*k6[i] + a1706*k7[i]) + (a1707*k8[i] + a1708*k9[i] + a1709*k10[i] + a1710*k11[i]) + (a1711*k12[i] + a1712*k13[i] + a1713*k14[i] + a1714*k15[i]) + (a1715*k16[i] + a1716*k17[i]))
   end
-  f(@muladd(t + c17*dt),tmp,k18)
+  f(t + c17*dt,tmp,k18)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a1800*k1[i] + a1805*k6[i] + a1806*k7[i]) + (a1807*k8[i] + a1808*k9[i] + a1809*k10[i] + a1810*k11[i]) + (a1811*k12[i] + a1812*k13[i] + a1813*k14[i] + a1814*k15[i]) + (a1815*k16[i] + a1816*k17[i] + a1817*k18[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a1800*k1[i] + a1805*k6[i] + a1806*k7[i]) + (a1807*k8[i] + a1808*k9[i] + a1809*k10[i] + a1810*k11[i]) + (a1811*k12[i] + a1812*k13[i] + a1813*k14[i] + a1814*k15[i]) + (a1815*k16[i] + a1816*k17[i] + a1817*k18[i]))
   end
-  f(@muladd(t + c18*dt),tmp,k19)
+  f(t + c18*dt,tmp,k19)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a1900*k1[i] + a1904*k5[i] + a1905*k6[i]) + (a1906*k7[i] + a1908*k9[i] + a1909*k10[i] + a1910*k11[i]) + (a1911*k12[i] + a1912*k13[i] + a1913*k14[i] + a1914*k15[i]) + (a1915*k16[i] + a1916*k17[i] + a1917*k18[i] + a1918*k19[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a1900*k1[i] + a1904*k5[i] + a1905*k6[i]) + (a1906*k7[i] + a1908*k9[i] + a1909*k10[i] + a1910*k11[i]) + (a1911*k12[i] + a1912*k13[i] + a1913*k14[i] + a1914*k15[i]) + (a1915*k16[i] + a1916*k17[i] + a1917*k18[i] + a1918*k19[i]))
   end
-  f(@muladd(t + c19*dt),tmp,k20)
+  f(t + c19*dt,tmp,k20)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a2000*k1[i] + a2003*k4[i] + a2004*k5[i]) + (a2005*k6[i] + a2007*k8[i] + a2009*k10[i] + a2010*k11[i]) + (a2017*k18[i] + a2018*k19[i] + a2019*k20[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a2000*k1[i] + a2003*k4[i] + a2004*k5[i]) + (a2005*k6[i] + a2007*k8[i] + a2009*k10[i] + a2010*k11[i]) + (a2017*k18[i] + a2018*k19[i] + a2019*k20[i]))
   end
-  f(@muladd(t + c20*dt),tmp,k21)
+  f(t + c20*dt,tmp,k21)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a2100*k1[i] + a2102*k3[i] + a2103*k4[i]) + (a2106*k7[i] + a2107*k8[i] + a2109*k10[i] + a2110*k11[i]) + (a2117*k18[i] + a2118*k19[i] + a2119*k20[i] + a2120*k21[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a2100*k1[i] + a2102*k3[i] + a2103*k4[i]) + (a2106*k7[i] + a2107*k8[i] + a2109*k10[i] + a2110*k11[i]) + (a2117*k18[i] + a2118*k19[i] + a2119*k20[i] + a2120*k21[i]))
   end
-  f(@muladd(t + c21*dt),tmp,k22)
+  f(t + c21*dt,tmp,k22)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a2200*k1[i] + a2201*k2[i] + a2204*k5[i]) + (a2206*k7[i] + a2220*k21[i] + a2221*k22[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a2200*k1[i] + a2201*k2[i] + a2204*k5[i]) + (a2206*k7[i] + a2220*k21[i] + a2221*k22[i]))
   end
-  f(@muladd(t + c22*dt),tmp,k23)
+  f(t + c22*dt,tmp,k23)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2300*k1[i] + a2302*k3[i] + a2322*k23[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2300*k1[i] + a2302*k3[i] + a2322*k23[i])
   end
-  f(@muladd(t + c23*dt),tmp,k24)
+  f(t + c23*dt,tmp,k24)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*((a2400*k1[i] + a2401*k2[i] + a2402*k3[i]) + (a2404*k5[i] + a2406*k7[i] + a2407*k8[i] + a2408*k9[i]) + (a2409*k10[i] + a2410*k11[i] + a2411*k12[i] + a2412*k13[i]) + (a2413*k14[i] + a2414*k15[i] + a2415*k16[i] + a2416*k17[i]) + (a2417*k18[i] + a2418*k19[i] + a2419*k20[i] + a2420*k21[i]) + (a2421*k22[i] + a2422*k23[i] + a2423*k24[i]))
+    @inbounds tmp[i] = uprev[i] + dt*((a2400*k1[i] + a2401*k2[i] + a2402*k3[i]) + (a2404*k5[i] + a2406*k7[i] + a2407*k8[i] + a2408*k9[i]) + (a2409*k10[i] + a2410*k11[i] + a2411*k12[i] + a2412*k13[i]) + (a2413*k14[i] + a2414*k15[i] + a2415*k16[i] + a2416*k17[i]) + (a2417*k18[i] + a2418*k19[i] + a2419*k20[i] + a2420*k21[i]) + (a2421*k22[i] + a2422*k23[i] + a2423*k24[i]))
   end
-  f(@muladd(t + c24*dt),tmp,k25)
+  f(t + c24*dt,tmp,k25)
   @tight_loop_macros for i in uidx
-    u[i] = @muladd uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b8*k8[i] + b10*k10[i] + b11*k11[i] + b13*k13[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b17*k17[i] + b18*k18[i] + b19*k19[i] + b20*k20[i] + b21*k21[i] + b22*k22[i] + b23*k23[i] + b24*k24[i] + b25*k25[i])
+    u[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b8*k8[i] + b10*k10[i] + b11*k11[i] + b13*k13[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b17*k17[i] + b18*k18[i] + b19*k19[i] + b20*k20[i] + b21*k21[i] + b22*k22[i] + b23*k23[i] + b24*k24[i] + b25*k25[i])
   end
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds atmp[i] =  (dt*(k2[i] - k24[i]) * adaptiveConst)./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol)
+      @inbounds atmp[i] = (dt*(k2[i] - k24[i]) * adaptiveConst)/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
@@ -517,101 +440,49 @@ end
   integrator.k[2] = integrator.fsallast
 end
 
-#=
-@inline function perform_step!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache
   k1  = integrator.fsalfirst
   a = dt*a0100
-  k2  = f(@muladd(t + c1*dt),@.(@muladd(uprev  + a*k1)))
-  k3  = f(@muladd(t + c2*dt),@.(@muladd(uprev  + dt*(a0200*k1 + a0201*k2))))
-  k4  = f(@muladd(t + c3*dt),@.(@muladd(uprev  + dt*(a0300*k1              + a0302*k3))))
-  k5  = f(@muladd(t + c4*dt),@.(@muladd(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4))))
-  k6  = f(@muladd(t + c5*dt),@.(@muladd(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5))))
-  k7  = f(@muladd(t + c6*dt),@.(@muladd(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6))))
-  k8  = f(@muladd(t + c7*dt),@.(@muladd(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7))))
-  k9  = f(@muladd(t + c8*dt),@.(@muladd(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8))))
-  k10 = f(@muladd(t + c9*dt),@.(@muladd(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9))))
-  k11 = f(@muladd(t + c10*dt),@.(@muladd(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10))))
-  k12 = f(@muladd(t + c11*dt),@.(@muladd(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11))))
-  k13 = f(@muladd(t + c12*dt),@.(@muladd(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12))))
-  k14 = f(@muladd(t + c13*dt),@.(@muladd(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13))))
-  k15 = f(@muladd(t + c14*dt),@.(@muladd(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14))))
-  k16 = f(@muladd(t + c15*dt),@.(@muladd(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15))))
-  k17 = f(@muladd(t + c16*dt),@.(@muladd(uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16))))
-  k18 = f(@muladd(t + c17*dt),@.(@muladd(uprev + dt*(a1700*k1                                                                                                                                                   + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17))))
-  k19 = f(@muladd(t + c18*dt),@.(@muladd(uprev + dt*(a1800*k1                                                                                                                                                   + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18))))
-  k20 = f(@muladd(t + c19*dt),@.(@muladd(uprev + dt*(a1900*k1                                                                                                                                                   + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))))
-  k21 = f(@muladd(t + c20*dt),@.(@muladd(uprev + dt*(a2000*k1                                                                                                                                                   + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20))))
-  k22 = f(@muladd(t + c21*dt),@.(@muladd(uprev + dt*(a2100*k1                                                                                                                                                   + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))))
-  k23 = f(@muladd(t + c22*dt),@.(@muladd(uprev + dt*(a2200*k1                                                                                                                                                   + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22))))
-  k24 = f(@muladd(t + c23*dt),@.(@muladd(uprev + dt*(a2300*k1                                                                                            + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23))))
-  k25 = f(@muladd(t + c24*dt),@.(@muladd(uprev + dt*(a2400*k1                                                                                            + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24))))
-  k26 = f(@muladd(t + c25*dt),@.(@muladd(uprev + dt*(a2500*k1                                                                                            + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25))))
-  k27 = f(@muladd(t + c26*dt),@.(@muladd(uprev + dt*(a2600*k1                                                     + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11               + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26))))
-  k28 = f(@muladd(t + c27*dt),@.(@muladd(uprev + dt*(a2700*k1                                                     + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10               + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27))))
-  k29 = f(@muladd(t + c28*dt),@.(@muladd(uprev + dt*(a2800*k1                                                     + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9               + a2810*k11 + a2811*k12               + a2813*k14 + a2814*k15 + a2815*k16                                                                                                   + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28))))
-  k30 = f(@muladd(t + c29*dt),@.(@muladd(uprev + dt*(a2900*k1                                        + a2904*k5 + a2905*k6 + a2906*k7                           + a2909*k10 + a2910*k11 + a2911*k12               + a2913*k14 + a2914*k15 + a2915*k16                                                                                                   + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29))))
-  k31 = f(@muladd(t + c30*dt),@.(@muladd(uprev + dt*(a3000*k1                           + a3003*k4 + a3004*k5 + a3005*k6              + a3007*k8              + a3009*k10 + a3010*k11                             + a3013*k14 + a3014*k15 + a3015*k16                                                                                                   + a3023*k24 + a3024*k25 + a3025*k26               + a3027*k28 + a3028*k29 + a3029*k30))))
-  k32 = f(@muladd(t + c31*dt),@.(@muladd(uprev + dt*(a3100*k1              + a3102*k3 + a3103*k4                           + a3106*k7 + a3107*k8              + a3109*k10 + a3110*k11                             + a3113*k14 + a3114*k15 + a3115*k16                                                                                                   + a3123*k24 + a3124*k25 + a3125*k26               + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31))))
-  k33 = f(@muladd(t + c32*dt),@.(@muladd(uprev + dt*(a3200*k1 + a3201*k2                           + a3204*k5              + a3206*k7                                                                                                                                                                                                                                                                                                                                 + a3230*k31 + a3231*k32))))
-  k34 = f(@muladd(t + c33*dt),@.(@muladd(uprev + dt*(a3300*k1              + a3302*k3                                                                                                                                                                                                                                                                                                                                                                                                                 + a3332*k33))))
-  k35 = f(@muladd(t + c34*dt),@.(@muladd(uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3              + a3404*k5              + a3406*k7 + a3407*k8              + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34))))
-  u = @. @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
+  k2  = f(t + c1*dt, @. uprev  + a*k1)
+  k3  = f(t + c2*dt, @. uprev + dt*(a0200*k1 + a0201*k2))
+  k4  = f(t + c3*dt, @. uprev  + dt*(a0300*k1              + a0302*k3))
+  k5  = f(t + c4*dt, @. uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4))
+  k6  = f(t + c5*dt, @. uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5))
+  k7  = f(t + c6*dt, @. uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6))
+  k8  = f(t + c7*dt, @. uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7))
+  k9  = f(t + c8*dt, @. uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8))
+  k10 = f(t + c9*dt, @. uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9))
+  k11 = f(t + c10*dt, @. uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10))
+  k12 = f(t + c11*dt, @. uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11))
+  k13 = f(t + c12*dt, @. uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12))
+  k14 = f(t + c13*dt, @. uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13))
+  k15 = f(t + c14*dt, @. uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14))
+  k16 = f(t + c15*dt, @. uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15))
+  k17 = f(t + c16*dt, @. uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16))
+  k18 = f(t + c17*dt, @. uprev + dt*(a1700*k1                                                                                                                                                   + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17))
+  k19 = f(t + c18*dt, @. uprev + dt*(a1800*k1                                                                                                                                                   + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18))
+  k20 = f(t + c19*dt, @. uprev + dt*(a1900*k1                                                                                                                                                   + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))
+  k21 = f(t + c20*dt, @. uprev + dt*(a2000*k1                                                                                                                                                   + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20))
+  k22 = f(t + c21*dt, @. uprev + dt*(a2100*k1                                                                                                                                                   + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))
+  k23 = f(t + c22*dt, @. uprev + dt*(a2200*k1                                                                                                                                                   + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22))
+  k24 = f(t + c23*dt, @. uprev + dt*(a2300*k1                                                                                            + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23))
+  k25 = f(t + c24*dt, @. uprev + dt*(a2400*k1                                                                                            + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24))
+  k26 = f(t + c25*dt, @. uprev + dt*(a2500*k1                                                                                            + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25))
+  k27 = f(t + c26*dt, @. uprev + dt*(a2600*k1                                                     + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11               + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26))
+  k28 = f(t + c27*dt, @. uprev + dt*(a2700*k1                                                     + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10               + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27))
+  k29 = f(t + c28*dt, @. uprev + dt*(a2800*k1                                                     + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9               + a2810*k11 + a2811*k12               + a2813*k14 + a2814*k15 + a2815*k16                                                                                                   + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28))
+  k30 = f(t + c29*dt, @. uprev + dt*(a2900*k1                                        + a2904*k5 + a2905*k6 + a2906*k7                           + a2909*k10 + a2910*k11 + a2911*k12               + a2913*k14 + a2914*k15 + a2915*k16                                                                                                   + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29))
+  k31 = f(t + c30*dt, @. uprev + dt*(a3000*k1                           + a3003*k4 + a3004*k5 + a3005*k6              + a3007*k8              + a3009*k10 + a3010*k11                             + a3013*k14 + a3014*k15 + a3015*k16                                                                                                   + a3023*k24 + a3024*k25 + a3025*k26               + a3027*k28 + a3028*k29 + a3029*k30))
+  k32 = f(t + c31*dt, @. uprev + dt*(a3100*k1              + a3102*k3 + a3103*k4                           + a3106*k7 + a3107*k8              + a3109*k10 + a3110*k11                             + a3113*k14 + a3114*k15 + a3115*k16                                                                                                   + a3123*k24 + a3124*k25 + a3125*k26               + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31))
+  k33 = f(t + c32*dt, @. uprev + dt*(a3200*k1 + a3201*k2                           + a3204*k5              + a3206*k7                                                                                                                                                                                                                                                                                                                                 + a3230*k31 + a3231*k32))
+  k34 = f(t + c33*dt, @. uprev + dt*(a3300*k1              + a3302*k3                                                                                                                                                                                                                                                                                                                                                                                                                 + a3332*k33))
+  k35 = f(t + c34*dt, @. uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3              + a3404*k5              + a3406*k7 + a3407*k8              + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34))
+  u = @. uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
   if integrator.opts.adaptive
-    tmp = @. (dt*(k2 - k34) * adaptiveConst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. (dt*(k2 - k34) * adaptiveConst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(tmp)
-  end
-  k = f(t+dt,u) # For the interpolation, needs k at the updated point
-  integrator.fsallast = k
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-=#
-
-@inline function perform_step!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache
-  k1  = integrator.fsalfirst
-  a = dt*a0100
-  k2  = f(@muladd(t + c1*dt),@muladd(uprev  + a*k1))
-  k3  = f(@muladd(t + c2*dt),@muladd(uprev + dt*(a0200*k1 + a0201*k2)))
-  k4  = f(@muladd(t + c3*dt),@muladd(uprev  + dt*(a0300*k1              + a0302*k3)))
-  k5  = f(@muladd(t + c4*dt),@muladd(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4)))
-  k6  = f(@muladd(t + c5*dt),@muladd(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5)))
-  k7  = f(@muladd(t + c6*dt),@muladd(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6)))
-  k8  = f(@muladd(t + c7*dt),@muladd(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7)))
-  k9  = f(@muladd(t + c8*dt),@muladd(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8)))
-  k10 = f(@muladd(t + c9*dt),@muladd(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)))
-  k11 = f(@muladd(t + c10*dt),@muladd(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)))
-  k12 = f(@muladd(t + c11*dt),@muladd(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)))
-  k13 = f(@muladd(t + c12*dt),@muladd(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)))
-  k14 = f(@muladd(t + c13*dt),@muladd(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)))
-  k15 = f(@muladd(t + c14*dt),@muladd(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)))
-  k16 = f(@muladd(t + c15*dt),@muladd(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)))
-  k17 = f(@muladd(t + c16*dt),@muladd(uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)))
-  k18 = f(@muladd(t + c17*dt),@muladd(uprev + dt*(a1700*k1                                                                                                                                                   + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17)))
-  k19 = f(@muladd(t + c18*dt),@muladd(uprev + dt*(a1800*k1                                                                                                                                                   + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18)))
-  k20 = f(@muladd(t + c19*dt),@muladd(uprev + dt*(a1900*k1                                                                                                                                                   + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)))
-  k21 = f(@muladd(t + c20*dt),@muladd(uprev + dt*(a2000*k1                                                                                                                                                   + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20)))
-  k22 = f(@muladd(t + c21*dt),@muladd(uprev + dt*(a2100*k1                                                                                                                                                   + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)))
-  k23 = f(@muladd(t + c22*dt),@muladd(uprev + dt*(a2200*k1                                                                                                                                                   + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22)))
-  k24 = f(@muladd(t + c23*dt),@muladd(uprev + dt*(a2300*k1                                                                                            + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23)))
-  k25 = f(@muladd(t + c24*dt),@muladd(uprev + dt*(a2400*k1                                                                                            + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24)))
-  k26 = f(@muladd(t + c25*dt),@muladd(uprev + dt*(a2500*k1                                                                                            + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25)))
-  k27 = f(@muladd(t + c26*dt),@muladd(uprev + dt*(a2600*k1                                                     + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11               + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26)))
-  k28 = f(@muladd(t + c27*dt),@muladd(uprev + dt*(a2700*k1                                                     + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10               + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27)))
-  k29 = f(@muladd(t + c28*dt),@muladd(uprev + dt*(a2800*k1                                                     + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9               + a2810*k11 + a2811*k12               + a2813*k14 + a2814*k15 + a2815*k16                                                                                                   + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28)))
-  k30 = f(@muladd(t + c29*dt),@muladd(uprev + dt*(a2900*k1                                        + a2904*k5 + a2905*k6 + a2906*k7                           + a2909*k10 + a2910*k11 + a2911*k12               + a2913*k14 + a2914*k15 + a2915*k16                                                                                                   + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29)))
-  k31 = f(@muladd(t + c30*dt),@muladd(uprev + dt*(a3000*k1                           + a3003*k4 + a3004*k5 + a3005*k6              + a3007*k8              + a3009*k10 + a3010*k11                             + a3013*k14 + a3014*k15 + a3015*k16                                                                                                   + a3023*k24 + a3024*k25 + a3025*k26               + a3027*k28 + a3028*k29 + a3029*k30)))
-  k32 = f(@muladd(t + c31*dt),@muladd(uprev + dt*(a3100*k1              + a3102*k3 + a3103*k4                           + a3106*k7 + a3107*k8              + a3109*k10 + a3110*k11                             + a3113*k14 + a3114*k15 + a3115*k16                                                                                                   + a3123*k24 + a3124*k25 + a3125*k26               + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31)))
-  k33 = f(@muladd(t + c32*dt),@muladd(uprev + dt*(a3200*k1 + a3201*k2                           + a3204*k5              + a3206*k7                                                                                                                                                                                                                                                                                                                                 + a3230*k31 + a3231*k32)))
-  k34 = f(@muladd(t + c33*dt),@muladd(uprev + dt*(a3300*k1              + a3302*k3                                                                                                                                                                                                                                                                                                                                                                                                                 + a3332*k33)))
-  k35 = f(@muladd(t + c34*dt),@muladd(uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3              + a3404*k5              + a3406*k7 + a3407*k8              + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34)))
-  u = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
-  if integrator.opts.adaptive
-    integrator.EEst = integrator.opts.internalnorm((dt*(k2 - k34) * adaptiveConst)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
   end
   k = f(t+dt,u) # For the interpolation, needs k at the updated point
   integrator.fsallast = k
@@ -631,84 +502,84 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::Feagin14Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin14Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k18,k19,k20,k21,k22,k23,k24,k25,k26,k27,k28,k29,k30,k31,k32,k33,k34,k35,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
   f(t,uprev,k1)
   a = dt*a0100
-  @. tmp = @muladd uprev + a*k1
-  f(@muladd(t + c1*dt),tmp,k2)
-  @. tmp = @muladd uprev + dt*(a0200*k1 + a0201*k2)
-  f(@muladd(t + c2*dt) ,tmp,k3)
-  @. tmp = @muladd uprev + dt*(a0300*k1 + a0302*k3)
-  f(@muladd(t + c3*dt),tmp,k4)
-  @. tmp = @muladd uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
-  f(@muladd(t + c4*dt),tmp,k5)
-  @. tmp = @muladd uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
-  f(@muladd(t + c5*dt),tmp,k6)
-  @. tmp = @muladd uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
-  f(@muladd(t + c6*dt),tmp,k7)
-  @. tmp = @muladd uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
-  f(@muladd(t + c7*dt),tmp,k8)
-  @. tmp = @muladd uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
-  f(@muladd(t + c8*dt),tmp,k9)
-  @. tmp = @muladd uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
-  f(@muladd(t + c9*dt),tmp,k10)
-  @. tmp = @muladd uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
-  f(@muladd(t + c10*dt),tmp,k11)
-  @. tmp = @muladd uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
-  f(@muladd(t + c11*dt),tmp,k12)
-  @. tmp = @muladd uprev + dt*(a1200*k1 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
-  f(@muladd(t + c12*dt),tmp,k13)
-  @. tmp = @muladd uprev + dt*(a1300*k1 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
-  f(@muladd(t + c13*dt),tmp,k14)
-  @. tmp = @muladd uprev + dt*(a1400*k1 + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)
-  f(@muladd(t + c14*dt),tmp,k15)
-  @. tmp = @muladd uprev + dt*(a1500*k1 + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)
-  f(@muladd(t + c15*dt),tmp,k16)
-  @. tmp = @muladd uprev + dt*(a1600*k1 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)
-  f(@muladd(t + c16*dt),tmp,k17)
-  @. tmp = @muladd uprev + dt*(a1700*k1 + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17)
-  f(@muladd(t + c17*dt),tmp,k18)
-  @. tmp = @muladd uprev + dt*(a1800*k1 + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18)
-  f(@muladd(t + c18*dt),tmp,k19)
-  @. tmp = @muladd uprev + dt*(a1900*k1 + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)
-  f(@muladd(t + c19*dt),tmp,k20)
-  @. tmp = @muladd uprev + dt*(a2000*k1 + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20)
-  f(@muladd(t + c20*dt),tmp,k21)
-  @. tmp = @muladd uprev + dt*(a2100*k1 + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)
-  f(@muladd(t + c21*dt),tmp,k22)
-  @. tmp = @muladd uprev + dt*(a2200*k1 + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22)
-  f(@muladd(t + c22*dt),tmp,k23)
-  @. tmp = @muladd uprev + dt*(a2300*k1 + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23)
-  f(@muladd(t + c23*dt),tmp,k24)
-  @. tmp = @muladd uprev + dt*(a2400*k1 + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24)
-  f(@muladd(t + c24*dt),tmp,k25)
-  @. tmp = @muladd uprev + dt*(a2500*k1 + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25)
-  f(@muladd(t + c25*dt),tmp,k26)
-  @. tmp = @muladd uprev + dt*(a2600*k1 + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11 + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26)
-  f(@muladd(t + c26*dt),tmp,k27)
-  @. tmp = @muladd uprev + dt*(a2700*k1 + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10 + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27)
-  f(@muladd(t + c27*dt),tmp,k28)
-  @. tmp = @muladd uprev + dt*(a2800*k1 + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9 + a2810*k11 + a2811*k12 + a2813*k14 + a2814*k15 + a2815*k16 + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28)
-  f(@muladd(t + c28*dt),tmp,k29)
-  @. tmp = @muladd uprev + dt*(a2900*k1 + a2904*k5 + a2905*k6 + a2906*k7 + a2909*k10 + a2910*k11 + a2911*k12 + a2913*k14 + a2914*k15 + a2915*k16 + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29)
-  f(@muladd(t + c29*dt),tmp,k30)
-  @. tmp = @muladd uprev + dt*(a3000*k1 + a3003*k4 + a3004*k5 + a3005*k6 + a3007*k8 + a3009*k10 + a3010*k11 + a3013*k14 + a3014*k15 + a3015*k16 + a3023*k24 + a3024*k25 + a3025*k26 + a3027*k28 + a3028*k29 + a3029*k30)
-  f(@muladd(t + c30*dt),tmp,k31)
-  @. tmp = @muladd uprev + dt*(a3100*k1 + a3102*k3 + a3103*k4 + a3106*k7 + a3107*k8 + a3109*k10 + a3110*k11 + a3113*k14 + a3114*k15 + a3115*k16 + a3123*k24 + a3124*k25 + a3125*k26 + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31)
-  f(@muladd(t + c31*dt),tmp,k32)
-  @. tmp = @muladd uprev + dt*(a3200*k1 + a3201*k2 + a3204*k5 + a3206*k7 + a3230*k31 + a3231*k32)
-  f(@muladd(t + c32*dt),tmp,k33)
-  @. tmp = @muladd uprev + dt*(a3300*k1 + a3302*k3 + a3332*k33)
-  f(@muladd(t + c33*dt),tmp,k34)
-  @. tmp = @muladd uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3 + a3404*k5 + a3406*k7 + a3407*k8 + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34)
-  f(@muladd(t + c34*dt),tmp,k35)
-  @. u = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
+  @. tmp = uprev + a*k1
+  f(t + c1*dt,tmp,k2)
+  @. tmp = uprev + dt*(a0200*k1 + a0201*k2)
+  f(t + c2*dt ,tmp,k3)
+  @. tmp = uprev + dt*(a0300*k1 + a0302*k3)
+  f(t + c3*dt,tmp,k4)
+  @. tmp = uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
+  f(t + c4*dt,tmp,k5)
+  @. tmp = uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
+  f(t + c5*dt,tmp,k6)
+  @. tmp = uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
+  f(t + c6*dt,tmp,k7)
+  @. tmp = uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
+  f(t + c7*dt,tmp,k8)
+  @. tmp = uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
+  f(t + c8*dt,tmp,k9)
+  @. tmp = uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
+  f(t + c9*dt,tmp,k10)
+  @. tmp = uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
+  f(t + c10*dt,tmp,k11)
+  @. tmp = uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
+  f(t + c11*dt,tmp,k12)
+  @. tmp = uprev + dt*(a1200*k1 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
+  f(t + c12*dt,tmp,k13)
+  @. tmp = uprev + dt*(a1300*k1 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
+  f(t + c13*dt,tmp,k14)
+  @. tmp = uprev + dt*(a1400*k1 + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)
+  f(t + c14*dt,tmp,k15)
+  @. tmp = uprev + dt*(a1500*k1 + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)
+  f(t + c15*dt,tmp,k16)
+  @. tmp = uprev + dt*(a1600*k1 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)
+  f(t + c16*dt,tmp,k17)
+  @. tmp = uprev + dt*(a1700*k1 + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17)
+  f(t + c17*dt,tmp,k18)
+  @. tmp = uprev + dt*(a1800*k1 + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18)
+  f(t + c18*dt,tmp,k19)
+  @. tmp = uprev + dt*(a1900*k1 + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)
+  f(t + c19*dt,tmp,k20)
+  @. tmp = uprev + dt*(a2000*k1 + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20)
+  f(t + c20*dt,tmp,k21)
+  @. tmp = uprev + dt*(a2100*k1 + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)
+  f(t + c21*dt,tmp,k22)
+  @. tmp = uprev + dt*(a2200*k1 + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22)
+  f(t + c22*dt,tmp,k23)
+  @. tmp = uprev + dt*(a2300*k1 + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23)
+  f(t + c23*dt,tmp,k24)
+  @. tmp = uprev + dt*(a2400*k1 + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24)
+  f(t + c24*dt,tmp,k25)
+  @. tmp = uprev + dt*(a2500*k1 + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25)
+  f(t + c25*dt,tmp,k26)
+  @. tmp = uprev + dt*(a2600*k1 + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11 + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26)
+  f(t + c26*dt,tmp,k27)
+  @. tmp = uprev + dt*(a2700*k1 + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10 + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27)
+  f(t + c27*dt,tmp,k28)
+  @. tmp = uprev + dt*(a2800*k1 + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9 + a2810*k11 + a2811*k12 + a2813*k14 + a2814*k15 + a2815*k16 + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28)
+  f(t + c28*dt,tmp,k29)
+  @. tmp = uprev + dt*(a2900*k1 + a2904*k5 + a2905*k6 + a2906*k7 + a2909*k10 + a2910*k11 + a2911*k12 + a2913*k14 + a2914*k15 + a2915*k16 + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29)
+  f(t + c29*dt,tmp,k30)
+  @. tmp = uprev + dt*(a3000*k1 + a3003*k4 + a3004*k5 + a3005*k6 + a3007*k8 + a3009*k10 + a3010*k11 + a3013*k14 + a3014*k15 + a3015*k16 + a3023*k24 + a3024*k25 + a3025*k26 + a3027*k28 + a3028*k29 + a3029*k30)
+  f(t + c30*dt,tmp,k31)
+  @. tmp = uprev + dt*(a3100*k1 + a3102*k3 + a3103*k4 + a3106*k7 + a3107*k8 + a3109*k10 + a3110*k11 + a3113*k14 + a3114*k15 + a3115*k16 + a3123*k24 + a3124*k25 + a3125*k26 + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31)
+  f(t + c31*dt,tmp,k32)
+  @. tmp = uprev + dt*(a3200*k1 + a3201*k2 + a3204*k5 + a3206*k7 + a3230*k31 + a3231*k32)
+  f(t + c32*dt,tmp,k33)
+  @. tmp = uprev + dt*(a3300*k1 + a3302*k3 + a3332*k33)
+  f(t + c33*dt,tmp,k34)
+  @. tmp = uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3 + a3404*k5 + a3406*k7 + a3407*k8 + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34)
+  f(t + c34*dt,tmp,k35)
+  @. u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
   if integrator.opts.adaptive
-    @. atmp = (dt*(k2 - k34) * adaptiveConst)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol)
+    @. atmp = (dt*(k2 - k34) * adaptiveConst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   f(t+dt,u,integrator.fsallast) # For the interpolation, needs k at the updated point
@@ -716,7 +587,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::Feagin14Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Feagin14Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache.tab
@@ -725,147 +596,147 @@ end
   f(t,uprev,k1)
   a = dt*a0100
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + a*k1[i]
+    @inbounds tmp[i] = uprev[i] + a*k1[i]
   end
-  f(@muladd(t + c1*dt),tmp,k2)
+  f(t + c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
   end
-  f(@muladd(t + c2*dt) ,tmp,k3)
+  f(t + c2*dt ,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
   end
-  f(@muladd(t + c3*dt),tmp,k4)
+  f(t + c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
   end
-  f(@muladd(t + c4*dt),tmp,k5)
+  f(t + c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
   end
-  f(@muladd(t + c5*dt),tmp,k6)
+  f(t + c5*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
   end
-  f(@muladd(t + c6*dt),tmp,k7)
+  f(t + c6*dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
   end
-  f(@muladd(t + c7*dt),tmp,k8)
+  f(t + c7*dt,tmp,k8)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
   end
-  f(@muladd(t + c8*dt),tmp,k9)
+  f(t + c8*dt,tmp,k9)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
   end
-  f(@muladd(t + c9*dt),tmp,k10)
+  f(t + c9*dt,tmp,k10)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
   end
-  f(@muladd(t + c10*dt),tmp,k11)
+  f(t + c10*dt,tmp,k11)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
   end
-  f(@muladd(t + c11*dt),tmp,k12)
+  f(t + c11*dt,tmp,k12)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1200*k1[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1200*k1[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
   end
-  f(@muladd(t + c12*dt),tmp,k13)
+  f(t + c12*dt,tmp,k13)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1300*k1[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1300*k1[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
   end
-  f(@muladd(t + c13*dt),tmp,k14)
+  f(t + c13*dt,tmp,k14)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1400*k1[i] + a1408*k9[i] + a1409*k10[i] + a1410*k11[i] + a1411*k12[i] + a1412*k13[i] + a1413*k14[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1400*k1[i] + a1408*k9[i] + a1409*k10[i] + a1410*k11[i] + a1411*k12[i] + a1412*k13[i] + a1413*k14[i])
   end
-  f(@muladd(t + c14*dt),tmp,k15)
+  f(t + c14*dt,tmp,k15)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1500*k1[i] + a1508*k9[i] + a1509*k10[i] + a1510*k11[i] + a1511*k12[i] + a1512*k13[i] + a1513*k14[i] + a1514*k15[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1500*k1[i] + a1508*k9[i] + a1509*k10[i] + a1510*k11[i] + a1511*k12[i] + a1512*k13[i] + a1513*k14[i] + a1514*k15[i])
   end
-  f(@muladd(t + c15*dt),tmp,k16)
+  f(t + c15*dt,tmp,k16)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1600*k1[i] + a1608*k9[i] + a1609*k10[i] + a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i] + a1614*k15[i] + a1615*k16[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1600*k1[i] + a1608*k9[i] + a1609*k10[i] + a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i] + a1614*k15[i] + a1615*k16[i])
   end
-  f(@muladd(t + c16*dt),tmp,k17)
+  f(t + c16*dt,tmp,k17)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1700*k1[i] + a1712*k13[i] + a1713*k14[i] + a1714*k15[i] + a1715*k16[i] + a1716*k17[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1700*k1[i] + a1712*k13[i] + a1713*k14[i] + a1714*k15[i] + a1715*k16[i] + a1716*k17[i])
   end
-  f(@muladd(t + c17*dt),tmp,k18)
+  f(t + c17*dt,tmp,k18)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1800*k1[i] + a1812*k13[i] + a1813*k14[i] + a1814*k15[i] + a1815*k16[i] + a1816*k17[i] + a1817*k18[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1800*k1[i] + a1812*k13[i] + a1813*k14[i] + a1814*k15[i] + a1815*k16[i] + a1816*k17[i] + a1817*k18[i])
   end
-  f(@muladd(t + c18*dt),tmp,k19)
+  f(t + c18*dt,tmp,k19)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a1900*k1[i] + a1912*k13[i] + a1913*k14[i] + a1914*k15[i] + a1915*k16[i] + a1916*k17[i] + a1917*k18[i] + a1918*k19[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a1900*k1[i] + a1912*k13[i] + a1913*k14[i] + a1914*k15[i] + a1915*k16[i] + a1916*k17[i] + a1917*k18[i] + a1918*k19[i])
   end
-  f(@muladd(t + c19*dt),tmp,k20)
+  f(t + c19*dt,tmp,k20)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2000*k1[i] + a2012*k13[i] + a2013*k14[i] + a2014*k15[i] + a2015*k16[i] + a2016*k17[i] + a2017*k18[i] + a2018*k19[i] + a2019*k20[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2000*k1[i] + a2012*k13[i] + a2013*k14[i] + a2014*k15[i] + a2015*k16[i] + a2016*k17[i] + a2017*k18[i] + a2018*k19[i] + a2019*k20[i])
   end
-  f(@muladd(t + c20*dt),tmp,k21)
+  f(t + c20*dt,tmp,k21)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2100*k1[i] + a2112*k13[i] + a2113*k14[i] + a2114*k15[i] + a2115*k16[i] + a2116*k17[i] + a2117*k18[i] + a2118*k19[i] + a2119*k20[i] + a2120*k21[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2100*k1[i] + a2112*k13[i] + a2113*k14[i] + a2114*k15[i] + a2115*k16[i] + a2116*k17[i] + a2117*k18[i] + a2118*k19[i] + a2119*k20[i] + a2120*k21[i])
   end
-  f(@muladd(t + c21*dt),tmp,k22)
+  f(t + c21*dt,tmp,k22)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2200*k1[i] + a2212*k13[i] + a2213*k14[i] + a2214*k15[i] + a2215*k16[i] + a2216*k17[i] + a2217*k18[i] + a2218*k19[i] + a2219*k20[i] + a2220*k21[i] + a2221*k22[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2200*k1[i] + a2212*k13[i] + a2213*k14[i] + a2214*k15[i] + a2215*k16[i] + a2216*k17[i] + a2217*k18[i] + a2218*k19[i] + a2219*k20[i] + a2220*k21[i] + a2221*k22[i])
   end
-  f(@muladd(t + c22*dt),tmp,k23)
+  f(t + c22*dt,tmp,k23)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2300*k1[i] + a2308*k9[i] + a2309*k10[i] + a2310*k11[i] + a2311*k12[i] + a2312*k13[i] + a2313*k14[i] + a2314*k15[i] + a2315*k16[i] + a2316*k17[i] + a2317*k18[i] + a2318*k19[i] + a2319*k20[i] + a2320*k21[i] + a2321*k22[i] + a2322*k23[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2300*k1[i] + a2308*k9[i] + a2309*k10[i] + a2310*k11[i] + a2311*k12[i] + a2312*k13[i] + a2313*k14[i] + a2314*k15[i] + a2315*k16[i] + a2316*k17[i] + a2317*k18[i] + a2318*k19[i] + a2319*k20[i] + a2320*k21[i] + a2321*k22[i] + a2322*k23[i])
   end
-  f(@muladd(t + c23*dt),tmp,k24)
+  f(t + c23*dt,tmp,k24)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2400*k1[i] + a2408*k9[i] + a2409*k10[i] + a2410*k11[i] + a2411*k12[i] + a2412*k13[i] + a2413*k14[i] + a2414*k15[i] + a2415*k16[i] + a2416*k17[i] + a2417*k18[i] + a2418*k19[i] + a2419*k20[i] + a2420*k21[i] + a2421*k22[i] + a2422*k23[i] + a2423*k24[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2400*k1[i] + a2408*k9[i] + a2409*k10[i] + a2410*k11[i] + a2411*k12[i] + a2412*k13[i] + a2413*k14[i] + a2414*k15[i] + a2415*k16[i] + a2416*k17[i] + a2417*k18[i] + a2418*k19[i] + a2419*k20[i] + a2420*k21[i] + a2421*k22[i] + a2422*k23[i] + a2423*k24[i])
   end
-  f(@muladd(t + c24*dt),tmp,k25)
+  f(t + c24*dt,tmp,k25)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2500*k1[i] + a2508*k9[i] + a2509*k10[i] + a2510*k11[i] + a2511*k12[i] + a2512*k13[i] + a2513*k14[i] + a2514*k15[i] + a2515*k16[i] + a2516*k17[i] + a2517*k18[i] + a2518*k19[i] + a2519*k20[i] + a2520*k21[i] + a2521*k22[i] + a2522*k23[i] + a2523*k24[i] + a2524*k25[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2500*k1[i] + a2508*k9[i] + a2509*k10[i] + a2510*k11[i] + a2511*k12[i] + a2512*k13[i] + a2513*k14[i] + a2514*k15[i] + a2515*k16[i] + a2516*k17[i] + a2517*k18[i] + a2518*k19[i] + a2519*k20[i] + a2520*k21[i] + a2521*k22[i] + a2522*k23[i] + a2523*k24[i] + a2524*k25[i])
   end
-  f(@muladd(t + c25*dt),tmp,k26)
+  f(t + c25*dt,tmp,k26)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2600*k1[i] + a2605*k6[i] + a2606*k7[i] + a2607*k8[i] + a2608*k9[i] + a2609*k10[i] + a2610*k11[i] + a2612*k13[i] + a2613*k14[i] + a2614*k15[i] + a2615*k16[i] + a2616*k17[i] + a2617*k18[i] + a2618*k19[i] + a2619*k20[i] + a2620*k21[i] + a2621*k22[i] + a2622*k23[i] + a2623*k24[i] + a2624*k25[i] + a2625*k26[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2600*k1[i] + a2605*k6[i] + a2606*k7[i] + a2607*k8[i] + a2608*k9[i] + a2609*k10[i] + a2610*k11[i] + a2612*k13[i] + a2613*k14[i] + a2614*k15[i] + a2615*k16[i] + a2616*k17[i] + a2617*k18[i] + a2618*k19[i] + a2619*k20[i] + a2620*k21[i] + a2621*k22[i] + a2622*k23[i] + a2623*k24[i] + a2624*k25[i] + a2625*k26[i])
   end
-  f(@muladd(t + c26*dt),tmp,k27)
+  f(t + c26*dt,tmp,k27)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2700*k1[i] + a2705*k6[i] + a2706*k7[i] + a2707*k8[i] + a2708*k9[i] + a2709*k10[i] + a2711*k12[i] + a2712*k13[i] + a2713*k14[i] + a2714*k15[i] + a2715*k16[i] + a2716*k17[i] + a2717*k18[i] + a2718*k19[i] + a2719*k20[i] + a2720*k21[i] + a2721*k22[i] + a2722*k23[i] + a2723*k24[i] + a2724*k25[i] + a2725*k26[i] + a2726*k27[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2700*k1[i] + a2705*k6[i] + a2706*k7[i] + a2707*k8[i] + a2708*k9[i] + a2709*k10[i] + a2711*k12[i] + a2712*k13[i] + a2713*k14[i] + a2714*k15[i] + a2715*k16[i] + a2716*k17[i] + a2717*k18[i] + a2718*k19[i] + a2719*k20[i] + a2720*k21[i] + a2721*k22[i] + a2722*k23[i] + a2723*k24[i] + a2724*k25[i] + a2725*k26[i] + a2726*k27[i])
   end
-  f(@muladd(t + c27*dt),tmp,k28)
+  f(t + c27*dt,tmp,k28)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2800*k1[i] + a2805*k6[i] + a2806*k7[i] + a2807*k8[i] + a2808*k9[i] + a2810*k11[i] + a2811*k12[i] + a2813*k14[i] + a2814*k15[i] + a2815*k16[i] + a2823*k24[i] + a2824*k25[i] + a2825*k26[i] + a2826*k27[i] + a2827*k28[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2800*k1[i] + a2805*k6[i] + a2806*k7[i] + a2807*k8[i] + a2808*k9[i] + a2810*k11[i] + a2811*k12[i] + a2813*k14[i] + a2814*k15[i] + a2815*k16[i] + a2823*k24[i] + a2824*k25[i] + a2825*k26[i] + a2826*k27[i] + a2827*k28[i])
   end
-  f(@muladd(t + c28*dt),tmp,k29)
+  f(t + c28*dt,tmp,k29)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a2900*k1[i] + a2904*k5[i] + a2905*k6[i] + a2906*k7[i] + a2909*k10[i] + a2910*k11[i] + a2911*k12[i] + a2913*k14[i] + a2914*k15[i] + a2915*k16[i] + a2923*k24[i] + a2924*k25[i] + a2925*k26[i] + a2926*k27[i] + a2927*k28[i] + a2928*k29[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a2900*k1[i] + a2904*k5[i] + a2905*k6[i] + a2906*k7[i] + a2909*k10[i] + a2910*k11[i] + a2911*k12[i] + a2913*k14[i] + a2914*k15[i] + a2915*k16[i] + a2923*k24[i] + a2924*k25[i] + a2925*k26[i] + a2926*k27[i] + a2927*k28[i] + a2928*k29[i])
   end
-  f(@muladd(t + c29*dt),tmp,k30)
+  f(t + c29*dt,tmp,k30)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a3000*k1[i] + a3003*k4[i] + a3004*k5[i] + a3005*k6[i] + a3007*k8[i] + a3009*k10[i] + a3010*k11[i] + a3013*k14[i] + a3014*k15[i] + a3015*k16[i] + a3023*k24[i] + a3024*k25[i] + a3025*k26[i] + a3027*k28[i] + a3028*k29[i] + a3029*k30[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a3000*k1[i] + a3003*k4[i] + a3004*k5[i] + a3005*k6[i] + a3007*k8[i] + a3009*k10[i] + a3010*k11[i] + a3013*k14[i] + a3014*k15[i] + a3015*k16[i] + a3023*k24[i] + a3024*k25[i] + a3025*k26[i] + a3027*k28[i] + a3028*k29[i] + a3029*k30[i])
   end
-  f(@muladd(t + c30*dt),tmp,k31)
+  f(t + c30*dt,tmp,k31)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a3100*k1[i] + a3102*k3[i] + a3103*k4[i] + a3106*k7[i] + a3107*k8[i] + a3109*k10[i] + a3110*k11[i] + a3113*k14[i] + a3114*k15[i] + a3115*k16[i] + a3123*k24[i] + a3124*k25[i] + a3125*k26[i] + a3127*k28[i] + a3128*k29[i] + a3129*k30[i] + a3130*k31[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a3100*k1[i] + a3102*k3[i] + a3103*k4[i] + a3106*k7[i] + a3107*k8[i] + a3109*k10[i] + a3110*k11[i] + a3113*k14[i] + a3114*k15[i] + a3115*k16[i] + a3123*k24[i] + a3124*k25[i] + a3125*k26[i] + a3127*k28[i] + a3128*k29[i] + a3129*k30[i] + a3130*k31[i])
   end
-  f(@muladd(t + c31*dt),tmp,k32)
+  f(t + c31*dt,tmp,k32)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a3200*k1[i] + a3201*k2[i] + a3204*k5[i] + a3206*k7[i] + a3230*k31[i] + a3231*k32[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a3200*k1[i] + a3201*k2[i] + a3204*k5[i] + a3206*k7[i] + a3230*k31[i] + a3231*k32[i])
   end
-  f(@muladd(t + c32*dt),tmp,k33)
+  f(t + c32*dt,tmp,k33)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a3300*k1[i] + a3302*k3[i] + a3332*k33[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a3300*k1[i] + a3302*k3[i] + a3332*k33[i])
   end
-  f(@muladd(t + c33*dt),tmp,k34)
+  f(t + c33*dt,tmp,k34)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] =  @muladd uprev[i] + dt*(a3400*k1[i] + a3401*k2[i] + a3402*k3[i] + a3404*k5[i] + a3406*k7[i] + a3407*k8[i] + a3409*k10[i] + a3410*k11[i] + a3411*k12[i] + a3412*k13[i] + a3413*k14[i] + a3414*k15[i] + a3415*k16[i] + a3416*k17[i] + a3417*k18[i] + a3418*k19[i] + a3419*k20[i] + a3420*k21[i] + a3421*k22[i] + a3422*k23[i] + a3423*k24[i] + a3424*k25[i] + a3425*k26[i] + a3426*k27[i] + a3427*k28[i] + a3428*k29[i] + a3429*k30[i] + a3430*k31[i] + a3431*k32[i] + a3432*k33[i] + a3433*k34[i])
+    @inbounds tmp[i] = uprev[i] + dt*(a3400*k1[i] + a3401*k2[i] + a3402*k3[i] + a3404*k5[i] + a3406*k7[i] + a3407*k8[i] + a3409*k10[i] + a3410*k11[i] + a3411*k12[i] + a3412*k13[i] + a3413*k14[i] + a3414*k15[i] + a3415*k16[i] + a3416*k17[i] + a3417*k18[i] + a3418*k19[i] + a3419*k20[i] + a3420*k21[i] + a3421*k22[i] + a3422*k23[i] + a3423*k24[i] + a3424*k25[i] + a3425*k26[i] + a3426*k27[i] + a3427*k28[i] + a3428*k29[i] + a3429*k30[i] + a3430*k31[i] + a3431*k32[i] + a3432*k33[i] + a3433*k34[i])
   end
-  f(@muladd(t + c34*dt),tmp,k35)
+  f(t + c34*dt,tmp,k35)
   @tight_loop_macros for i in uidx
-    u[i] = @muladd uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b8*k8[i] + b10*k10[i] + b11*k11[i] + b12*k12[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b18*k18[i] + b19*k19[i] + b20*k20[i] + b21*k21[i] + b22*k22[i] + b23*k23[i] + b24*k24[i] + b25*k25[i] + b26*k26[i] + b27*k27[i] + b28*k28[i] + b29*k29[i] + b30*k30[i] + b31*k31[i] + b32*k32[i] + b33*k33[i] + b34*k34[i] + b35*k35[i])
+    u[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b8*k8[i] + b10*k10[i] + b11*k11[i] + b12*k12[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b18*k18[i] + b19*k19[i] + b20*k20[i] + b21*k21[i] + b22*k22[i] + b23*k23[i] + b24*k24[i] + b25*k25[i] + b26*k26[i] + b27*k27[i] + b28*k28[i] + b29*k29[i] + b30*k30[i] + b31*k31[i] + b32*k32[i] + b33*k33[i] + b34*k34[i] + b35*k35[i])
   end
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds atmp[i] =  (dt*(k2[i] - k34[i]) * adaptiveConst)./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol)
+      @inbounds atmp[i] =  (dt*(k2[i] - k34[i]) * adaptiveConst)/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end

--- a/src/integrators/fixed_timestep_integrators.jl
+++ b/src/integrators/fixed_timestep_integrators.jl
@@ -8,7 +8,7 @@ end
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
 end
 
-@inline function perform_step!(integrator,cache::DiscreteConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DiscreteConstantCache,f=integrator.f)
   if discrete_apply_map(integrator.alg)
     if discrete_scale_by_time(integrator.alg)
       integrator.u = integrator.uprev .+ integrator.dt.*f(integrator.t+integrator.dt,integrator.uprev)
@@ -19,13 +19,13 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::DiscreteCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DiscreteCache,f=integrator.f)
   @unpack u,uprev,dt,t = integrator
   @unpack du = cache
   if discrete_apply_map(integrator.alg)
     if discrete_scale_by_time(integrator.alg)
       f(t+dt,uprev,du)
-      @. u = @muladd uprev + dt*du
+      @. u = uprev + dt*du
     else
       f(t+dt,uprev,u)
     end
@@ -36,14 +36,14 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::DiscreteCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DiscreteCache,f=integrator.f)
   @unpack u,uprev,dt,t = integrator
   @unpack du = cache
   if discrete_apply_map(integrator.alg)
     if discrete_scale_by_time(integrator.alg)
       f(t+dt,uprev,du)
       @tight_loop_macros for i in eachindex(integrator.u)
-        @inbounds u[i] = @muladd uprev[i] + dt*du[i]
+        @inbounds u[i] = uprev[i] + dt*du[i]
       end
     else
       f(t+dt,uprev,u)
@@ -65,10 +65,10 @@ end
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::EulerConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::EulerConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   k = integrator.fsalfirst
-  u = muladd.(dt,k,uprev)
+  u = @. uprev + dt*k
   k = f(t+dt,u) # For the interpolation, needs k at the updated point
   integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
@@ -87,22 +87,22 @@ end
   f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
 end
 
-@inline function perform_step!(integrator,cache::EulerCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::EulerCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   fsalfirst,fsallast = integrator.fsalfirst,integrator.fsallast
   uidx = eachindex(integrator.uprev)
   @tight_loop_macros for i in uidx
-    @inbounds u[i] = muladd(dt,fsalfirst[i],uprev[i])
+    @inbounds u[i] = uprev[i] + dt*fsalfirst[i]
   end
   f(t+dt,u,fsallast) # For the interpolation, needs k at the updated point
   @pack integrator = t,dt,u,k
 end
 
 #=
-@inline function perform_step!(integrator,cache::EulerCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::EulerCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
-  @. u = muladd(dt,integrator.fsalfirst,uprev)
+  @. u = uprev + dt*integrator.fsalfirst
   f(t+dt,u,integrator.fsallast) # For the interpolation, needs k at the updated point
   @pack integrator = t,dt,u,k
 end
@@ -119,12 +119,12 @@ end
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::MidpointConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::MidpointConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   halfdt = dt/2
   k = integrator.fsalfirst
-  k = f(t+halfdt,uprev.+halfdt.*k)
-  u = uprev .+ dt.*k
+  k = f(t+halfdt, @. uprev + halfdt*k)
+  u = @. uprev + dt*k
   integrator.fsallast = f(t+dt,u) # For interpolation, then FSAL'd
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -143,30 +143,30 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::MidpointCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::MidpointCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack k,du,tmp,fsalfirst = cache
   halfdt = dt/2
-  @. tmp = muladd(halfdt,integrator.fsalfirst,uprev)
+  @. tmp = uprev + halfdt*integrator.fsalfirst
   f(t+halfdt,tmp,du)
-  @. u = muladd(dt,du,uprev)
+  @. u = uprev + dt*du
   f(t+dt,u,k)
   @pack integrator = t,dt,u
 end
 =#
 
-@inline function perform_step!(integrator,cache::MidpointCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::MidpointCache,f=integrator.f)
   @unpack t,dt,uprev,u = integrator
   uidx = eachindex(integrator.uprev)
   @unpack k,tmp,fsalfirst = cache
   halfdt = dt/2
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = muladd(halfdt,fsalfirst[i],uprev[i])
+    @inbounds tmp[i] = uprev[i] + halfdt*fsalfirst[i]
   end
   f(t+halfdt,tmp,k)
   @tight_loop_macros for i in uidx
-    @inbounds u[i] = muladd(dt,k[i],uprev[i])
+    @inbounds u[i] = uprev[i] + dt*k[i]
   end
   f(t+dt,u,k)
   @pack integrator = t,dt,u
@@ -183,15 +183,15 @@ end
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::RK4ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::RK4ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   halfdt = dt/2
   k₁ =integrator.fsalfirst
   ttmp = t+halfdt
-  k₂ = f(ttmp,muladd.(halfdt,k₁,uprev))
-  k₃ = f(ttmp,muladd.(halfdt,k₂,uprev))
-  k₄ = f(t+dt,muladd.(dt,k₃,uprev))
-  u = muladd.(dt/6,muladd.(2,(k₂ .+ k₃),k₁.+k₄),uprev)
+  k₂ = f(ttmp, @. uprev + halfdt*k₁)
+  k₃ = f(ttmp, @. uprev + halfdt*k₂)
+  k₄ = f(t+dt, @. uprev + dt*k₃)
+  u = @. uprev + (dt/6)*(2*(k₂ + k₃) + (k₁+k₄))
   k = f(t+dt,u)
   integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
@@ -210,7 +210,7 @@ end
   f(integrator.t,integrator.uprev,integrator.fsalfirst) # pre-start FSAL
 end
 
-@inline function perform_step!(integrator,cache::RK4Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::RK4Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack tmp,fsalfirst,k₂,k₃,k₄,k = cache
@@ -218,39 +218,39 @@ end
   halfdt = dt/2
   ttmp = t+halfdt
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = muladd(halfdt,k₁[i],uprev[i])
+    @inbounds tmp[i] = uprev[i] + halfdt*k₁[i]
   end
   f(ttmp,tmp,k₂)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = muladd(halfdt,k₂[i],uprev[i])
+    @inbounds tmp[i] = uprev[i] + halfdt*k₂[i]
   end
   f(ttmp,tmp,k₃)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = muladd(dt,k₃[i],uprev[i])
+    @inbounds tmp[i] = uprev[i] + dt*k₃[i]
   end
   f(t+dt,tmp,k₄)
   @tight_loop_macros for i in uidx
-    @inbounds u[i] = muladd(dt/6,muladd(2,(k₂[i] + k₃[i]),k₁[i] + k₄[i]),uprev[i])
+    @inbounds u[i] = uprev[i] + (dt/6)*(2*(k₂[i] + k₃[i]) + (k₁[i] + k₄[i]))
   end
   f(t+dt,u,k)
   @pack integrator = t,dt,u
 end
 
 #=
-@inline function perform_step!(integrator,cache::RK4Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::RK4Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack tmp,fsalfirst,k₂,k₃,k₄,k = cache
   k₁ = fsalfirst
   halfdt = dt/2
   ttmp = t+halfdt
-  @. tmp = muladd(halfdt,k₁,uprev)
+  @. tmp = uprev + halfdt*k₁
   f(ttmp,tmp,k₂)
-  @. tmp = muladd(halfdt,k₂,uprev)
+  @. tmp = uprev + halfdt*k₂
   f(ttmp,tmp,k₃)
-  @. tmp = muladd(dt,k₃,uprev)
+  @. tmp = uprev + dt*k₃
   f(t+dt,tmp,k₄)
-  @. u = muladd(dt/6,muladd(2,(k₂ + k₃),k₁ + k₄),uprev)
+  @. u = uprev + (dt/6)*(2*(k₂ + k₃) + (k₁ + k₄))
   f(t+dt,u,k)
   @pack integrator = t,dt,u
 end

--- a/src/integrators/general_rosenbrock_integrator.jl
+++ b/src/integrators/general_rosenbrock_integrator.jl
@@ -9,7 +9,7 @@
   integrator.k[2] = integrator.fsallast
 end
 
-@inline function perform_step!(integrator,cache::GenRosen4ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::GenRosen4ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u = integrator
   @unpack A,c,α,αEEst,stages = cache
   @unpack kk = cache
@@ -19,28 +19,29 @@ end
   for i = 2:stages-1
     utilde = zero(kk[1])
     for j = 1:i-1
-      utilde = @muladd utilde + A[j,i]*kk[j]
+      utilde = @. utilde + A[j,i]*kk[j]
     end
-    kk[i] = f(@muladd(t+c[i]*dt),@muladd(uprev+dt*utilde));
+    kk[i] = f(t+c[i]*dt, @. uprev+dt*utilde);
   end
   #Calc Last
   utilde = zero(kk[1])
   for j = 1:stages-1
-    utilde = @muladd utilde + A[j,end]*kk[j]
+    utilde = @. utilde + A[j,end]*kk[j]
   end
-  kk[end] = f(@muladd(t+c[end]*dt),@muladd(uprev+dt*utilde)); integrator.fsallast = kk[end] # Uses fsallast as temp even if not fsal
+  kk[end] = f(t+c[end]*dt, @. uprev+dt*utilde); integrator.fsallast = kk[end] # Uses fsallast as temp even if not fsal
   # Accumulate Result
   utilde = α[1]*kk[1]
   for i = 2:stages
-    utilde = @muladd utilde + α[i]*kk[i]
+    utilde = @. utilde + α[i]*kk[i]
   end
-  u = @muladd uprev + dt*utilde
+  u = @. uprev + dt*utilde
   if integrator.opts.adaptive
     uEEst = αEEst[1]*kk[1]
     for i = 2:stages
-      uEEst = @muladd uEEst + αEEst[i]*kk[i]
+      uEEst = @. uEEst + αEEst[i]*kk[i]
     end
-    integrator.EEst = integrator.opts.internalnorm( dt*(utilde-uEEst)/@muladd(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+    tmp = @. dt*(utilde-uEEst)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+    integrator.EEst = integrator.opts.internalnorm(tmp)
   end
   if isfsal(integrator.alg.tableau)
     integrator.fsallast = kk[end]

--- a/src/integrators/high_order_rk_integrators.jl
+++ b/src/integrators/high_order_rk_integrators.jl
@@ -9,53 +9,25 @@
   integrator.k[2] = integrator.fsallast
 end
 
-#=
-@inline function perform_step!(integrator,cache::TanYam7ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::TanYam7ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a93,a94,a95,a96,a97,a98,a101,a103,a104,a105,a106,a107,a108,b1,b4,b5,b6,b7,b8,b9,bhat1,bhat4,bhat5,bhat6,bhat7,bhat8,bhat10 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(@muladd(t + c1*dt),@.(@muladd(uprev+a*k1)))
-  k3 = f(@muladd(t + c2*dt),@.(@muladd(uprev+dt*(a31*k1+a32*k2))))
-  k4 = f(@muladd(t + c3*dt),@.(@muladd(uprev+dt*(a41*k1       +a43*k3))))
-  k5 = f(@muladd(t + c4*dt),@.(@muladd(uprev+dt*(a51*k1       +a53*k3+a54*k4))))
-  k6 = f(@muladd(t + c5*dt),@.(@muladd(uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5))))
-  k7 = f(@muladd(t + c6*dt),@.(@muladd(uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6))))
-  k8 = f(@muladd(t + c7*dt),@.(@muladd(uprev+dt*(a81*k1       +a83*k3+a84*k4+a85*k5+a86*k6+a87*k7))))
-  k9 = f(t+dt,@.(@muladd(uprev+dt*(a91*k1       +a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8))))
-  k10= f(t+dt,@.(@muladd(uprev+dt*(a101*k1      +a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8))))
-  u = @. @muladd uprev + dt*(k1*b1+k4*b4+k5*b5+k6*b6+k7*b7+k8*b8+k9*b9)
+  k2 = f(t + c1*dt, @. uprev+a*k1)
+  k3 = f(t + c2*dt, @. uprev+dt*(a31*k1+a32*k2))
+  k4 = f(t + c3*dt, @. uprev+dt*(a41*k1       +a43*k3))
+  k5 = f(t + c4*dt, @. uprev+dt*(a51*k1       +a53*k3+a54*k4))
+  k6 = f(t + c5*dt, @. uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5))
+  k7 = f(t + c6*dt, @. uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6))
+  k8 = f(t + c7*dt, @. uprev+dt*(a81*k1       +a83*k3+a84*k4+a85*k5+a86*k6+a87*k7))
+  k9 = f(t+dt, @. uprev+dt*(a91*k1       +a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8))
+  k10= f(t+dt, @. uprev+dt*(a101*k1      +a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8))
+  u = @. uprev + dt*(k1*b1+k4*b4+k5*b5+k6*b6+k7*b7+k8*b8+k9*b9)
   if integrator.opts.adaptive
-    utilde = @. @muladd uprev + dt*(k1*bhat1+k4*bhat4+k5*bhat5+k6*bhat6+k7*bhat7+k8*bhat8+k10*bhat10)
-    tmp = @. ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
+    utilde = @. uprev + dt*(k1*bhat1+k4*bhat4+k5*bhat5+k6*bhat6+k7*bhat7+k8*bhat8+k10*bhat10)
+    tmp = @. ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(tmp)
-  end
-  k = f(t+dt,u) # For the interpolation, needs k at the updated point
-  integrator.fsallast = k
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-=#
-
-@inline function perform_step!(integrator,cache::TanYam7ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack c1,c2,c3,c4,c5,c6,c7,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a93,a94,a95,a96,a97,a98,a101,a103,a104,a105,a106,a107,a108,b1,b4,b5,b6,b7,b8,b9,bhat1,bhat4,bhat5,bhat6,bhat7,bhat8,bhat10 = cache
-  k1 = integrator.fsalfirst
-  a = dt*a21
-  k2 = f(@muladd(t + c1*dt),@muladd(uprev+a*k1))
-  k3 = f(@muladd(t + c2*dt),@muladd(uprev+dt*(a31*k1+a32*k2)))
-  k4 = f(@muladd(t + c3*dt),@muladd(uprev+dt*(a41*k1       +a43*k3)))
-  k5 = f(@muladd(t + c4*dt),@muladd(uprev+dt*(a51*k1       +a53*k3+a54*k4)))
-  k6 = f(@muladd(t + c5*dt),@muladd(uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5)))
-  k7 = f(@muladd(t + c6*dt),@muladd(uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6)))
-  k8 = f(@muladd(t + c7*dt),@muladd(uprev+dt*(a81*k1       +a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)))
-  k9 = f(t+dt,@muladd(uprev+dt*(a91*k1       +a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8)))
-  k10= f(t+dt,@muladd(uprev+dt*(a101*k1      +a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8)))
-  u = @muladd uprev + dt*(k1*b1+k4*b4+k5*b5+k6*b6+k7*b7+k8*b8+k9*b9)
-  if integrator.opts.adaptive
-    utilde = @muladd uprev + dt*(k1*bhat1+k4*bhat4+k5*bhat5+k6*bhat6+k7*bhat7+k8*bhat8+k10*bhat10)
-    integrator.EEst = integrator.opts.internalnorm( ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)))
   end
   k = f(t+dt,u) # For the interpolation, needs k at the updated point
   integrator.fsallast = k
@@ -75,7 +47,7 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::TanYam7Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::TanYam7Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack fsalfirst,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp,k = cache
@@ -83,28 +55,28 @@ end
   k1 = fsalfirst
   f(t,uprev,k1)
   a = dt*a21
-  @. tmp = @muladd uprev+a*k1
-  f(@muladd(t + c1*dt),tmp,k2)
-  @. tmp = @muladd uprev+dt*(a31*k1+a32*k2)
-  f(@muladd(t + c2*dt),tmp,k3)
-  @. tmp = @muladd uprev+dt*(a41*k1+a43*k3)
-  f(@muladd(t + c3*dt),tmp,k4)
-  @. tmp = @muladd uprev+dt*(a51*k1+a53*k3+a54*k4)
-  f(@muladd(t + c4*dt),tmp,k5)
-  @. tmp = @muladd uprev+dt*(a61*k1+a63*k3+a64*k4+a65*k5)
-  f(@muladd(t + c5*dt),tmp,k6)
-  @. tmp = @muladd uprev+dt*(a71*k1+a73*k3+a74*k4+a75*k5+a76*k6)
-  f(@muladd(t + c6*dt),tmp,k7)
-  @. tmp = @muladd uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
-  f(@muladd(t + c7*dt),tmp,k8)
-  @. tmp = @muladd uprev+dt*(a91*k1+a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8)
+  @. tmp = uprev+a*k1
+  f(t + c1*dt,tmp,k2)
+  @. tmp = uprev+dt*(a31*k1+a32*k2)
+  f(t + c2*dt,tmp,k3)
+  @. tmp = uprev+dt*(a41*k1+a43*k3)
+  f(t + c3*dt,tmp,k4)
+  @. tmp = uprev+dt*(a51*k1+a53*k3+a54*k4)
+  f(t + c4*dt,tmp,k5)
+  @. tmp = uprev+dt*(a61*k1+a63*k3+a64*k4+a65*k5)
+  f(t + c5*dt,tmp,k6)
+  @. tmp = uprev+dt*(a71*k1+a73*k3+a74*k4+a75*k5+a76*k6)
+  f(t + c6*dt,tmp,k7)
+  @. tmp = uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
+  f(t + c7*dt,tmp,k8)
+  @. tmp = uprev+dt*(a91*k1+a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8)
   f(t+dt,tmp,k9)
-  @. tmp = @muladd uprev+dt*(a101*k1+a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8)
+  @. tmp = uprev+dt*(a101*k1+a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8)
   f(t+dt,tmp,k10)
   @. u = uprev + dt*(k1*b1+k4*b4+k5*b5+k6*b6+k7*b7+k8*b8+k9*b9)
   if integrator.opts.adaptive
     @. utilde = uprev + dt*(k1*bhat1+k4*bhat4+k5*bhat5+k6*bhat6+k7*bhat7+k8*bhat8+k10*bhat10)
-    @. atmp = ((utilde-u)./(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. atmp = ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   f(t+dt,u,k)
@@ -112,7 +84,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::TanYam7Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::TanYam7Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack fsalfirst,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp,k = cache
@@ -121,39 +93,39 @@ end
   f(t,uprev,k1)
   a = dt*a21
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a*k1[i]
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(@muladd(t + c1*dt),tmp,k2)
+  f(t + c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a31*k1[i]+a32*k2[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(@muladd(t + c2*dt),tmp,k3)
+  f(t + c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a41*k1[i]+a43*k3[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a43*k3[i])
   end
-  f(@muladd(t + c3*dt),tmp,k4)
+  f(t + c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a51*k1[i]+a53*k3[i]+a54*k4[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a53*k3[i]+a54*k4[i])
   end
-  f(@muladd(t + c4*dt),tmp,k5)
+  f(t + c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
-  f(@muladd(t + c5*dt),tmp,k6)
+  f(t + c5*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
   end
-  f(@muladd(t + c6*dt),tmp,k7)
+  f(t + c6*dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
   end
-  f(@muladd(t + c7*dt),tmp,k8)
+  f(t + c7*dt,tmp,k8)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a91*k1[i]+a93*k3[i]+a94*k4[i]+a95*k5[i]+a96*k6[i]+a97*k7[i]+a98*k8[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a91*k1[i]+a93*k3[i]+a94*k4[i]+a95*k5[i]+a96*k6[i]+a97*k7[i]+a98*k8[i])
   end
   f(t+dt,tmp,k9)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a101*k1[i]+a103*k3[i]+a104*k4[i]+a105*k5[i]+a106*k6[i]+a107*k7[i]+a108*k8[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a101*k1[i]+a103*k3[i]+a104*k4[i]+a105*k5[i]+a106*k6[i]+a107*k7[i]+a108*k8[i])
   end
   f(t+dt,tmp,k10)
   @tight_loop_macros for i in uidx
@@ -162,7 +134,7 @@ end
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
       @inbounds utilde[i] = uprev[i] + dt*(k1[i]*bhat1+k4[i]*bhat4+k5[i]*bhat5+k6[i]*bhat6+k7[i]*bhat7+k8[i]*bhat8+k10[i]*bhat10)
-      @inbounds atmp[i] = ((utilde[i]-u[i])./(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds atmp[i] = (utilde[i]-u[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
@@ -182,30 +154,29 @@ end
   end
 end
 
-#=
-@inline function perform_step!(integrator,cache::DP8ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DP8ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,bhh1,bhh2,bhh3,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache
   k1 = integrator.fsalfirst
   a = dt*a0201
-  k2 = f(@muladd(t + c2*dt),@.(@muladd(uprev+a*k1)))
-  k3 = f(@muladd(t + c3*dt),@.(@muladd(uprev+dt*(a0301*k1+a0302*k2))))
-  k4 = f(@muladd(t + c4*dt),@.(@muladd(uprev+dt*(a0401*k1       +a0403*k3))))
-  k5 = f(@muladd(t + c5*dt),@.(@muladd(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4))))
-  k6 = f(@muladd(t + c6*dt),@.(@muladd(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5))))
-  k7 = f(@muladd(t + c7*dt),@.(@muladd(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6))))
-  k8 = f(@muladd(t + c8*dt),@.(@muladd(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7))))
-  k9 = f(@muladd(t + c9*dt),@.(@muladd(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8))))
-  k10 =f(@muladd(t + c10*dt),@.(@muladd(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9))))
-  k11= f(@muladd(t + c11*dt),@.(@muladd(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10))))
-  k12= f(t+dt,@.(@muladd(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11))))
-  kupdate= @. @muladd b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
+  k2 = f(t + c2*dt, @. uprev+a*k1)
+  k3 = f(t + c3*dt, @. uprev+dt*(a0301*k1+a0302*k2))
+  k4 = f(t + c4*dt, @. uprev+dt*(a0401*k1       +a0403*k3))
+  k5 = f(t + c5*dt, @. uprev+dt*(a0501*k1       +a0503*k3+a0504*k4))
+  k6 = f(t + c6*dt, @. uprev+dt*(a0601*k1                +a0604*k4+a0605*k5))
+  k7 = f(t + c7*dt, @. uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6))
+  k8 = f(t + c8*dt, @. uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7))
+  k9 = f(t + c9*dt, @. uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8))
+  k10 =f(t + c10*dt, @. uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9))
+  k11= f(t + c11*dt, @. uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10))
+  k12= f(t+dt, @. uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11))
+  kupdate= @. b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
   update = dt*kupdate
   u = uprev + update
   if integrator.opts.adaptive
-    tmp = @. dt*(@muladd(k1*er1 + k6*er6 + k7*er7 + k8*er8 + k9*er9 + k10*er10 + k11*er11 + k12*er12))./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. dt*(k1*er1 + k6*er6 + k7*er7 + k8*er8 + k9*er9 + k10*er10 + k11*er11 + k12*er12)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     err5 = integrator.opts.internalnorm(tmp) # Order 5
-    tmp = @. @muladd(update - dt*(bhh1*k1 + bhh2*k9 + bhh3*k12))./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. (update - dt*(bhh1*k1 + bhh2*k9 + bhh3*k12))/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     err3 = integrator.opts.internalnorm(tmp) # Order 3
     err52 = err5*err5
     if err5 ≈ 0 && err3 ≈ 0
@@ -219,69 +190,18 @@ end
   if integrator.opts.calck
     @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache
     @unpack d401,d406,d407,d408,d409,d410,d411,d412,d413,d414,d415,d416,d501,d506,d507,d508,d509,d510,d511,d512,d513,d514,d515,d516,d601,d606,d607,d608,d609,d610,d611,d612,d613,d614,d615,d616,d701,d706,d707,d708,d709,d710,d711,d712,d713,d714,d715,d716 = cache
-    k14 = f(@muladd(t + c14*dt),@.(@muladd(uprev+dt*(a1401*k1         +a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13))))
-    k15 = f(@muladd(t + c15*dt),@.(@muladd(uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8                   +a1511*k11+a1512*k12+a1513*k13+a1514*k14))))
-    k16 = f(@muladd(t + c16*dt),@.(@muladd(uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9                              +a1613*k13+a1614*k14+a1615*k15))))
+    k14 = f(t + c14*dt, @. uprev+dt*(a1401*k1         +a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13))
+    k15 = f(t + c15*dt, @. uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8                   +a1511*k11+a1512*k12+a1513*k13+a1514*k14))
+    k16 = f(t + c16*dt, @. uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9                              +a1613*k13+a1614*k14+a1615*k15))
     udiff = kupdate
     integrator.k[1] = udiff
     bspl = k1 - udiff
     integrator.k[2] = bspl
     integrator.k[3] = @. udiff - k13 - bspl
-    integrator.k[4] = @.(@muladd(d401*k1+d406*k6+d407*k7+d408*k8+d409*k9+d410*k10+d411*k11+d412*k12+d413*k13+d414*k14+d415*k15+d416*k16))
-    integrator.k[5] = @.(@muladd(d501*k1+d506*k6+d507*k7+d508*k8+d509*k9+d510*k10+d511*k11+d512*k12+d513*k13+d514*k14+d515*k15+d516*k16))
-    integrator.k[6] = @.(@muladd(d601*k1+d606*k6+d607*k7+d608*k8+d609*k9+d610*k10+d611*k11+d612*k12+d613*k13+d614*k14+d615*k15+d616*k16))
-    integrator.k[7] = @.(@muladd(d701*k1+d706*k6+d707*k7+d708*k8+d709*k9+d710*k10+d711*k11+d712*k12+d713*k13+d714*k14+d715*k15+d716*k16))
-  end
-  @pack integrator = t,dt,u,k
-end
-=#
-
-@inline function perform_step!(integrator,cache::DP8ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,bhh1,bhh2,bhh3,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache
-  k1 = integrator.fsalfirst
-  a = dt*a0201
-  k2 = f(@muladd(t + c2*dt),uprev+a*k1)
-  k3 = f(@muladd(t + c3*dt),@muladd(uprev+dt*(a0301*k1+a0302*k2)))
-  k4 = f(@muladd(t + c4*dt),@muladd(uprev+dt*(a0401*k1       +a0403*k3)))
-  k5 = f(@muladd(t + c5*dt),@muladd(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4)))
-  k6 = f(@muladd(t + c6*dt),@muladd(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5)))
-  k7 = f(@muladd(t + c7*dt),@muladd(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6)))
-  k8 = f(@muladd(t + c8*dt),@muladd(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7)))
-  k9 = f(@muladd(t + c9*dt),@muladd(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)))
-  k10 =f(@muladd(t + c10*dt),@muladd(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)))
-  k11= f(@muladd(t + c11*dt),@muladd(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)))
-  k12= f(t+dt,@muladd(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)))
-  kupdate= @muladd b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
-  update = dt*kupdate
-  u = uprev + update
-  if integrator.opts.adaptive
-    err5 = integrator.opts.internalnorm(dt*(@muladd(k1*er1 + k6*er6 + k7*er7 + k8*er8 + k9*er9 + k10*er10 + k11*er11 + k12*er12))./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)) # Order 5
-    err3 = integrator.opts.internalnorm(@muladd(update - dt*(bhh1*k1 + bhh2*k9 + bhh3*k12))./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)) # Order 3
-    err52 = err5*err5
-    if err5 ≈ 0 && err3 ≈ 0
-      integrator.EEst = zero(typeof(integrator.EEst))
-    else
-      integrator.EEst = err52./sqrt(err52 + 0.01*err3*err3)
-    end
-  end
-  k13 = f(t+dt,u)
-  integrator.fsallast = k13
-  if integrator.opts.calck
-    @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache
-    @unpack d401,d406,d407,d408,d409,d410,d411,d412,d413,d414,d415,d416,d501,d506,d507,d508,d509,d510,d511,d512,d513,d514,d515,d516,d601,d606,d607,d608,d609,d610,d611,d612,d613,d614,d615,d616,d701,d706,d707,d708,d709,d710,d711,d712,d713,d714,d715,d716 = cache
-    k14 = f(@muladd(t + c14*dt),@muladd(uprev+dt*(a1401*k1         +a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13)))
-    k15 = f(@muladd(t + c15*dt),@muladd(uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8                   +a1511*k11+a1512*k12+a1513*k13+a1514*k14)))
-    k16 = f(@muladd(t + c16*dt),@muladd(uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9                              +a1613*k13+a1614*k14+a1615*k15)))
-    udiff = kupdate
-    integrator.k[1] = udiff
-    bspl = k1 - udiff
-    integrator.k[2] = bspl
-    integrator.k[3] = udiff - k13 - bspl
-    integrator.k[4] = @muladd(d401*k1+d406*k6+d407*k7+d408*k8+d409*k9+d410*k10+d411*k11+d412*k12+d413*k13+d414*k14+d415*k15+d416*k16)
-    integrator.k[5] = @muladd(d501*k1+d506*k6+d507*k7+d508*k8+d509*k9+d510*k10+d511*k11+d512*k12+d513*k13+d514*k14+d515*k15+d516*k16)
-    integrator.k[6] = @muladd(d601*k1+d606*k6+d607*k7+d608*k8+d609*k9+d610*k10+d611*k11+d612*k12+d613*k13+d614*k14+d615*k15+d616*k16)
-    integrator.k[7] = @muladd(d701*k1+d706*k6+d707*k7+d708*k8+d709*k9+d710*k10+d711*k11+d712*k12+d713*k13+d714*k14+d715*k15+d716*k16)
+    integrator.k[4] = @. d401*k1+d406*k6+d407*k7+d408*k8+d409*k9+d410*k10+d411*k11+d412*k12+d413*k13+d414*k14+d415*k15+d416*k16
+    integrator.k[5] = @. d501*k1+d506*k6+d507*k7+d508*k8+d509*k9+d510*k10+d511*k11+d512*k12+d513*k13+d514*k14+d515*k15+d516*k16
+    integrator.k[6] = @. d601*k1+d606*k6+d607*k7+d608*k8+d609*k9+d610*k10+d611*k11+d612*k12+d613*k13+d614*k14+d615*k15+d616*k16
+    integrator.k[7] = @. d701*k1+d706*k6+d707*k7+d708*k8+d709*k9+d710*k10+d711*k11+d712*k12+d713*k13+d714*k14+d715*k15+d716*k16
   end
   @pack integrator = t,dt,u,k
 end
@@ -295,41 +215,41 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::DP8Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DP8Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,bhh1,bhh2,bhh3,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,update,udiff,bspl,dense_tmp3,dense_tmp4,dense_tmp5,dense_tmp6,dense_tmp7,kupdate,utilde,tmp,atmp,atmp2 = cache
   f(t,uprev,k1)
   a = dt*a0201
-  @. tmp = @muladd uprev+a*k1
-  f(@muladd(t + c2*dt),tmp,k2)
-  @. tmp = @muladd uprev+dt*(a0301*k1+a0302*k2)
-  f(@muladd(t + c3*dt),tmp,k3)
-  @. tmp = @muladd uprev+dt*(a0401*k1+a0403*k3)
-  f(@muladd(t + c4*dt),tmp,k4)
-  @. tmp = @muladd uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
-  f(@muladd(t + c5*dt),tmp,k5)
-  @. tmp = @muladd uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
-  f(@muladd(t + c6*dt),tmp,k6)
-  @. tmp = @muladd uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
-  f(@muladd(t + c7*dt),tmp,k7)
-  @. tmp = @muladd uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
-  f(@muladd(t + c8*dt),tmp,k8)
-  @. tmp = @muladd uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
-  f(@muladd(t + c9*dt),tmp,k9)
-  @. tmp = @muladd uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
-  f(@muladd(t + c10*dt),tmp,k10)
-  @. tmp = @muladd uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
-  f(@muladd(t + c11*dt),tmp,k11)
-  @. tmp = @muladd uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
+  @. tmp = uprev+a*k1
+  f(t + c2*dt,tmp,k2)
+  @. tmp = uprev+dt*(a0301*k1+a0302*k2)
+  f(t + c3*dt,tmp,k3)
+  @. tmp = uprev+dt*(a0401*k1+a0403*k3)
+  f(t + c4*dt,tmp,k4)
+  @. tmp = uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
+  f(t + c5*dt,tmp,k5)
+  @. tmp = uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
+  f(t + c6*dt,tmp,k6)
+  @. tmp = uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
+  f(t + c7*dt,tmp,k7)
+  @. tmp = uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
+  f(t + c8*dt,tmp,k8)
+  @. tmp = uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
+  f(t + c9*dt,tmp,k9)
+  @. tmp = uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
+  f(t + c10*dt,tmp,k10)
+  @. tmp = uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
+  f(t + c11*dt,tmp,k11)
+  @. tmp = uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
   f(t+dt,tmp,k12)
-  @. kupdate = @muladd b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
+  @. kupdate = b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
   @. update = dt*kupdate
   @. u = uprev + update
   if integrator.opts.adaptive
-    @. atmp = (dt*(@muladd(k1*er1 + k6*er6 + k7*er7 + k8*er8 + k9*er9 + k10*er10 + k11*er11 + k12*er12))./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
-    @. atmp2= (@muladd(update - dt*(bhh1*k1 + bhh2*k9 + bhh3*k12))./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. atmp = dt*(k1*er1 + k6*er6 + k7*er7 + k8*er8 + k9*er9 + k10*er10 + k11*er11 + k12*er12)/@muladd(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
+    @. atmp2= (update - dt*(bhh1*k1 + bhh2*k9 + bhh3*k12))/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     err5 = integrator.opts.internalnorm(atmp) # Order 5
     err3 = integrator.opts.internalnorm(atmp2) # Order 3
     err52 = err5*err5
@@ -343,25 +263,25 @@ end
   if integrator.opts.calck
     @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache.tab
     @unpack d401,d406,d407,d408,d409,d410,d411,d412,d413,d414,d415,d416,d501,d506,d507,d508,d509,d510,d511,d512,d513,d514,d515,d516,d601,d606,d607,d608,d609,d610,d611,d612,d613,d614,d615,d616,d701,d706,d707,d708,d709,d710,d711,d712,d713,d714,d715,d716 = cache.tab
-    @. tmp = @muladd uprev+dt*(a1401*k1+a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13)
-    f(@muladd(t + c14*dt),tmp,k14)
-    @. tmp = @muladd uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8+a1511*k11+a1512*k12+a1513*k13+a1514*k14)
-    f(@muladd(t + c15*dt),tmp,k15)
-    @. tmp = @muladd uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9+a1613*k13+a1614*k14+a1615*k15)
-    f(@muladd(t + c16*dt),tmp,k16)
+    @. tmp = uprev+dt*(a1401*k1+a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13)
+    f(t + c14*dt,tmp,k14)
+    @. tmp = uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8+a1511*k11+a1512*k12+a1513*k13+a1514*k14)
+    f(t + c15*dt,tmp,k15)
+    @. tmp = uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9+a1613*k13+a1614*k14+a1615*k15)
+    f(t + c16*dt,tmp,k16)
     @. udiff = kupdate
     @. bspl = k1 - udiff
     @. integrator.k[3] = udiff - k13 - bspl
-    @. integrator.k[4] = @muladd(d401*k1+d406*k6+d407*k7+d408*k8+d409*k9+d410*k10+d411*k11+d412*k12+d413*k13+d414*k14+d415*k15+d416*k16)
-    @. integrator.k[5] = @muladd(d501*k1+d506*k6+d507*k7+d508*k8+d509*k9+d510*k10+d511*k11+d512*k12+d513*k13+d514*k14+d515*k15+d516*k16)
-    @. integrator.k[6] = @muladd(d601*k1+d606*k6+d607*k7+d608*k8+d609*k9+d610*k10+d611*k11+d612*k12+d613*k13+d614*k14+d615*k15+d616*k16)
-    @. integrator.k[7] = @muladd(d701*k1+d706*k6+d707*k7+d708*k8+d709*k9+d710*k10+d711*k11+d712*k12+d713*k13+d714*k14+d715*k15+d716*k16)
+    @. integrator.k[4] = d401*k1+d406*k6+d407*k7+d408*k8+d409*k9+d410*k10+d411*k11+d412*k12+d413*k13+d414*k14+d415*k15+d416*k16
+    @. integrator.k[5] = d501*k1+d506*k6+d507*k7+d508*k8+d509*k9+d510*k10+d511*k11+d512*k12+d513*k13+d514*k14+d515*k15+d516*k16
+    @. integrator.k[6] = d601*k1+d606*k6+d607*k7+d608*k8+d609*k9+d610*k10+d611*k11+d612*k12+d613*k13+d614*k14+d615*k15+d616*k16
+    @. integrator.k[7] = d701*k1+d706*k6+d707*k7+d708*k8+d709*k9+d710*k10+d711*k11+d712*k12+d713*k13+d714*k14+d715*k15+d716*k16
   end
   @pack integrator = t,dt,u,k
 end
 =#
 
-@inline function perform_step!(integrator,cache::DP8Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DP8Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,bhh1,bhh2,bhh3,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache.tab
@@ -369,58 +289,58 @@ end
   f(t,uprev,k1)
   a = dt*a0201
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a*k1[i]
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(@muladd(t + c2*dt),tmp,k2)
+  f(t + c2*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
   end
-  f(@muladd(t + c3*dt),tmp,k3)
+  f(t + c3*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
   end
-  f(@muladd(t + c4*dt),tmp,k4)
+  f(t + c4*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
   end
-  f(@muladd(t + c5*dt),tmp,k5)
+  f(t + c5*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
   end
-  f(@muladd(t + c6*dt),tmp,k6)
+  f(t + c6*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
   end
-  f(@muladd(t + c7*dt),tmp,k7)
+  f(t + c7*dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
   end
-  f(@muladd(t + c8*dt),tmp,k8)
+  f(t + c8*dt,tmp,k8)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
   end
-  f(@muladd(t + c9*dt),tmp,k9)
+  f(t + c9*dt,tmp,k9)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
   end
-  f(@muladd(t + c10*dt),tmp,k10)
+  f(t + c10*dt,tmp,k10)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
   end
-  f(@muladd(t + c11*dt),tmp,k11)
+  f(t + c11*dt,tmp,k11)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
   end
   f(t+dt,tmp,k12)
   @tight_loop_macros for i in uidx
-    @inbounds kupdate[i] = @muladd b1*k1[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i]
+    @inbounds kupdate[i] = b1*k1[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i]
     @inbounds update[i] = dt*kupdate[i]
     @inbounds u[i] = uprev[i] + update[i]
   end
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds atmp[i] = (dt*(@muladd(k1[i]*er1 + k6[i]*er6 + k7[i]*er7 + k8[i]*er8 + k9[i]*er9 + k10[i]*er10 + k11[i]*er11 + k12[i]*er12))./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
-      @inbounds atmp2[i]= (@muladd(update[i] - dt*(bhh1*k1[i] + bhh2*k9[i] + bhh3*k12[i]))./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds atmp[i] = dt*(k1[i]*er1 + k6[i]*er6 + k7[i]*er7 + k8[i]*er8 + k9[i]*er9 + k10[i]*er10 + k11[i]*er11 + k12[i]*er12)/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
+      @inbounds atmp2[i]= (update[i] - dt*(bhh1*k1[i] + bhh2*k9[i] + bhh3*k12[i]))/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     err5 = integrator.opts.internalnorm(atmp) # Order 5
     err3 = integrator.opts.internalnorm(atmp2) # Order 3
@@ -436,25 +356,25 @@ end
     @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache.tab
     @unpack d401,d406,d407,d408,d409,d410,d411,d412,d413,d414,d415,d416,d501,d506,d507,d508,d509,d510,d511,d512,d513,d514,d515,d516,d601,d606,d607,d608,d609,d610,d611,d612,d613,d614,d615,d616,d701,d706,d707,d708,d709,d710,d711,d712,d713,d714,d715,d716 = cache.tab
     @tight_loop_macros for i in uidx
-      @inbounds tmp[i] = @muladd uprev[i]+dt*(a1401*k1[i]+a1407*k7[i]+a1408*k8[i]+a1409*k9[i]+a1410*k10[i]+a1411*k11[i]+a1412*k12[i]+a1413*k13[i])
+      @inbounds tmp[i] = uprev[i]+dt*(a1401*k1[i]+a1407*k7[i]+a1408*k8[i]+a1409*k9[i]+a1410*k10[i]+a1411*k11[i]+a1412*k12[i]+a1413*k13[i])
     end
-    f(@muladd(t + c14*dt),tmp,k14)
+    f(t + c14*dt,tmp,k14)
     @tight_loop_macros for i in uidx
-      @inbounds tmp[i] = @muladd uprev[i]+dt*(a1501*k1[i]+a1506*k6[i]+a1507*k7[i]+a1508*k8[i]+a1511*k11[i]+a1512*k12[i]+a1513*k13[i]+a1514*k14[i])
+      @inbounds tmp[i] = uprev[i]+dt*(a1501*k1[i]+a1506*k6[i]+a1507*k7[i]+a1508*k8[i]+a1511*k11[i]+a1512*k12[i]+a1513*k13[i]+a1514*k14[i])
     end
-    f(@muladd(t + c15*dt),tmp,k15)
+    f(t + c15*dt,tmp,k15)
     @tight_loop_macros for i in uidx
-      @inbounds tmp[i] = @muladd uprev[i]+dt*(a1601*k1[i]+a1606*k6[i]+a1607*k7[i]+a1608*k8[i]+a1609*k9[i]+a1613*k13[i]+a1614*k14[i]+a1615*k15[i])
+      @inbounds tmp[i] = uprev[i]+dt*(a1601*k1[i]+a1606*k6[i]+a1607*k7[i]+a1608*k8[i]+a1609*k9[i]+a1613*k13[i]+a1614*k14[i]+a1615*k15[i])
     end
-    f(@muladd(t + c16*dt),tmp,k16)
+    f(t + c16*dt,tmp,k16)
     @tight_loop_macros for i in uidx
       @inbounds udiff[i]= kupdate[i]
       @inbounds bspl[i] = k1[i] - udiff[i]
       @inbounds integrator.k[3][i] = udiff[i] - k13[i] - bspl[i]
-      @inbounds integrator.k[4][i] = @muladd(d401*k1[i]+d406*k6[i]+d407*k7[i]+d408*k8[i]+d409*k9[i]+d410*k10[i]+d411*k11[i]+d412*k12[i]+d413*k13[i]+d414*k14[i]+d415*k15[i]+d416*k16[i])
-      @inbounds integrator.k[5][i] = @muladd(d501*k1[i]+d506*k6[i]+d507*k7[i]+d508*k8[i]+d509*k9[i]+d510*k10[i]+d511*k11[i]+d512*k12[i]+d513*k13[i]+d514*k14[i]+d515*k15[i]+d516*k16[i])
-      @inbounds integrator.k[6][i] = @muladd(d601*k1[i]+d606*k6[i]+d607*k7[i]+d608*k8[i]+d609*k9[i]+d610*k10[i]+d611*k11[i]+d612*k12[i]+d613*k13[i]+d614*k14[i]+d615*k15[i]+d616*k16[i])
-      @inbounds integrator.k[7][i] = @muladd(d701*k1[i]+d706*k6[i]+d707*k7[i]+d708*k8[i]+d709*k9[i]+d710*k10[i]+d711*k11[i]+d712*k12[i]+d713*k13[i]+d714*k14[i]+d715*k15[i]+d716*k16[i])
+      @inbounds integrator.k[4][i] = d401*k1[i]+d406*k6[i]+d407*k7[i]+d408*k8[i]+d409*k9[i]+d410*k10[i]+d411*k11[i]+d412*k12[i]+d413*k13[i]+d414*k14[i]+d415*k15[i]+d416*k16[i]
+      @inbounds integrator.k[5][i] = d501*k1[i]+d506*k6[i]+d507*k7[i]+d508*k8[i]+d509*k9[i]+d510*k10[i]+d511*k11[i]+d512*k12[i]+d513*k13[i]+d514*k14[i]+d515*k15[i]+d516*k16[i]
+      @inbounds integrator.k[6][i] = d601*k1[i]+d606*k6[i]+d607*k7[i]+d608*k8[i]+d609*k9[i]+d610*k10[i]+d611*k11[i]+d612*k12[i]+d613*k13[i]+d614*k14[i]+d615*k15[i]+d616*k16[i]
+      @inbounds integrator.k[7][i] = d701*k1[i]+d706*k6[i]+d707*k7[i]+d708*k8[i]+d709*k9[i]+d710*k10[i]+d711*k11[i]+d712*k12[i]+d713*k13[i]+d714*k14[i]+d715*k15[i]+d716*k16[i]
     end
   end
   @pack integrator = t,dt,u,k
@@ -471,59 +391,28 @@ end
   integrator.k[2] = integrator.fsallast
 end
 
-#=
-@inline function perform_step!(integrator,cache::TsitPap8ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::TsitPap8ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,bhat1,bhat6,bhat7,bhat8,bhat9,bhat10,bhat13 = cache
   k1 = integrator.fsalfirst
   a = dt*a0201
-  k2 = f(@muladd(t + c1*dt),@.(@muladd(uprev+a*k1)))
-  k3 = f(@muladd(t + c2*dt),@.(@muladd(uprev+dt*(a0301*k1+a0302*k2))))
-  k4 = f(@muladd(t + c3*dt),@.(@muladd(uprev+dt*(a0401*k1       +a0403*k3))))
-  k5 = f(@muladd(t + c4*dt),@.(@muladd(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4))))
-  k6 = f(@muladd(t + c5*dt),@.(@muladd(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5))))
-  k7 = f(@muladd(t + c6*dt),@.(@muladd(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6))))
-  k8 = f(@muladd(t + c7*dt),@.(@muladd(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7))))
-  k9 = f(@muladd(t + c8*dt),@.(@muladd(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8))))
-  k10 =f(@muladd(t + c9*dt),@.(@muladd(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9))))
-  k11= f(@muladd(t + c10*dt),@.(@muladd(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10))))
-  k12= f(t+dt,@.(@muladd(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11))))
-  k13= f(t+dt,@.(@muladd(uprev+dt*(a1301*k1                +a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10))))
-  update = @. dt*(@muladd(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12))
+  k2 = f(t + c1*dt, @. uprev+a*k1)
+  k3 = f(t + c2*dt, @. uprev+dt*(a0301*k1+a0302*k2))
+  k4 = f(t + c3*dt, @. uprev+dt*(a0401*k1       +a0403*k3))
+  k5 = f(t + c4*dt, @. uprev+dt*(a0501*k1       +a0503*k3+a0504*k4))
+  k6 = f(t + c5*dt, @. uprev+dt*(a0601*k1                +a0604*k4+a0605*k5))
+  k7 = f(t + c6*dt, @. uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6))
+  k8 = f(t + c7*dt, @. uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7))
+  k9 = f(t + c8*dt, @. uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8))
+  k10 =f(t + c9*dt, @. uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9))
+  k11= f(t + c10*dt, @. uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10))
+  k12= f(t+dt, @. uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11))
+  k13= f(t+dt, @. uprev+dt*(a1301*k1                +a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10))
+  update = @. dt*(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12)
   u = uprev + update
   if integrator.opts.adaptive
-    tmp = @. @muladd(update - dt*(k1*bhat1 + k6*bhat6 + k7*bhat7 + k8*bhat8 + k9*bhat9 + k10*bhat10 + k13*bhat13))./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)
+    tmp = @. (update - dt*(k1*bhat1 + k6*bhat6 + k7*bhat7 + k8*bhat8 + k9*bhat9 + k10*bhat10 + k13*bhat13))/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(tmp)
-  end
-  k = f(t+dt,u)
-  integrator.fsallast = k
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-=#
-
-@inline function perform_step!(integrator,cache::TsitPap8ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,bhat1,bhat6,bhat7,bhat8,bhat9,bhat10,bhat13 = cache
-  k1 = integrator.fsalfirst
-  a = dt*a0201
-  k2 = f(@muladd(t + c1*dt),uprev+a*k1)
-  k3 = f(@muladd(t + c2*dt),@muladd(uprev+dt*(a0301*k1+a0302*k2)))
-  k4 = f(@muladd(t + c3*dt),@muladd(uprev+dt*(a0401*k1       +a0403*k3)))
-  k5 = f(@muladd(t + c4*dt),@muladd(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4)))
-  k6 = f(@muladd(t + c5*dt),@muladd(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5)))
-  k7 = f(@muladd(t + c6*dt),@muladd(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6)))
-  k8 = f(@muladd(t + c7*dt),@muladd(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7)))
-  k9 = f(@muladd(t + c8*dt),@muladd(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)))
-  k10 =f(@muladd(t + c9*dt),@muladd(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)))
-  k11= f(@muladd(t + c10*dt),@muladd(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)))
-  k12= f(t+dt,@muladd(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)))
-  k13= f(t+dt,@muladd(uprev+dt*(a1301*k1                +a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10)))
-  update = dt*(@muladd(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12))
-  u = uprev + update
-  if integrator.opts.adaptive
-    integrator.EEst = integrator.opts.internalnorm(@muladd(update - dt*(k1*bhat1 + k6*bhat6 + k7*bhat7 + k8*bhat8 + k9*bhat9 + k10*bhat10 + k13*bhat13))./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
   end
   k = f(t+dt,u)
   integrator.fsallast = k
@@ -543,7 +432,7 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::TsitPap8Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::TsitPap8Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,bhat1,bhat6,bhat7,bhat8,bhat9,bhat10,bhat13 = cache.tab
@@ -551,34 +440,34 @@ end
   k1 = cache.fsalfirst
   f(t,uprev,k1)
   a = dt*a0201
-  @. tmp = @muladd uprev+a*k1
-  f(@muladd(t + c1*dt),tmp,k2)
-  @. tmp = @muladd uprev+dt*(a0301*k1+a0302*k2)
-  f(@muladd(t + c2*dt),tmp,k3)
-  @. tmp = @muladd uprev+dt*(a0401*k1+a0403*k3)
-  f(@muladd(t + c3*dt),tmp,k4)
-  @. tmp = @muladd uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
-  f(@muladd(t + c4*dt),tmp,k5)
-  @. tmp = @muladd uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
-  f(@muladd(t + c5*dt),tmp,k6)
-  @. tmp = @muladd uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
-  f(@muladd(t + c6*dt),tmp,k7)
-  @. tmp = @muladd uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
-  f(@muladd(t + c7*dt),tmp,k8)
-  @. tmp = @muladd uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
-  f(@muladd(t + c8*dt),tmp,k9)
-  @. tmp = @muladd uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
-  f(@muladd(t + c9*dt),tmp,k10)
-  @. tmp = @muladd uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
-  f(@muladd(t + c10*dt),tmp,k11)
-  @. tmp = @muladd uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
+  @. tmp = uprev+a*k1
+  f(t + c1*dt,tmp,k2)
+  @. tmp = uprev+dt*(a0301*k1+a0302*k2)
+  f(t + c2*dt,tmp,k3)
+  @. tmp = uprev+dt*(a0401*k1+a0403*k3)
+  f(t + c3*dt,tmp,k4)
+  @. tmp = uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
+  f(t + c4*dt,tmp,k5)
+  @. tmp = uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
+  f(t + c5*dt,tmp,k6)
+  @. tmp = uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
+  f(t + c6*dt,tmp,k7)
+  @. tmp = uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
+  f(t + c7*dt,tmp,k8)
+  @. tmp = uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
+  f(t + c8*dt,tmp,k9)
+  @. tmp = uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
+  f(t + c9*dt,tmp,k10)
+  @. tmp = uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
+  f(t + c10*dt,tmp,k11)
+  @. tmp = uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
   f(t+dt,tmp,k12)
-  @. tmp = @muladd uprev+dt*(a1301*k1+a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10)
+  @. tmp = uprev+dt*(a1301*k1+a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10)
   f(t+dt,tmp,k13)
-  @. update = dt*@muladd(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12)
+  @. update = dt*(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12)
   @. u = uprev + update
   if integrator.opts.adaptive
-    @. atmp = (@muladd(update - dt*(k1*bhat1 + k6*bhat6 + k7*bhat7 + k8*bhat8 + k9*bhat9 + k10*bhat10 + k13*bhat13))./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. atmp = (update - dt*(k1*bhat1 + k6*bhat6 + k7*bhat7 + k8*bhat8 + k9*bhat9 + k10*bhat10 + k13*bhat13))/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   f(t+dt,u,k)
@@ -586,7 +475,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::TsitPap8Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::TsitPap8Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,bhat1,bhat6,bhat7,bhat8,bhat9,bhat10,bhat13 = cache.tab
@@ -595,60 +484,60 @@ end
   f(t,uprev,k1)
   a = dt*a0201
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a*k1[i]
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(@muladd(t + c1*dt),tmp,k2)
+  f(t + c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
   end
-  f(@muladd(t + c2*dt),tmp,k3)
+  f(t + c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
   end
-  f(@muladd(t + c3*dt),tmp,k4)
+  f(t + c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
   end
-  f(@muladd(t + c4*dt),tmp,k5)
+  f(t + c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
   end
-  f(@muladd(t + c5*dt),tmp,k6)
+  f(t + c5*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
   end
-  f(@muladd(t + c6*dt),tmp,k7)
+  f(t + c6*dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
   end
-  f(@muladd(t + c7*dt),tmp,k8)
+  f(t + c7*dt,tmp,k8)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
   end
-  f(@muladd(t + c8*dt),tmp,k9)
+  f(t + c8*dt,tmp,k9)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
   end
-  f(@muladd(t + c9*dt),tmp,k10)
+  f(t + c9*dt,tmp,k10)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
   end
-  f(@muladd(t + c10*dt),tmp,k11)
+  f(t + c10*dt,tmp,k11)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
   end
   f(t+dt,tmp,k12)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a1301*k1[i]+a1304*k4[i]+a1305*k5[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a1301*k1[i]+a1304*k4[i]+a1305*k5[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i])
   end
   f(t+dt,tmp,k13)
   @tight_loop_macros for i in uidx
-    @inbounds update[i] = dt*@muladd(b1*k1[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i])
+    @inbounds update[i] = dt*(b1*k1[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i])
     @inbounds u[i] = uprev[i] + update[i]
   end
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds atmp[i] = (@muladd(update[i] - dt*(k1[i]*bhat1 + k6[i]*bhat6 + k7[i]*bhat7 + k8[i]*bhat8 + k9[i]*bhat9 + k10[i]*bhat10 + k13[i]*bhat13))./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds atmp[i] = (update[i] - dt*(k1[i]*bhat1 + k6[i]*bhat6 + k7[i]*bhat7 + k8[i]*bhat8 + k9[i]*bhat9 + k10[i]*bhat10 + k13[i]*bhat13))/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end

--- a/src/integrators/implicit_integrators.jl
+++ b/src/integrators/implicit_integrators.jl
@@ -102,7 +102,7 @@ function (p::RHS_Trap)(uprev,resid)
   p.f(p.t+p.dt,reshape(uprev,p.sizeu),du1)
   #@. resid = @muladd uprev - p.u_old - (p.dt/2)*(du1+p.f_old)
   @tight_loop_macros for i in p.uidx
-    @inbounds resid[i] = @muladd uprev[i] - p.u_old[i] - (p.dt/2)*(du1[i]+p.f_old[i])
+    @inbounds resid[i] = uprev[i] - p.u_old[i] - (p.dt/2)*(du1[i]+p.f_old[i])
   end
 end
 

--- a/src/integrators/low_order_rk_integrators.jl
+++ b/src/integrators/low_order_rk_integrators.jl
@@ -9,41 +9,20 @@
   integrator.k[2] = integrator.fsallast
 end
 
-#=
-@inline function perform_step!(integrator,cache::BS3ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::BS3ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack a21,a32,a41,a42,a43,c1,c2,b1,b2,b3,b4 = cache
   k1 = integrator.fsalfirst
   a1 = dt*a21
-  k2 = f(@muladd(t+c1*dt),@.(@muladd(uprev+a1*k1)))
+  k2 = f(t+c1*dt, @. uprev+a1*k1)
   a2 = dt*a32
-  k3 = f(@muladd(t+c2*dt),@.(@muladd(uprev+a2*k2)))
-  u = @. @muladd uprev+dt*(a41*k1+a42*k2+a43*k3)
+  k3 = f(t+c2*dt, @. uprev+a2*k2)
+  u = @. uprev+dt*(a41*k1+a42*k2+a43*k3)
   k4 = f(t+dt,u); integrator.fsallast = k4
   if integrator.opts.adaptive
-    utilde = @. @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4)
-    tmp = @. ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
+    utilde = @. uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4)
+    tmp = @. ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(tmp)
-  end
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end
-=#
-
-@inline function perform_step!(integrator,cache::BS3ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack a21,a32,a41,a42,a43,c1,c2,b1,b2,b3,b4 = cache
-  k1 = integrator.fsalfirst
-  a1 = dt*a21
-  k2 = f(@muladd(t+c1*dt),@muladd(uprev+a1*k1))
-  a2 = dt*a32
-  k3 = f(@muladd(t+c2*dt),@muladd(uprev+a2*k2))
-  u = @muladd uprev+dt*(a41*k1+a42*k2+a43*k3)
-  k4 = f(t+dt,u); integrator.fsallast = k4
-  if integrator.opts.adaptive
-    utilde = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4)
-    integrator.EEst = integrator.opts.internalnorm( ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)))
   end
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -61,29 +40,29 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::BS3Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::BS3Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack k2,k3,k4,utilde,tmp,atmp = cache
   k1 = cache.fsalfirst
   @unpack a21,a32,a41,a42,a43,c1,c2,b1,b2,b3,b4 = cache.tab
   a1 = dt*a21
-  @. tmp = @muladd uprev+a1*k1
-  f(@muladd(t+c1*dt),tmp,k2)
+  @. tmp = uprev+a1*k1
+  f(t+c1*dt,tmp,k2)
   a2 = dt*a32
-  @. tmp = @muladd uprev+a2*k2
-  f(@muladd(t+c2*dt),tmp,k3)
-  @. u = @muladd uprev+dt*(a41*k1+a42*k2+a43*k3)
+  @. tmp = uprev+a2*k2
+  f(t+c2*dt,tmp,k3)
+  @. u = uprev+dt*(a41*k1+a42*k2+a43*k3)
   f(t+dt,u,k4)
   if integrator.opts.adaptive
-    @. utilde = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4)
-    @. atmp = ((utilde-u)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. utilde = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4)
+    @. atmp = ((utilde-u)/@muladd(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   @pack integrator = t,dt,u,k
 end
 =#
 
-@inline function perform_step!(integrator,cache::BS3Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::BS3Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack k2,k3,k4,utilde,tmp,atmp = cache
@@ -91,22 +70,22 @@ end
   @unpack a21,a32,a41,a42,a43,c1,c2,b1,b2,b3,b4 = cache.tab
   a1 = dt*a21
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a1*k1[i]
+    @inbounds tmp[i] = uprev[i]+a1*k1[i]
   end
-  f(@muladd(t+c1*dt),tmp,k2)
+  f(t+c1*dt,tmp,k2)
   a2 = dt*a32
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a2*k2[i]
+    @inbounds tmp[i] = uprev[i]+a2*k2[i]
   end
-  f(@muladd(t+c2*dt),tmp,k3)
+  f(t+c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds u[i] = @muladd uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
+    @inbounds u[i] = uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
   end
   f(t+dt,u,k4)
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds utilde[i] = @muladd uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b4*k4[i])
-      @inbounds atmp[i] = ((utilde[i]-u[i])./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds utilde[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b4*k4[i])
+      @inbounds atmp[i] = (utilde[i]-u[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
@@ -127,50 +106,24 @@ end
   integrator.k[integrator.kshortsize] = integrator.fsallast
 end
 
-#=
-@inline function perform_step!(integrator,cache::BS5ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-        @unpack c1,c2,c3,c4,c5,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,bhat1,bhat3,bhat4,bhat5,bhat6,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7,btilde8 = cache
-  k1 = integrator.fsalfirst
-  a = dt*a21
-  k2 = f(@muladd(t+c1*dt),@.(@muladd(uprev+a*k1)))
-  k3 = f(@muladd(t+c2*dt),@.(@muladd(uprev+dt*(a31*k1+a32*k2))))
-  k4 = f(@muladd(t+c3*dt),@.(@muladd(uprev+dt*(a41*k1+a42*k2+a43*k3))))
-  k5 = f(@muladd(t+c4*dt),@.(@muladd(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4))))
-  k6 = f(@muladd(t+c5*dt),@.(@muladd(uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5))))
-  k7 = f(t+dt,@.(@muladd(uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6))))
-  u = @. @muladd uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
-  integrator.fsallast = f(t+dt,u); k8 = integrator.fsallast
-  if integrator.opts.adaptive
-    uhat   = @. dt*@muladd(bhat1*k1 + bhat3*k3 + bhat4*k4 + bhat5*k5 + bhat6*k6)
-    utilde = @. @muladd uprev + dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7 + btilde8*k8)
-    EEst1  = @. integrator.opts.internalnorm( sum(((uhat)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))))
-    EEst2  = @. integrator.opts.internalnorm( sum(((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))))
-    integrator.EEst = max(EEst1,EEst2)
-  end
-  integrator.k[1]=k1; integrator.k[2]=k2; integrator.k[3]=k3;integrator.k[4]=k4;integrator.k[5]=k5;integrator.k[6]=k6;integrator.k[7]=k7;integrator.k[8]=k8
-  @pack integrator = t,dt,u,k
-end
-=#
-
-@inline function perform_step!(integrator,cache::BS5ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::BS5ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack c1,c2,c3,c4,c5,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,bhat1,bhat3,bhat4,bhat5,bhat6,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7,btilde8 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(@muladd(t+c1*dt),@muladd(uprev+a*k1))
-  k3 = f(@muladd(t+c2*dt),@muladd(uprev+dt*(a31*k1+a32*k2)))
-  k4 = f(@muladd(t+c3*dt),@muladd(uprev+dt*(a41*k1+a42*k2+a43*k3)))
-  k5 = f(@muladd(t+c4*dt),@muladd(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)))
-  k6 = f(@muladd(t+c5*dt),@muladd(uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)))
-  k7 = f(t+dt,@muladd(uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)))
-  u = @muladd uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
+  k2 = f(t+c1*dt, @. uprev+a*k1)
+  k3 = f(t+c2*dt, @. uprev+dt*(a31*k1+a32*k2))
+  k4 = f(t+c3*dt, @. uprev+dt*(a41*k1+a42*k2+a43*k3))
+  k5 = f(t+c4*dt, @. uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4))
+  k6 = f(t+c5*dt, @. uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5))
+  k7 = f(t+dt, @. uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6))
+  u = @. uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
   integrator.fsallast = f(t+dt,u); k8 = integrator.fsallast
   if integrator.opts.adaptive
-    uhat   = dt*@muladd(bhat1*k1 + bhat3*k3 + bhat4*k4 + bhat5*k5 + bhat6*k6)
-    utilde = @muladd uprev + dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7 + btilde8*k8)
-    EEst1 = integrator.opts.internalnorm( sum(((uhat)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))))
-    EEst2 = integrator.opts.internalnorm( sum(((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))))
+    uhat   = @. dt*(bhat1*k1 + bhat3*k3 + bhat4*k4 + bhat5*k5 + bhat6*k6)
+    utilde = @. uprev + dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7 + btilde8*k8)
+    EEst1 = integrator.opts.internalnorm( sum(@. uhat/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)))
+    EEst2 = integrator.opts.internalnorm( sum(@. (utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)))
     integrator.EEst = max(EEst1,EEst2)
   end
   integrator.k[1]=k1; integrator.k[2]=k2; integrator.k[3]=k3;integrator.k[4]=k4;integrator.k[5]=k5;integrator.k[6]=k6;integrator.k[7]=k7;integrator.k[8]=k8
@@ -189,31 +142,31 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::BS5Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::BS5Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,utilde,uhat,tmp,atmp,atmptilde = cache
   @unpack c1,c2,c3,c4,c5,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,bhat1,bhat3,bhat4,bhat5,bhat6,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7,btilde8 = cache.tab
   a = dt*a21
-  @. tmp = @muladd uprev+a*k1
-  f(@muladd(t+c1*dt),tmp,k2)
-  @. tmp = @muladd uprev+dt*(a31*k1+a32*k2)
-  f(@muladd(t+c2*dt),tmp,k3)
-  @. tmp = @muladd uprev+dt*(a41*k1+a42*k2+a43*k3)
-  f(@muladd(t+c3*dt),tmp,k4)
-  @. tmp = @muladd uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
-  f(@muladd(t+c4*dt),tmp,k5)
-  @. tmp = @muladd uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
-  f(@muladd(t+c5*dt),tmp,k6)
-  @. tmp = @muladd uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
+  @. tmp = uprev+a*k1
+  f(t+c1*dt,tmp,k2)
+  @. tmp = uprev+dt*(a31*k1+a32*k2)
+  f(t+c2*dt,tmp,k3)
+  @. tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
+  f(t+c3*dt,tmp,k4)
+  @. tmp = uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
+  f(t+c4*dt,tmp,k5)
+  @. tmp = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
+  f(t+c5*dt,tmp,k6)
+  @. tmp = uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
   f(t+dt,tmp,k7)
-  @. u = @muladd uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
+  @. u = uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
   f(t+dt,u,k8)
   if integrator.opts.adaptive
-    @. uhat   = dt*@muladd(bhat1*k1 + bhat3*k3 + bhat4*k4 + bhat5*k5 + bhat6*k6)
-    @. utilde = @muladd uprev + dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7 + btilde8*k8)
-    @. atmp = ((uhat)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
-    @. atmptilde = ((utilde-u)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. uhat   = dt*(bhat1*k1 + bhat3*k3 + bhat4*k4 + bhat5*k5 + bhat6*k6)
+    @. utilde = uprev + dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7 + btilde8*k8)
+    @. atmp = ((uhat)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+    @. atmptilde = ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     EEst1 = integrator.opts.internalnorm(atmp)
     EEst2 = integrator.opts.internalnorm(atmptilde)
     integrator.EEst = max(EEst1,EEst2)
@@ -222,46 +175,46 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::BS5Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::BS5Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,utilde,uhat,tmp,atmp,atmptilde = cache
   @unpack c1,c2,c3,c4,c5,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,bhat1,bhat3,bhat4,bhat5,bhat6,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7,btilde8 = cache.tab
   a = dt*a21
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a*k1[i]
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(@muladd(t+c1*dt),tmp,k2)
+  f(t+c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a31*k1[i]+a32*k2[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(@muladd(t+c2*dt),tmp,k3)
+  f(t+c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
   end
-  f(@muladd(t+c3*dt),tmp,k4)
+  f(t+c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
   end
-  f(@muladd(t+c4*dt),tmp,k5)
+  f(t+c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
-  f(@muladd(t+c5*dt),tmp,k6)
+  f(t+c5*dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a71*k1[i]+a72*k2[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a71*k1[i]+a72*k2[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
   end
   f(t+dt,tmp,k7)
   @tight_loop_macros for i in uidx
-    @inbounds u[i] = @muladd uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
+    @inbounds u[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
   end
   f(t+dt,u,k8)
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds uhat[i]   = dt*@muladd(bhat1*k1[i] + bhat3*k3[i] + bhat4*k4[i] + bhat5*k5[i] + bhat6*k6[i])
-      @inbounds utilde[i] = @muladd uprev[i] + dt*(btilde1*k1[i] + btilde2*k2[i] + btilde3*k3[i] + btilde4*k4[i] + btilde5*k5[i] + btilde6*k6[i] + btilde7*k7[i] + btilde8*k8[i])
-      @inbounds atmp[i] = ((uhat[i])./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
-      @inbounds atmptilde[i] = ((utilde[i]-u[i])./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds uhat[i]   = dt*(bhat1*k1[i] + bhat3*k3[i] + bhat4*k4[i] + bhat5*k5[i] + bhat6*k6[i])
+      @inbounds utilde[i] = uprev[i] + dt*(btilde1*k1[i] + btilde2*k2[i] + btilde3*k3[i] + btilde4*k4[i] + btilde5*k5[i] + btilde6*k6[i] + btilde7*k7[i] + btilde8*k8[i])
+      @inbounds atmp[i] = uhat[i]/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
+      @inbounds atmptilde[i] = (utilde[i]-u[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     EEst1 = integrator.opts.internalnorm(atmp)
     EEst2 = integrator.opts.internalnorm(atmptilde)
@@ -284,50 +237,22 @@ end
   integrator.k[integrator.kshortsize] = integrator.fsallast
 end
 
-#=
-@inline function perform_step!(integrator,cache::Tsit5ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Tsit5ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,b1,b2,b3,b4,b5,b6,b7 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(@muladd(t+c1*dt),@.(@muladd(uprev+a*k1)))
-  k3 = f(@muladd(t+c2*dt),@.(@muladd(uprev+dt*(a31*k1+a32*k2))))
-  k4 = f(@muladd(t+c3*dt),@.(@muladd(uprev+dt*(a41*k1+a42*k2+a43*k3))))
-  k5 = f(@muladd(t+c4*dt),@.(@muladd(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4))))
-  k6 = f(t+dt,@.(@muladd(uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5))))
-  u = @. @muladd uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
+  k2 = f(t+c1*dt, @. uprev+a*k1)
+  k3 = f(t+c2*dt, @. uprev+dt*(a31*k1+a32*k2))
+  k4 = f(t+c3*dt, @. uprev+dt*(a41*k1+a42*k2+a43*k3))
+  k5 = f(t+c4*dt, @. uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4))
+  k6 = f(t+dt, @. uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5))
+  u = @. uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
   integrator.fsallast = f(t+dt,u); k7 = integrator.fsallast
   if integrator.opts.adaptive
-    utilde = @. @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
-    tmp = @. ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
+    utilde = @. uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
+    tmp = @. ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(tmp)
-  end
-  integrator.k[1] = k1
-  integrator.k[2] = k2
-  integrator.k[3] = k3
-  integrator.k[4] = k4
-  integrator.k[5] = k5
-  integrator.k[6] = k6
-  integrator.k[7] = k7
-  @pack integrator = t,dt,u,k
-end
-=#
-
-@inline function perform_step!(integrator,cache::Tsit5ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,b1,b2,b3,b4,b5,b6,b7 = cache
-  k1 = integrator.fsalfirst
-  a = dt*a21
-  k2 = f(@muladd(t+c1*dt),@muladd(uprev+a*k1))
-  k3 = f(@muladd(t+c2*dt),@muladd(uprev+dt*(a31*k1+a32*k2)))
-  k4 = f(@muladd(t+c3*dt),@muladd(uprev+dt*(a41*k1+a42*k2+a43*k3)))
-  k5 = f(@muladd(t+c4*dt),@muladd(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)))
-  k6 = f(t+dt,@muladd(uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)))
-  u = @muladd uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
-  integrator.fsallast = f(t+dt,u); k7 = integrator.fsallast
-  if integrator.opts.adaptive
-    utilde = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
-    integrator.EEst = integrator.opts.internalnorm(((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)))
   end
   integrator.k[1] = k1
   integrator.k[2] = k2
@@ -355,67 +280,67 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::Tsit5Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Tsit5Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,b1,b2,b3,b4,b5,b6,b7 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
   a = dt*a21
-  @. tmp = @muladd uprev+a*k1
-  f(@muladd(t+c1*dt),tmp,k2)
-  @. tmp = @muladd uprev+dt*(a31*k1+a32*k2)
-  f(@muladd(t+c2*dt),tmp,k3)
-  @. tmp = @muladd uprev+dt*(a41*k1+a42*k2+a43*k3)
-  f(@muladd(t+c3*dt),tmp,k4)
-  @. tmp = @muladd uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
-  f(@muladd(t+c4*dt),tmp,k5)
-  @. tmp = @muladd uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
+  @. tmp = uprev+a*k1
+  f(t+c1*dt,tmp,k2)
+  @. tmp = uprev+dt*(a31*k1+a32*k2)
+  f(t+c2*dt,tmp,k3)
+  @. tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
+  f(t+c3*dt,tmp,k4)
+  @. tmp = uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
+  f(t+c4*dt,tmp,k5)
+  @. tmp = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
   f(t+dt,tmp,k6)
-  @. u = @muladd uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
+  @. u = uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
   f(t+dt,u,k7)
   if integrator.opts.adaptive
-    @. utilde = @muladd uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
-    @. atmp = ((utilde-u)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. utilde = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
+    @. atmp = ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   @pack integrator = t,dt,u,k
 end
 =#
 
-@inline function perform_step!(integrator,cache::Tsit5Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::Tsit5Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,b1,b2,b3,b4,b5,b6,b7 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
   a = dt*a21
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a*k1[i]
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(@muladd(t+c1*dt),tmp,k2)
+  f(t+c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a31*k1[i]+a32*k2[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(@muladd(t+c2*dt),tmp,k3)
+  f(t+c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
   end
-  f(@muladd(t+c3*dt),tmp,k4)
+  f(t+c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
   end
-  f(@muladd(t+c4*dt),tmp,k5)
+  f(t+c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
   f(t+dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds u[i] = @muladd uprev[i]+dt*(a71*k1[i]+a72*k2[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
+    @inbounds u[i] = uprev[i]+dt*(a71*k1[i]+a72*k2[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
   end
   f(t+dt,u,k7)
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds utilde[i] = @muladd uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b4*k4[i] + b5*k5[i] + b6*k6[i] + b7*k7[i])
-      @inbounds atmp[i] = ((utilde[i]-u[i])./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds utilde[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b4*k4[i] + b5*k5[i] + b6*k6[i] + b7*k7[i])
+      @inbounds atmp[i] = (utilde[i]-u[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
@@ -434,58 +359,30 @@ end
   end
 end
 
-#=
-@inline function perform_step!(integrator,cache::DP5ConstantCache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DP5ConstantCache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a73,a74,a75,a76,b1,b3,b4,b5,b6,b7,c1,c2,c3,c4,c5,c6 = cache
   @unpack d1,d3,d4,d5,d6,d7 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(@muladd(t+c1*dt),@.(@muladd(uprev+a*k1)))
-  k3 = f(@muladd(t+c2*dt),@.(@muladd(uprev+dt*(a31*k1+a32*k2))))
-  k4 = f(@muladd(t+c3*dt),@.(@muladd(uprev+dt*(a41*k1+a42*k2+a43*k3))))
-  k5 = f(@muladd(t+c4*dt),@.(@muladd(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4))))
-  k6 = f(t+dt,@.(@muladd uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)))
-  update = @. @muladd a71*k1+a73*k3+a74*k4+a75*k5+a76*k6
-  u = @. @muladd uprev+dt*update
+  k2 = f(t+c1*dt, @. uprev+a*k1)
+  k3 = f(t+c2*dt, @. uprev+dt*(a31*k1+a32*k2))
+  k4 = f(t+c3*dt, @. uprev+dt*(a41*k1+a42*k2+a43*k3))
+  k5 = f(t+c4*dt, @. uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4))
+  k6 = f(t+dt, @. uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5))
+  update = @. a71*k1+a73*k3+a74*k4+a75*k5+a76*k6
+  u = @. uprev+dt*update
   integrator.fsallast = f(t+dt,u); k7 = integrator.fsallast
   if integrator.opts.adaptive
     utilde = @. uprev + dt*(b1*k1 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
-    tmp = @. ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol))
+    tmp = @. ((utilde-u)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
   integrator.k[1] = update
   bspl = k1 - update
   integrator.k[2] = bspl
   integrator.k[3] = @. update - k7 - bspl
-  integrator.k[4] = @. @muladd (d1*k1+d3*k3+d4*k4+d5*k5+d6*k6+d7*k7)
-  @pack integrator = t,dt,u,k
-end
-=#
-
-@inline function perform_step!(integrator,cache::DP5ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
-  @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a73,a74,a75,a76,b1,b3,b4,b5,b6,b7,c1,c2,c3,c4,c5,c6 = cache
-  @unpack d1,d3,d4,d5,d6,d7 = cache
-  k1 = integrator.fsalfirst
-  a = dt*a21
-  k2 = f(@muladd(t+c1*dt),@muladd(uprev+a*k1))
-  k3 = f(@muladd(t+c2*dt),@muladd(uprev+dt*(a31*k1+a32*k2)))
-  k4 = f(@muladd(t+c3*dt),@muladd(uprev+dt*(a41*k1+a42*k2+a43*k3)))
-  k5 = f(@muladd(t+c4*dt),@muladd(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)))
-  k6 = f(t+dt,@muladd uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5))
-  update = @muladd a71*k1+a73*k3+a74*k4+a75*k5+a76*k6
-  u = @muladd uprev+dt*update
-  integrator.fsallast = f(t+dt,u); k7 = integrator.fsallast
-  if integrator.opts.adaptive
-    utilde = uprev + dt*(b1*k1 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
-    integrator.EEst = integrator.opts.internalnorm( ((utilde-u)./@muladd(integrator.opts.abstol+max.(abs.(uprev),abs.(u)).*integrator.opts.reltol)))
-  end
-  integrator.k[1] = update
-  bspl = k1 - update
-  integrator.k[2] = bspl
-  integrator.k[3] = update - k7 - bspl
-  integrator.k[4] = @muladd (d1*k1+d3*k3+d4*k4+d5*k5+d6*k6+d7*k7)
+  integrator.k[4] = @. d1*k1+d3*k3+d4*k4+d5*k5+d6*k6+d7*k7
   @pack integrator = t,dt,u,k
 end
 
@@ -497,29 +394,29 @@ end
 end
 
 #=
-@inline function perform_step!(integrator,cache::DP5Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DP5Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a73,a74,a75,a76,b1,b3,b4,b5,b6,b7,c1,c2,c3,c4,c5,c6 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,dense_tmp3,dense_tmp4,update,bspl,utilde,tmp,atmp = cache
   @unpack d1,d3,d4,d5,d6,d7 = cache.tab
   a = dt*a21
-  @. tmp = @muladd uprev+a*k1
-  f(@muladd(t+c1*dt),tmp,k2)
-  @. tmp = @muladd uprev+dt*(a31*k1+a32*k2)
-  f(@muladd(t+c2*dt),tmp,k3)
-  @. tmp = @muladd uprev+dt*(a41*k1+a42*k2+a43*k3)
-  f(@muladd(t+c3*dt),tmp,k4)
-  @. tmp = @muladd uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
-  f(@muladd(t+c4*dt),tmp,k5)
-  @. tmp = @muladd uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
+  @. tmp = uprev+a*k1
+  f(t+c1*dt,tmp,k2)
+  @. tmp = uprev+dt*(a31*k1+a32*k2)
+  f(t+c2*dt,tmp,k3)
+  @. tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
+  f(t+c3*dt,tmp,k4)
+  @. tmp = uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
+  f(t+c4*dt,tmp,k5)
+  @. tmp = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
   f(t+dt,tmp,k6)
-  @. update = @muladd a71*k1+a73*k3+a74*k4+a75*k5+a76*k6
-  @. u = @muladd uprev+dt*update
+  @. update = a71*k1+a73*k3+a74*k4+a75*k5+a76*k6
+  @. u = uprev+dt*update
   f(t+dt,u,k7);
   if integrator.opts.adaptive
     @. utilde = @muladd uprev + dt*(b1*k1 + b3*k3 + b4*k4 + b5*k5 + b6*k6 + b7*k7)
-    @. atmp = ((utilde-u)./@muladd(integrator.opts.abstol+max(abs(uprev),abs(u)).*integrator.opts.reltol))
+    @. atmp = ((utilde-u)/@muladd(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   @. bspl = k1 - update
@@ -529,7 +426,7 @@ end
 end
 =#
 
-@inline function perform_step!(integrator,cache::DP5Cache,f=integrator.f)
+@inline @muladd function perform_step!(integrator,cache::DP5Cache,f=integrator.f)
   @unpack t,dt,uprev,u,k = integrator
   uidx = eachindex(integrator.uprev)
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a73,a74,a75,a76,b1,b3,b4,b5,b6,b7,c1,c2,c3,c4,c5,c6 = cache.tab
@@ -537,41 +434,41 @@ end
   @unpack d1,d3,d4,d5,d6,d7 = cache.tab
   a = dt*a21
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+a*k1[i]
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(@muladd(t+c1*dt),tmp,k2)
+  f(t+c1*dt,tmp,k2)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a31*k1[i]+a32*k2[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(@muladd(t+c2*dt),tmp,k3)
+  f(t+c2*dt,tmp,k3)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
   end
-  f(@muladd(t+c3*dt),tmp,k4)
+  f(t+c3*dt,tmp,k4)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
   end
-  f(@muladd(t+c4*dt),tmp,k5)
+  f(t+c4*dt,tmp,k5)
   @tight_loop_macros for i in uidx
-    @inbounds tmp[i] = @muladd uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
+    @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
   f(t+dt,tmp,k6)
   @tight_loop_macros for i in uidx
-    @inbounds update[i] = @muladd a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i]
-    @inbounds u[i] = @muladd uprev[i]+dt*update[i]
+    @inbounds update[i] = a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i]
+    @inbounds u[i] = uprev[i]+dt*update[i]
   end
   f(t+dt,u,k7);
   if integrator.opts.adaptive
     @tight_loop_macros for (i,atol,rtol) in zip(uidx,Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds utilde[i] = @muladd uprev[i] + dt*(b1*k1[i] + b3*k3[i] + b4*k4[i] + b5*k5[i] + b6*k6[i] + b7*k7[i])
-      @inbounds atmp[i] = ((utilde[i]-u[i])./@muladd(atol+max(abs(uprev[i]),abs(u[i])).*rtol))
+      @inbounds utilde[i] = uprev[i] + dt*(b1*k1[i] + b3*k3[i] + b4*k4[i] + b5*k5[i] + b6*k6[i] + b7*k7[i])
+      @inbounds atmp[i] = (utilde[i]-u[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   @tight_loop_macros for i in uidx
     @inbounds bspl[i] = k1[i] - update[i]
     @inbounds integrator.k[3][i] = update[i] - k7[i] - bspl[i]
-    @inbounds integrator.k[4][i] = @muladd(d1*k1[i]+d3*k3[i]+d4*k4[i]+d5*k5[i]+d6*k6[i]+d7*k7[i])
+    @inbounds integrator.k[4][i] = d1*k1[i]+d3*k3[i]+d4*k4[i]+d5*k5[i]+d6*k6[i]+d7*k7[i]
   end
   @pack integrator = t,dt,u,k
 end


### PR DESCRIPTION
These are some first changes to the integrators in order to correctly apply the new `@muladd` macro https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/57 (which might still end in a separate package?). There are still some integrators missing and one should also update the calculations in the  `dense` subdirectory.

A general problem is that `muladd` can only act as dot call on vectors, resulting in many broadcasts especially for not in-place methods without for loops. However, according to https://github.com/JuliaLang/julia/issues/22255 this leads to performance issues. Nevertheless for the beginning I added dots to many not in-place methods, similar to the commented code, since it guarantees the correct application of `muladd`. Probably a workaround for these problems (as long as there is no fix for the performance issues) is to replace expressions with 12+ broadcasts with the not dotted expression if all variables are scalars and otherwise create an output vector which can be filled in a for loop (as it is done for in-place methods); depending on the type of `u` one of these options would be executed. This should guarantee a correct application of `muladd` but needs code duplication.