### PR TITLE
Updates of SDIRK and generic implicit integrators

### DIFF
--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -173,22 +173,18 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,
   TrapezoidCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,J,W,jac_config,uf,ηold,κ,tol,10000,uprev3,tprev2)
 end
 
-mutable struct TRBDF2ConstantCache{F,uEltypeNoUnits,uType,tType} <: OrdinaryDiffEqConstantCache
+mutable struct TRBDF2ConstantCache{F,uEltypeNoUnits} <: OrdinaryDiffEqConstantCache
   uf::F
   ηold::uEltypeNoUnits
   κ::uEltypeNoUnits
   tol::uEltypeNoUnits
   newton_iters::Int
-  uprev3::uType
-  tprev2::tType
 end
 
 function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,reltol,::Type{Val{false}})
   uf = UDerivativeWrapper(f,t)
   ηold = one(uEltypeNoUnits)
-  uprev3 = u
-  tprev2 = t
 
   if alg.κ != nothing
     κ = alg.κ
@@ -201,7 +197,7 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,
     tol = min(0.03,first(reltol)^(0.5))
   end
 
-  TRBDF2ConstantCache(uf,ηold,κ,tol,10000,uprev3,tprev2)
+  TRBDF2ConstantCache(uf,ηold,κ,tol,10000)
 end
 
 mutable struct TRBDF2Cache{uType,rateType,J,JC,UF,uEltypeNoUnits,tType} <: OrdinaryDiffEqMutableCache
@@ -216,7 +212,7 @@ mutable struct TRBDF2Cache{uType,rateType,J,JC,UF,uEltypeNoUnits,tType} <: Ordin
   z::uType
   Δzᵧ::uType
   Δz::uType
-  est::uType
+  tmp::uType
   J::J
   W::J
   jac_config::JC
@@ -240,7 +236,7 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,
   zprev = similar(u); zᵧ = similar(u); z = similar(u)
   Δzᵧ = similar(u); Δz = similar(u)
   fsalfirst = zeros(rate_prototype)
-  k = zeros(rate_prototype); est = similar(u)
+  k = zeros(rate_prototype); tmp = similar(u)
   vfr = VectorFReturn(f,size(u))
   uf = UJacobianWrapper(vfr,t)
   if alg_autodiff(alg)
@@ -265,6 +261,6 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,
 
   TRBDF2Cache{typeof(u),typeof(rate_prototype),typeof(J),typeof(jac_config),
               typeof(uf),uEltypeNoUnits,typeof(t)}(
-              u,uprev,uᵧ,du1,fsalfirst,k,zprev,zᵧ,z,Δzᵧ,Δz,est,J,
+              u,uprev,uᵧ,du1,fsalfirst,k,zprev,zᵧ,z,Δzᵧ,Δz,tmp,J,
               W,jac_config,uf,ηold,κ,tol,10000)
 end

--- a/src/integrators/generic_implicit_integrators.jl
+++ b/src/integrators/generic_implicit_integrators.jl
@@ -204,7 +204,7 @@ function initialize!(integrator, cache::GenericTrapezoidCache)
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = cache.k
-  f(integrator.t,integrator.uprev,integrator.fsalfirst)
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst

--- a/src/integrators/generic_implicit_integrators.jl
+++ b/src/integrators/generic_implicit_integrators.jl
@@ -26,12 +26,12 @@ function (p::ImplicitRHS)(u,resid)
   @. resid = u - p.C - p.a*vecdu1
 end
 
-function initialize!(integrator,cache::C,f=integrator.f) where
+function initialize!(integrator, cache::C) where
     {C<:Union{GenericImplicitEulerConstantCache,GenericTrapezoidConstantCache}}
   cache.uhold[1] = integrator.uprev; cache.C[1] = integrator.uprev
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.fsalfirst = f(integrator.t,integrator.uprev)
+  integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -39,15 +39,15 @@ function initialize!(integrator,cache::C,f=integrator.f) where
   integrator.k[2] = integrator.fsallast
 end
 
-@muladd function perform_step!(integrator,cache::GenericImplicitEulerConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
+@muladd function perform_step!(integrator, cache::GenericImplicitEulerConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
   @unpack uhold,C,rhs,nl_rhs = cache
   C[1] = uprev
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     uhold[1] = current_extrapolant(t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
-    uhold[1] = uprev + integrator.fsalfirst*dt
+    uhold[1] = @. uprev + integrator.fsalfirst*dt
   else # :constant
     uhold[1] = uprev
   end
@@ -64,9 +64,14 @@ end
     # Use 2rd divided differences a la SPICE and Shampine
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
-    DD3 = ((u - uprev)/((dt)*(t+dt-tprev)) + (uprev-uprev2)/((t-tprev)*(t+dt-tprev)))
-    dEst = @. (dt^2)*abs(DD3/6)
-    integrator.EEst = integrator.opts.internalnorm(@. dEst/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+
+    dt1 = 1/(dt*(t+dt-tprev))
+    dt2 = 1/((t-tprev)*(t+dt-tprev))
+    dt3 = dt^2/6
+
+    dEst = @. dt3*abs(dt1*(u - uprev) + dt2*(uprev-uprev2))
+    atmp = calculate_residuals(dEst, uprev, u, integrator.opts.abstol, integrator.opts.abstol)
+    integrator.EEst = integrator.opts.internalnorm(atmp)
   else
     integrator.EEst = 1
   end
@@ -76,28 +81,28 @@ end
   integrator.u = u
 end
 
-function initialize!(integrator,cache::C,f=integrator.f) where
+function initialize!(integrator, cache::C) where
     {C<:Union{GenericImplicitEulerCache,GenericTrapezoidCache}}
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  f(integrator.t,integrator.uprev,integrator.fsalfirst)
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 
+  # Avoid undefined entries if k is an array of arrays
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
 end
 
-@muladd function perform_step!(integrator,cache::GenericImplicitEulerCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  uidx = eachindex(integrator.uprev)
+@muladd function perform_step!(integrator, cache::GenericImplicitEulerCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
   @unpack C,dual_cache,k,nl_rhs,rhs,uhold = cache
   copy!(C,uprev)
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     current_extrapolant!(u,t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
-    u .= uprev .+ integrator.fsalfirst.*dt
+    @. u = uprev + integrator.fsalfirst*dt
   else
     copy!(u,uprev)
   end
@@ -112,13 +117,14 @@ end
     # Use 2rd divided differences a la SPICE and Shampine
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
-    dt1 = (dt)*(t+dt-tprev)
-    dt2 = (t-tprev)*(t+dt-tprev)
-    @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds DD3 = (u[i] - uprev[i])/dt1 + (uprev[i]-uprev2[i])/dt2
-      dEst = (dt^2)*abs(DD3)/6
-      @inbounds k[i] = dEst/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
-    end
+
+    dt1 = 1/((dt)*(t+dt-tprev))
+    dt2 = 1/((t-tprev)*(t+dt-tprev))
+    dt3 = dt^2/6
+
+    @. k = dt3*abs(dt1*(u - uprev) + dt2*(uprev-uprev2))
+    # does not work with units - additional unitless array required!
+    calculate_residuals!(k, k, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(k)
   else
     integrator.EEst = 1
@@ -127,9 +133,9 @@ end
   f(t+dt,u,k)
 end
 
-function initialize!(integrator,cache::GenericTrapezoidConstantCache,f=integrator.f)
+function initialize!(integrator, cache::GenericTrapezoidConstantCache)
   cache.uhold[1] = integrator.uprev; cache.C[1] = integrator.uprev
-  integrator.fsalfirst = f(integrator.t,integrator.uprev)
+  integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
 
@@ -139,15 +145,15 @@ function initialize!(integrator,cache::GenericTrapezoidConstantCache,f=integrato
   integrator.k[2] = integrator.fsallast
 end
 
-function perform_step!(integrator,cache::GenericTrapezoidConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
+function perform_step!(integrator, cache::GenericTrapezoidConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,k,f = integrator
   @unpack uhold,C,rhs,nl_rhs = cache
   C[1] = first(uprev) + (dt/2)*first(integrator.fsalfirst)
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     uhold[1] = current_extrapolant(t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
-    uhold[1] = uprev + integrator.fsalfirst*dt
+    uhold[1] = @. uprev + integrator.fsalfirst*dt
   else # :constant
     uhold[1] = uprev
   end
@@ -167,10 +173,15 @@ function perform_step!(integrator,cache::GenericTrapezoidConstantCache,f=integra
       tprev = integrator.tprev
       uprev3 = cache.uprev3
       tprev2 = cache.tprev2
-      DD31 = ((u - uprev)/((dt)*(t+dt-tprev)) + (uprev-uprev2)/((t-tprev)*(t+dt-tprev)))
-      DD30 = ((uprev - uprev2)/((t-tprev)*(t-tprev2)) + (uprev2-uprev3)/((tprev-tprev2)*(t-tprev2)))
-      dEst = @. (dt^3)*abs(((DD31 - DD30)/(t+dt-tprev2))/12)
-      integrator.EEst = integrator.opts.internalnorm(@. dEst/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+
+      dt1 = 1/(dt*(t+dt-tprev))
+      dt2 = (tprev-dt-tprev2)/((t-tprev)*(t+dt-tprev)*(t-tprev2))
+      dt3 = -1/((tprev-tprev2)*(t-tprev2))
+      dt4 = dt^3/abs(12*(t+dt-tprev2))
+
+      dEst = @. dt4*abs(dt1*(u-uprev) + dt2*(uprev-uprev2) + dt3*(uprev2-uprev3))
+      atmp = calculate_residuals(dEst, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
+      integrator.EEst = integrator.opts.internalnorm(atmp)
       if integrator.EEst <= 1
         cache.uprev3 = uprev2
         cache.tprev2 = tprev
@@ -189,7 +200,7 @@ function perform_step!(integrator,cache::GenericTrapezoidConstantCache,f=integra
   @pack integrator = t,dt,u
 end
 
-function initialize!(integrator,cache::GenericTrapezoidCache,f=integrator.f)
+function initialize!(integrator, cache::GenericTrapezoidCache)
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = cache.k
@@ -200,8 +211,8 @@ function initialize!(integrator,cache::GenericTrapezoidCache,f=integrator.f)
   integrator.k[2] = integrator.fsallast
 end
 
-function perform_step!(integrator,cache::GenericTrapezoidCache,f=integrator.f)
-  @unpack t,dt,uprev,u,k = integrator
+function perform_step!(integrator, cache::GenericTrapezoidCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack C,dual_cache,k,rhs,nl_rhs,uhold = cache
   C .= vec(uprev) .+ (dt/2).*vec(integrator.fsalfirst)
@@ -209,7 +220,7 @@ function perform_step!(integrator,cache::GenericTrapezoidCache,f=integrator.f)
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     current_extrapolant!(u,t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
-    u .= uprev .+ integrator.fsalfirst.*dt
+    @. u = uprev + integrator.fsalfirst*dt
   else
     copy!(u,uprev)
   end
@@ -228,16 +239,15 @@ function perform_step!(integrator,cache::GenericTrapezoidCache,f=integrator.f)
       tprev = integrator.tprev
       uprev3 = cache.uprev3
       tprev2 = cache.tprev2
-      dt1 = (dt)*(t+dt-tprev)
-      dt2 = ((t-tprev)*(t+dt-tprev))
-      dt3 = ((t-tprev)*(t-tprev2))
-      dt4 = ((tprev-tprev2)*(t-tprev2))
-      @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-        @inbounds DD31 = (u[i] - uprev[i])/dt1 + (uprev[i]-uprev2[i])/dt2
-        @inbounds DD30 = (uprev[i] - uprev2[i])/dt3 + (uprev2[i]-uprev3[i])/dt4
-        dEst = (dt^3)*abs(((DD31 - DD30)/(t+dt-tprev2))/12)
-        @inbounds k[i] = dEst/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
-      end
+
+      dt1 = 1/(dt*(t+dt-tprev))
+      dt2 = (tprev-dt-tprev2)/((t-tprev)*(t+dt-tprev)*(t-tprev2))
+      dt3 = -1/((tprev-tprev2)*(t-tprev2))
+      dt4 = dt^3/abs(12*(t+dt-tprev2))
+
+      @. k = dt4*abs(dt1*(u-uprev) + dt2*(uprev-uprev2) + dt3*(uprev2-uprev3))
+      # does not work with units - additional unitless array required!
+      calculate_residuals!(k, k, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
       integrator.EEst = integrator.opts.internalnorm(k)
       if integrator.EEst <= 1
         copy!(cache.uprev3,uprev2)

--- a/src/integrators/sdirk_integrators.jl
+++ b/src/integrators/sdirk_integrators.jl
@@ -287,7 +287,7 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-  u = u .+ dz
+  u = @. u + (z + dz)
 
   if integrator.opts.adaptive
     if integrator.iter > 2
@@ -430,7 +430,7 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-  u .+= dz
+  @. u += z + dz
 
   if integrator.opts.adaptive
     if integrator.iter > 2
@@ -492,12 +492,6 @@ end
   c1 = γ/4
   c2 = a2/2
 
-  # b1 = ω
-  # bhat1 = (1-ω)/3
-  # b2 = ω
-  # bhat2 = (3ω + 1)/3
-  # b3 = d
-  # bhat3 = d/3
   btilde1 = (1-sqrt(2))/3
   btilde2 = 1/3
   btilde3 = (sqrt(2)-2)/3
@@ -644,12 +638,6 @@ end
   c1 = γ/4
   c2 = a2/2
 
-  # b1 = ω
-  # bhat1 = (1-ω)/3
-  # b2 = ω
-  # bhat2 = (3ω + 1)/3
-  # b3 = d
-  # bhat3 = d/3
   btilde1 = (1-sqrt(2))/3
   btilde2 = 1/3
   btilde3 = (sqrt(2)-2)/3

--- a/src/integrators/sdirk_integrators.jl
+++ b/src/integrators/sdirk_integrators.jl
@@ -1,7 +1,7 @@
-function initialize!(integrator,cache::ImplicitEulerConstantCache,f=integrator.f)
+function initialize!(integrator, cache::ImplicitEulerConstantCache)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -9,19 +9,21 @@ function initialize!(integrator,cache::ImplicitEulerConstantCache,f=integrator.f
   integrator.k[2] = integrator.fsallast
 end
 
-@muladd function perform_step!(integrator,cache::ImplicitEulerConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack uf = cache
-  uf.t = t
+@muladd function perform_step!(integrator, cache::ImplicitEulerConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
+  @unpack uf,κ,tol = cache
+
+  κtol = κ*tol # save in cache instead of κ and tol?
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     u = current_extrapolant(t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
-    u = uprev + integrator.fsalfirst*dt
+    u = @. uprev + integrator.fsalfirst*dt
   else # :constant
     u = uprev
   end
 
+  uf.t = t
   if typeof(uprev) <: AbstractArray
     J = ForwardDiff.jacobian(uf,uprev)
     W = I - dt*J
@@ -30,39 +32,32 @@ end
     W = 1 - dt*J
   end
 
-  z = u - uprev
-  iter = 0
-  κ = cache.κ
-  tol = cache.tol
-
-  iter += 1
-  b = -z .+ dt.*f(t+dt,uprev + z)
+  z = u .- uprev
+  iter = 1
+  b = dt.*f(t+dt,u) .- z
   dz = W\b
   ndz = integrator.opts.internalnorm(dz)
-  z = z + dz
+  z = z .+ dz
 
   η = max(cache.ηold,eps(first(u)))^(0.8)
-  if integrator.success_iter > 0
-    do_newton = (η*ndz > κ*tol)
-  else
-    do_newton = true
-  end
+  do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
-    b = -z .+ dt.*f(t+dt,uprev + z)
+    u = u .+ dz
+    b = dt.*f(t+dt,uprev + z) .- z
     dz = W\b
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
-    z = z + dz
+    do_newton = (η*ndz > κtol)
+    z = z .+ dz
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -72,15 +67,21 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-  u = uprev + z
+  u = u .+ dz
 
   if integrator.opts.adaptive && integrator.success_iter > 0
     # Use 2rd divided differences a la SPICE and Shampine
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
-    DD3 = ((u - uprev)/((dt)*(t+dt-tprev)) + (uprev-uprev2)/((t-tprev)*(t+dt-tprev)))
-    dEst = (dt^2)*abs(DD3/6)
-    integrator.EEst = @. dEst/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
+
+    dt1 = 1/(dt*(t+dt-tprev))
+    dt2 = 1/((t-tprev)*(t+dt-tprev))
+    dt3 = dt^2/6
+
+    dEst = @. dt3*abs(dt1*(u - uprev) + dt2*(uprev-uprev2))
+    atmp = calculate_residuals(dEst, uprev, u, integrator.opts.abstol,
+                               integrator.opts.reltol)
+    integrator.EEst = integrator.opts.internalnorm(atmp)
   else
     integrator.EEst = 1
   end
@@ -91,7 +92,7 @@ end
   integrator.u = u
 end#
 
-function initialize!(integrator,cache::ImplicitEulerCache,f=integrator.f)
+function initialize!(integrator, cache::ImplicitEulerCache)
   integrator.kshortsize = 2
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
@@ -99,14 +100,15 @@ function initialize!(integrator,cache::ImplicitEulerCache,f=integrator.f)
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
 end
 
-@muladd function perform_step!(integrator,cache::ImplicitEulerCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack uf,du1,dz,z,k,J,W,jac_config = cache
+@muladd function perform_step!(integrator, cache::ImplicitEulerCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
+  @unpack uf,du1,dz,z,k,J,W,jac_config,κ,tol = cache
   mass_matrix = integrator.sol.prob.mass_matrix
 
+  κtol = κ*tol # save in cache instead of κ and tol?
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     current_extrapolant!(u,t+dt,integrator)
@@ -116,26 +118,19 @@ end
     copy!(u,uprev)
   end
 
-  if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
-    current_extrapolant!(u,t+dt,integrator)
-  elseif integrator.alg.extrapolant == :linear
-    u .= uprev .+ integrator.fsalfirst.*dt
-  else
-    copy!(u,uprev)
-  end
-
-  uf.t = t
-
   if has_invW(f)
-    f(Val{:invW},t,uprev,dt,W) # W == inverse W
+    # skip calculation of inv(W) if step is repeated
+    !repeat_step && f(Val{:invW},t,uprev,dt,W) # W == inverse W
   else
-    if !integrator.last_stepfail && cache.newton_iters == 1 && cache.ηold < integrator.alg.new_jac_conv_bound
+    # skip calculation of J if step is repeated
+    if repeat_step || (!integrator.last_stepfail && cache.newton_iters == 1 && cache.ηold < integrator.alg.new_jac_conv_bound)
       new_jac = false
     else # Compute a new Jacobian
       new_jac = true
       if has_jac(f)
         f(Val{:jac},t,uprev,J)
       else
+        uf.t = t
         if alg_autodiff(integrator.alg)
           ForwardDiff.jacobian!(J,uf,vec(du1),vec(uprev),jac_config)
         else
@@ -143,7 +138,8 @@ end
         end
       end
     end
-    if integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps()
+    # skip calculation of W if step is repeated
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
       new_W = true
       for j in 1:length(u), i in 1:length(u)
           @inbounds W[i,j] = mass_matrix[i,j]-dt*J[i,j]
@@ -154,11 +150,7 @@ end
   end
 
   @. z = u - uprev
-  iter = 0
-  κ = cache.κ
-  tol = cache.tol
-
-  iter += 1
+  iter = 1
   f(t+dt,u,k)
   scale!(k,dt)
   k .-= z
@@ -169,18 +161,14 @@ end
   end
   ndz = integrator.opts.internalnorm(dz)
   z .+= dz
-  @. u = uprev + z
 
   η = max(cache.ηold,eps(first(u)))^(0.8)
-  if integrator.success_iter > 0
-    do_newton = (η*ndz > κ*tol)
-  else
-    do_newton = true
-  end
+  do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
+    u .+= dz
     f(t+dt,u,k)
     scale!(k,dt)
     k .-= z
@@ -192,14 +180,13 @@ end
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
+    do_newton = (η*ndz > κtol)
     z .+= dz
-    @. u = uprev + z
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -209,19 +196,20 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-  @. u = uprev + z
+  u .+= dz
 
   if integrator.opts.adaptive && integrator.success_iter > 0
     # Use 2rd divided differences a la SPICE and Shampine
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
-    dt1 = (dt)*(t+dt-tprev)
-    dt2 = (t-tprev)*(t+dt-tprev)
-    @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds DD3 = (u[i] - uprev[i])/dt1 + (uprev[i]-uprev2[i])/dt2
-      dEst = (dt^2)*abs(DD3)/6
-      @inbounds k[i] = dEst/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
-    end
+
+    dt1 = 1/(dt*(t+dt-tprev))
+    dt2 = 1/((t-tprev)*(t+dt-tprev))
+    dt3 = dt^2/6
+
+    @. k = dt3*abs(dt1*(u - uprev) + dt2*(uprev-uprev2))
+    # does not work with units - additional unitless array required!
+    calculate_residuals!(k, k, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(k)
   else
     integrator.EEst = 1
@@ -230,10 +218,10 @@ end
   f(t+dt,u,integrator.fsallast)
 end
 
-function initialize!(integrator,cache::TrapezoidConstantCache,f=integrator.f)
+function initialize!(integrator, cache::TrapezoidConstantCache)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -241,20 +229,22 @@ function initialize!(integrator,cache::TrapezoidConstantCache,f=integrator.f)
   integrator.k[2] = integrator.fsallast
 end
 
-@muladd function perform_step!(integrator,cache::TrapezoidConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack uf = cache
-  uf.t = t
+@muladd function perform_step!(integrator, cache::TrapezoidConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
+  @unpack uf,κ,tol = cache
   dto2 = dt/2
+
+  κtol = κ*tol # save in cache instead of κ and tol?
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     u = current_extrapolant(t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
-    u = uprev + integrator.fsalfirst*dt
+    u = @. uprev + integrator.fsalfirst*dt
   else # :constant
     u = uprev
   end
 
+  uf.t = t
   if typeof(uprev) <: AbstractArray
     J = ForwardDiff.jacobian(uf,uprev)
     W = I - dto2*J
@@ -262,39 +252,32 @@ end
     J = ForwardDiff.derivative(uf,uprev)
     W = 1 - dto2*J
   end
-  z = u - uprev
-  iter = 0
-  κ = cache.κ
-  tol = cache.tol
-
-  iter += 1
-  b = -z .+ dto2.*f(t+dto2,uprev + z)
+  z = u .- uprev
+  iter = 1
+  b = dto2.*f(t+dto2,u) .- z
   dz = W\b
   ndz = integrator.opts.internalnorm(dz)
-  z = z + dz
+  z = z .+ dz
 
   η = max(cache.ηold,eps(first(u)))^(0.8)
-  if integrator.success_iter > 0
-    do_newton = (η*ndz > κ*tol)
-  else
-    do_newton = true
-  end
+  do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
-    b = -z .+ dto2.*f(t+dto2,uprev + z)
+    u = u .+ dz
+    b = dto2.*f(t+dto2,u) .- z
     dz = W\b
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
-    z = z + dz
+    do_newton = (η*ndz > κtol)
+    z = z .+ dz
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -304,10 +287,7 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-  u = uprev + 2z
-  integrator.fsallast = f(t+dt,u)
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
+  u = u .+ dz
 
   if integrator.opts.adaptive
     if integrator.iter > 2
@@ -316,10 +296,16 @@ end
       tprev = integrator.tprev
       uprev3 = cache.uprev3
       tprev2 = cache.tprev2
-      DD31 = ((u - uprev)/((dt)*(t+dt-tprev)) + (uprev-uprev2)/((t-tprev)*(t+dt-tprev)))
-      DD30 = ((uprev - uprev2)/((t-tprev)*(t-tprev2)) + (uprev2-uprev3)/((tprev-tprev2)*(t-tprev2)))
-      dEst = (dt^3)*abs(((DD31 - DD30)/(t+dt-tprev2))/12)
-      integrator.EEst = @. dEst/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
+
+      dt1 = 1/(dt*(t+dt-tprev))
+      dt2 = (tprev-dt-tprev2)/((t-tprev)*(t+dt-tprev)*(t-tprev2))
+      dt3 = -1/((tprev-tprev2)*(t-tprev2))
+      dt4 = dt^3/abs(12*(t+dt-tprev2))
+
+      dEst = @. dt4*abs(dt1*(u-uprev) + dt2*(uprev-uprev2) + dt3*(uprev2-uprev3))
+      atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol,
+                                 integrator.opts.reltol)
+      integrator.EEst = integrator.opts.internalnorm(atmp)
       if integrator.EEst <= 1
         cache.uprev3 = uprev2
         cache.tprev2 = tprev
@@ -333,45 +319,52 @@ end
     end
   end
 
+  integrator.fsallast = f(t+dt,u)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
   integrator.u = u
 end
 
-function initialize!(integrator,cache::TrapezoidCache,f=integrator.f)
+function initialize!(integrator, cache::TrapezoidCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
 end
 
-@muladd function perform_step!(integrator,cache::TrapezoidCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack uf,du1,dz,z,k,J,W,jac_config = cache
+@muladd function perform_step!(integrator, cache::TrapezoidCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
+  @unpack uf,du1,dz,z,k,J,W,jac_config,κ,tol = cache
   mass_matrix = integrator.sol.prob.mass_matrix
+
+  κtol = κ*tol # save in cache instead of κ and tol?
 
   if integrator.success_iter > 0 && !integrator.u_modified && integrator.alg.extrapolant == :interpolant
     current_extrapolant!(u,t+dt,integrator)
   elseif integrator.alg.extrapolant == :linear
     @. u = uprev + integrator.fsalfirst*dt
-  else
+  else # :constant
     copy!(u,uprev)
   end
 
   dto2 = dt/2
-  uf.t = t
 
   if has_invW(f)
-    f(Val{:invW},t,uprev,dt,W) # W == inverse W
+    # skip calculation of inv(W) if step is repeated
+    !repeat_step && f(Val{:invW},t,uprev,dt,W) # W == inverse W
   else
-    if !integrator.last_stepfail && cache.newton_iters == 1 && cache.ηold < integrator.alg.new_jac_conv_bound
+    # skip calculation of J if step is repeated
+    if repeat_step || (!integrator.last_stepfail && cache.newton_iters == 1 && cache.ηold < integrator.alg.new_jac_conv_bound)
       new_jac = false
     else # Compute a new Jacobian
       new_jac = true
       if has_jac(f)
         f(Val{:jac},t,uprev,J)
       else
+        uf.t = t
         if alg_autodiff(integrator.alg)
           ForwardDiff.jacobian!(J,uf,vec(du1),vec(uprev),jac_config)
         else
@@ -379,7 +372,8 @@ end
         end
       end
     end
-    if integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps()
+    # skip calculation of W if step is repeated
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
       new_W = true
       for j in 1:length(u), i in 1:length(u)
           @inbounds W[i,j] = mass_matrix[i,j]-dto2*J[i,j]
@@ -390,11 +384,7 @@ end
   end
 
   @. z = u - uprev
-  iter = 0
-  κ = cache.κ
-  tol = cache.tol
-
-  iter += 1
+  iter = 1
   f(t+dto2,u,k)
   scale!(k,dto2)
   k .-= z
@@ -405,18 +395,14 @@ end
   end
   ndz = integrator.opts.internalnorm(dz)
   z .+= dz
-  @. u = uprev + z
 
   η = max(cache.ηold,eps(first(u)))^(0.8)
-  if integrator.success_iter > 0
-    do_newton = (η*ndz > κ*tol)
-  else
-    do_newton = true
-  end
+  do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
+    u .+= dz
     f(t+dto2,u,k)
     scale!(k,dto2)
     k .-= z
@@ -428,14 +414,13 @@ end
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
+    do_newton = (η*ndz > κtol)
     z .+= dz
-    @. u = uprev + z
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -445,7 +430,7 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-  @. u = uprev + 2*z
+  u .+= dz
 
   if integrator.opts.adaptive
     if integrator.iter > 2
@@ -454,16 +439,15 @@ end
       tprev = integrator.tprev
       uprev3 = cache.uprev3
       tprev2 = cache.tprev2
-      dt1 = (dt)*(t+dt-tprev)
-      dt2 = ((t-tprev)*(t+dt-tprev))
-      dt3 = ((t-tprev)*(t-tprev2))
-      dt4 = ((tprev-tprev2)*(t-tprev2))
-      @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-        @inbounds DD31 = (u[i] - uprev[i])/dt1 + (uprev[i]-uprev2[i])/dt2
-        @inbounds DD30 = (uprev[i] - uprev2[i])/dt3 + (uprev2[i]-uprev3[i])/dt4
-        dEst = (dt^3)*abs(((DD31 - DD30)/(t+dt-tprev2))/12)
-        @inbounds k[i] = dEst/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
-      end
+
+      dt1 = 1/(dt*(t+dt-tprev))
+      dt2 = (tprev-dt-tprev2)/((t-tprev)*(t+dt-tprev)*(t-tprev2))
+      dt3 = -1/((tprev-tprev2)*(t-tprev2))
+      dt4 = dt^3/abs(12*(t+dt-tprev2))
+
+      @. k = dt4*abs(dt1*(u-uprev) + dt2*(uprev-uprev2) + dt3*(uprev2-uprev3))
+      # does not work with units - additional unitless array required!
+      calculate_residuals!(k, k, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
       integrator.EEst = integrator.opts.internalnorm(k)
       if integrator.EEst <= 1
         copy!(cache.uprev3,uprev2)
@@ -481,10 +465,10 @@ end
   f(t+dt,u,integrator.fsallast)
 end
 
-function initialize!(integrator,cache::TRBDF2ConstantCache,f=integrator.f)
+function initialize!(integrator, cache::TRBDF2ConstantCache)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -492,71 +476,78 @@ function initialize!(integrator,cache::TRBDF2ConstantCache,f=integrator.f)
   integrator.k[2] = integrator.fsallast
 end
 
-@muladd function perform_step!(integrator,cache::TRBDF2ConstantCache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack uf = cache
-  uf.t = t
+@muladd function perform_step!(integrator, cache::TRBDF2ConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
+  @unpack uf,κ,tol = cache
+
+  # Precalculations
+  # -> move constants to cache?
   γ = 2 - sqrt(2)
   ω = sqrt(2)/4
   d = γ/2
 
-  b1 = ω
-  bhat1 = (1-ω)/3
-  b2 = ω
-  bhat2 = (3ω + 1)/3
-  b3 = d
-  bhat3 = d/3
+  a1 = -sqrt(2)/2
+  a2 = 1 + sqrt(2)/2
+
+  c1 = γ/4
+  c2 = a2/2
+
+  # b1 = ω
+  # bhat1 = (1-ω)/3
+  # b2 = ω
+  # bhat2 = (3ω + 1)/3
+  # b3 = d
+  # bhat3 = d/3
+  btilde1 = (1-sqrt(2))/3
+  btilde2 = 1/3
+  btilde3 = (sqrt(2)-2)/3
+
+  κtol = κ*tol # save in cache instead of κ and tol?
 
   γdt = γ*dt
-  κ = cache.κ
-  tol = cache.tol
+  ddt = d*dt
 
+  uf.t = t
   if typeof(uprev) <: AbstractArray
     J = ForwardDiff.jacobian(uf,uprev)
-    W = I - d*dt*J
+    W = I - ddt*J
   else
     J = ForwardDiff.derivative(uf,uprev)
-    W = 1 - d*dt*J
+    W = 1 - ddt*J
   end
 
   # TODO: Add extrapolant initial guess
-  zprev = dt*integrator.fsalfirst
+  zprev = dt.*integrator.fsalfirst
 
   ##### Solve Trapezoid Step
 
   zᵧ = zprev
   iter = 1
-  uᵧ = @. (uprev + d*zprev) + d*zᵧ
+  uᵧ = @. uprev + γ*zᵧ
   b = dt.*f(t+γdt,uᵧ) .- zᵧ
   Δzᵧ = W\b
   ndz = integrator.opts.internalnorm(Δzᵧ)
-  zᵧ = zᵧ + Δzᵧ
-
-  uᵧ = @. (uprev + d*zprev) + d*zᵧ
+  zᵧ = zᵧ .+ Δzᵧ
 
   η = max(cache.ηold,eps(first(u)))^(0.8)
-  if integrator.success_iter > 0
-    do_newton = (η*ndz > κ*tol)
-  else
-    do_newton = true
-  end
+  do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
-    uᵧ = @. (uprev + d*zprev) + d*zᵧ
+    uᵧ = @. uᵧ + d*Δzᵧ
     b = dt.*f(t+γdt,uᵧ) .- zᵧ
     Δzᵧ = W\b
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(Δzᵧ)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
-    zᵧ = zᵧ + Δzᵧ
+    do_newton = (η*ndz > κtol)
+    zᵧ = zᵧ .+ Δzᵧ
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -564,40 +555,37 @@ end
     return
   end
 
-  uᵧ = @. (uprev + d*zprev) + d*zᵧ
-
   ################################## Solve BDF2 Step
 
   ### Initial Guess From Shampine
-  z = (1.5 + sqrt(2))*zprev + (2.5 + 2sqrt(2))*zᵧ -
-      (6 + 4.5sqrt(2))*(uᵧ - uprev)
+  z = @. a1*zprev + a2*zᵧ
 
   iter = 1
-  u = @. (uprev + ω*zprev + ω*zᵧ) + d*z
+  u = @. uprev + c1*zprev + c2*zᵧ
   b = dt.*f(t+dt,u) .- z
   dz = W\b
   ndz = integrator.opts.internalnorm(dz)
-  z = z + dz
+  z = z .+ dz
 
   η = max(η,eps(first(u)))^(0.8)
-  do_newton = (η*ndz > κ*tol)
+  do_newton = (η*ndz > κtol)
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
-    u = @. (uprev + ω*zprev + ω*zᵧ) + d*z
+    u = @. u + d*dz
     b = dt.*f(t+dt,u) .- z
     dz = W\b
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
-    z = z + dz
+    do_newton = (η*ndz > κtol)
+    z = z .+ dz
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -605,70 +593,85 @@ end
     return
   end
 
-  u = @. (uprev + ω*zprev + ω*zᵧ) + d*z
+  u = @. u + d*dz
 
   ################################### Finalize
 
-  integrator.fsallast = z/dt
-  integrator.k[1] = integrator.fsalfirst
-  integrator.k[2] = integrator.fsallast
-  cache.ηold = η
-  cache.newton_iters = iter
-
   if integrator.opts.adaptive
-    est = (bhat1-b1)*zprev + (bhat2-b2)*zᵧ + (bhat3-b3)*z
+    est = @. btilde1*zprev + btilde2*zᵧ + btilde3*z
     if integrator.alg.smooth_est # From Shampine
       Est = W\est
     else
       Est = est
     end
-    integrator.EEst = integrator.opts.internalnorm(@. abs(Est)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol))
+    atmp = calculate_residuals(Est, uprev, u, integrator.opts.abstol,
+                               integrator.opts.reltol)
+    integrator.EEst = integrator.opts.internalnorm(atmp)
   end
 
+  integrator.fsallast = z./dt
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
+  cache.ηold = η
+  cache.newton_iters = iter
   integrator.u = u
 end
 
-function initialize!(integrator,cache::TRBDF2Cache,f=integrator.f)
+function initialize!(integrator, cache::TRBDF2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
 end
 
-@muladd function perform_step!(integrator,cache::TRBDF2Cache,f=integrator.f)
-  @unpack t,dt,uprev,u = integrator
-  @unpack uf,du1,uᵧ,Δzᵧ,Δz,zprev,zᵧ,z,k,J,W,jac_config,est = cache
+@muladd function perform_step!(integrator, cache::TRBDF2Cache, repeat_step=false)
+  @unpack t,dt,uprev,u,f = integrator
+  @unpack uf,du1,uᵧ,Δzᵧ,Δz,zprev,zᵧ,z,k,J,W,jac_config,est,κ,tol = cache
   mass_matrix = integrator.sol.prob.mass_matrix
 
-  uf.t = t
+  # Precalculations
+  # -> move constants to cache?
   γ = 2 - sqrt(2)
   ω = sqrt(2)/4
   d = γ/2
 
-  b1 = ω
-  bhat1 = (1-ω)/3
-  b2 = ω
-  bhat2 = (3ω + 1)/3
-  b3 = d
-  bhat3 = d/3
+  a1 = -sqrt(2)/2
+  a2 = 1 + sqrt(2)/2
+
+  c1 = γ/4
+  c2 = a2/2
+
+  # b1 = ω
+  # bhat1 = (1-ω)/3
+  # b2 = ω
+  # bhat2 = (3ω + 1)/3
+  # b3 = d
+  # bhat3 = d/3
+  btilde1 = (1-sqrt(2))/3
+  btilde2 = 1/3
+  btilde3 = (sqrt(2)-2)/3
+
+  κtol = κ*tol # save in cache instead of κ and tol?
 
   γdt = γ*dt
-  κ = cache.κ
-  tol = cache.tol
+  ddt = d*dt
 
   if has_invW(f)
-    f(Val{:invW},t,uprev,dt*d,W) # W == inverse W
+    # skip calculation of inv(W) if step is repeated
+    !repeat_step && f(Val{:invW},t,uprev,ddt,W) # W == inverse W
   else
-    if !integrator.last_stepfail && cache.newton_iters == 1 && cache.ηold < integrator.alg.new_jac_conv_bound
+    # skip calculation of J if step is repeated
+    if repeat_step || (!integrator.last_stepfail && cache.newton_iters == 1 && cache.ηold < integrator.alg.new_jac_conv_bound)
       new_jac = false
     else # Compute a new Jacobian
       new_jac = true
       if has_jac(f)
         f(Val{:jac},t,uprev,J)
       else
+        uf.t = t
         if alg_autodiff(integrator.alg)
           ForwardDiff.jacobian!(J,uf,vec(du1),vec(uprev),jac_config)
         else
@@ -676,9 +679,9 @@ end
         end
       end
     end
-    if integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps()
+    # skip calculation of W if step is repeated
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
       new_W = true
-      ddt = d*dt
       for j in 1:length(u), i in 1:length(u)
           @inbounds W[i,j] = mass_matrix[i,j]-ddt*J[i,j]
       end
@@ -687,11 +690,14 @@ end
     end
   end
 
+  # TODO: Add extrapolant initial guess
   @. zprev = dt*integrator.fsalfirst
+
+  ##### Solve Trapezoid Step
+
   @. zᵧ = zprev
   iter = 1
-
-  @. uᵧ = (uprev + d*zprev) + d*zᵧ
+  @. uᵧ = uprev + γ*zprev
   f(t+γdt,uᵧ,k)
   @. k = dt*k - zᵧ
   if has_invW(f)
@@ -700,21 +706,15 @@ end
     integrator.alg.linsolve(vec(Δzᵧ),W,vec(k),new_W)
   end
   ndz = integrator.opts.internalnorm(Δzᵧ)
-  @. zᵧ = zᵧ + Δzᵧ
-
-  @. uᵧ = (uprev + d*zprev) + d*zᵧ
+  zᵧ .+= Δzᵧ
 
   η = max(cache.ηold,eps(first(u)))^(0.8)
-  if integrator.success_iter > 0
-    do_newton = (η*ndz > κ*tol)
-  else
-    do_newton = true
-  end
+  do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
     iter += 1
-    @. uᵧ = (uprev + d*zprev) + d*zᵧ
+    @. uᵧ += d*Δzᵧ
     f(t+γdt,uᵧ,k)
     @. k = dt*k - zᵧ
     if has_invW(f)
@@ -725,13 +725,13 @@ end
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(Δzᵧ)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
-    @. zᵧ = zᵧ + Δzᵧ
+    do_newton = (η*ndz > κtol)
+    zᵧ .+= Δzᵧ
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -739,16 +739,13 @@ end
     return
   end
 
-  @. uᵧ = (uprev + d*zprev) + d*zᵧ
-
   ################################## Solve BDF2 Step
 
   ### Initial Guess From Shampine
-  a1 = (1.5 + sqrt(2)); a2 = (2.5 + 2sqrt(2)); a3 = (6 + 4.5sqrt(2))
-  @. z = a1*zprev + a2*zᵧ - a3*(uᵧ - uprev)
-  iter = 1
+  @. z = a1*zprev + a2*zᵧ
 
-  @. u = (uprev + ω*zprev + ω*zᵧ) + d*z
+  iter = 1
+  @. u = uprev + c1*zprev + c2*zᵧ
   f(t+dt,u,k)
   @. k = dt*k - z
   if has_invW(f)
@@ -757,14 +754,15 @@ end
     integrator.alg.linsolve(vec(Δz),W,vec(k),false)
   end
   ndz = integrator.opts.internalnorm(Δz)
-  @. z = z + Δz
+  z .+= Δz
 
   η = max(η,eps(first(u)))^(0.8)
-  do_newton = (η*ndz > κ*tol)
+  do_newton = (η*ndz > κtol)
 
   fail_convergence = false
   while (do_newton || iter < integrator.alg.min_newton_iter) && iter < integrator.alg.max_newton_iter
-    @. u = (uprev + ω*zprev + ω*zᵧ) + d*z
+    iter += 1
+    @. u += d*Δz
     f(t+dt,u,k)
     @. k = dt*k - z
     if has_invW(f)
@@ -775,13 +773,13 @@ end
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(Δz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κ*tol
+    if θ > 1 || ndz*(θ^(integrator.alg.max_newton_iter - iter)/(1-θ)) > κtol
       fail_convergence = true
       break
     end
     η = θ/(1-θ)
-    do_newton = (η*ndz > κ*tol)
-    @. z = z + Δz
+    do_newton = (η*ndz > κtol)
+    z .+= Δz
   end
 
   if (iter >= integrator.alg.max_newton_iter && do_newton) || fail_convergence
@@ -789,14 +787,12 @@ end
     return
   end
 
-  @. u = (uprev + ω*zprev + ω*zᵧ) + d*z
+  @. u += d*Δz
 
   ################################### Finalize
 
-
   if integrator.opts.adaptive
-    be1 = (bhat1-b1); be2 = (bhat2-b2); be3 = (bhat3-b3)
-    @. est = be1*zprev + be2*zᵧ + be3*z
+    @. est = btilde1*zprev + btilde2*zᵧ + btilde3*z
     if integrator.alg.smooth_est # From Shampine
       if has_invW(f)
         A_mul_B!(vec(k),W,vec(est))
@@ -806,9 +802,8 @@ end
     else
       k .= est
     end
-    @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      est[i] = abs(k[i])/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
-    end
+    # does not work with units - additional unitless array required!
+    calculate_residuals!(est, k, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(est)
   end
 


### PR DESCRIPTION
Again this updates calculation of error estimates and function arguments. However, this PR might need a more careful inspection since I also tried to reduce the number of calculations and therefore I introduced some new variables, especially in TRBDF2. The SDIRK integrators could be further improved, I guess, by saving `κ*tol` instead of both `κ` and `tol` in the cache (at least in `perform_steps!` only the product is needed) and by saving all constants of TRPBDF2 in a tableau. This is not part of this PR yet, but could be made an additional commit. I hope I didn't introduce any floating point issues by these simplifications.

This PR should hopefully also address https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/134, however, I'm not sure whether https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/139 still remains an issue.

I compared these updated methods to the master branch with the ROBER benchmark for high tolerances:

master
![figure_1_sdirk_master](https://user-images.githubusercontent.com/26102/29173559-f7542ec2-7de3-11e7-95bb-a80308a6f1e3.png)

PR
![figure_1_sdirk_pr](https://user-images.githubusercontent.com/26102/29173570-01df2ed2-7de4-11e7-93cd-4bdd4aff476a.png)

The plots are very similar apart from the Trapezoid curves which I don't understand.