### PR TITLE
Correct divided differences

### DIFF
--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -1,10 +1,12 @@
-struct LinearImplicitEulerCache{uType,rateType,J} <: OrdinaryDiffEqMutableCache
+struct LinearImplicitEulerCache{uType,rateType,J,uNoUnitsType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
   fsalfirst::rateType
   W::J
   k::rateType
+  tmp::uType
+  atmp::uNoUnitsType
 end
 
 u_cache(c::LinearImplicitEulerCache)    = (c.uprev2,c.z,c.dz)
@@ -14,7 +16,8 @@ function alg_cache(alg::LinearImplicitEuler,u,rate_prototype,uEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{true}})
   W = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
   k = zeros(rate_prototype); fsalfirst = zeros(rate_prototype)
-  LinearImplicitEulerCache(u,uprev,uprev2,fsalfirst,W,k)
+  tmp = similar(u); atmp = similar(u,uEltypeNoUnits)
+  LinearImplicitEulerCache(u,uprev,uprev2,fsalfirst,W,k,tmp,atmp)
 end
 
 struct LinearImplicitEulerConstantCache <: OrdinaryDiffEqConstantCache

--- a/src/integrators/linear_integrators.jl
+++ b/src/integrators/linear_integrators.jl
@@ -1,7 +1,7 @@
-function initialize!(integrator,cache::LinearImplicitEulerConstantCache,f=integrator.f)
+function initialize!(integrator, cache::LinearImplicitEulerConstantCache)
   integrator.kshortsize = 2
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -9,7 +9,7 @@ function initialize!(integrator,cache::LinearImplicitEulerConstantCache,f=integr
   integrator.k[2] = integrator.fsallast
 end
 
-function perform_step!(integrator,cache::LinearImplicitEulerConstantCache,f=integrator.f)
+@muladd function perform_step!(integrator, cache::LinearImplicitEulerConstantCache, repeat_step=false)
   @unpack t,dt,uprev,u,k = integrator
 
   L = update_coefficients(integrator.f,t+dt,u)
@@ -26,12 +26,21 @@ function perform_step!(integrator,cache::LinearImplicitEulerConstantCache,f=inte
   u = W\k
 
   if integrator.opts.adaptive && integrator.success_iter > 0
-    # Use 2rd divided differences a la SPICE and Shampine
+    # local truncation error (LTE) bound by dt^2/2*max|y''(t)|
+    # use 2nd divided differences (DD) a la SPICE and Shampine
+
+    # TODO: check numerical stability
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
-    DD3 = ((u - uprev)/((dt)*(t+dt-tprev)) + (uprev-uprev2)/((t-tprev)*(t+dt-tprev)))
-    dEst = (dt^2)*abs(DD3/6)
-    integrator.EEst = dEst/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
+
+    dt1 = dt*(t+dt-tprev)
+    dt2 = (t-tprev)*(t+dt-tprev)
+    c = 7/12 # default correction factor in SPICE (LTE overestimated by DD)
+    r = c*dt^2 # by mean value theorem 2nd DD equals y''(s)/2 for some s
+
+    tmp = @. r*abs((u - uprev)/dt1 - (uprev - uprev2)/dt2)
+    atmp = calculate_residuals(tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
+    integrator.EEst = integrator.opts.internalnorm(atmp)
   else
     integrator.EEst = 1
   end
@@ -39,28 +48,26 @@ function perform_step!(integrator,cache::LinearImplicitEulerConstantCache,f=inte
   integrator.fsallast = f(t+dt,u)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  @pack integrator = t,dt,u
-end#
+  integrator.u = u
+end
 
-function initialize!(integrator,cache::LinearImplicitEulerCache,f=integrator.f)
+function initialize!(integrator, cache::LinearImplicitEulerCache)
   integrator.kshortsize = 2
-  @unpack k,fsalfirst = cache
-  integrator.fsalfirst = fsalfirst
-  integrator.fsallast = k
+  integrator.fsalfirst = cache.fsalfirst
+  integrator.fsallast = cache.k
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
 end
 
-function perform_step!(integrator,cache::LinearImplicitEulerCache,f=integrator.f)
+@muladd function perform_step!(integrator, cache::LinearImplicitEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u = integrator
-  @unpack W,k = cache
+  @unpack W,k,tmp,atmp = cache
   mass_matrix = integrator.sol.prob.mass_matrix
 
   L = integrator.f
   update_coefficients!(L,t+dt,u)
-
 
   if typeof(L) <: AbstractDiffEqLinearOperator
 
@@ -71,8 +78,6 @@ function perform_step!(integrator,cache::LinearImplicitEulerCache,f=integrator.f
           @inbounds W[i,j] = @muladd mass_matrix[i,j]-dt*L[i,j]
       end
       k .= uprev # + B
-      integrator.alg.linsolve(vec(u),W,vec(k),true)
-
   else # Must be a DiffEqAffineOperator
 
       # Of the form u' = A(t)u + B(t)
@@ -84,41 +89,44 @@ function perform_step!(integrator,cache::LinearImplicitEulerCache,f=integrator.f
           @inbounds W[i,j] = @muladd mass_matrix[i,j]-dt*A[i,j]
       end
       @. k = uprev + dt*B
-      integrator.alg.linsolve(vec(u),W,vec(k),true)
   end
 
+  integrator.alg.linsolve(vec(u), W, vec(k), true)
+
   if integrator.opts.adaptive && integrator.success_iter > 0
-    # Use 2rd divided differences a la SPICE and Shampine
+    # local truncation error (LTE) bound by dt^2/2*max|y''(t)|
+    # use 2nd divided differences (DD) a la SPICE and Shampine
+
+    # TODO: check numerical stability
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
+
     dt1 = (dt)*(t+dt-tprev)
     dt2 = (t-tprev)*(t+dt-tprev)
-    @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds DD3 = (u[i] - uprev[i])/dt1 + (uprev[i]-uprev2[i])/dt2
-      dEst = (dt^2)*abs(DD3)/6
-      @inbounds k[i] = dEst/(atol+max(abs(uprev[i]),abs(u[i]))*rtol)
-    end
-    integrator.EEst = integrator.opts.internalnorm(k)
+    c = 7/12 # default correction factor in SPICE (LTE overestimated by DD)
+    r = c*dt^2 # by mean value theorem 2nd DD equals y''(s)/2 for some s
+
+    @. tmp = r*abs((u - uprev)/dt1 - (uprev - uprev2)/dt2)
+    calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
+    integrator.EEst = integrator.opts.internalnorm(atmp)
   else
     integrator.EEst = 1
   end
 
   f(t+dt,u,integrator.fsallast)
-  @pack integrator = t,dt,u
 end
 
-function initialize!(integrator,cache::MidpointSplittingCache,f=integrator.f)
+function initialize!(integrator, cache::MidpointSplittingCache)
   integrator.kshortsize = 2
-  @unpack k,fsalfirst = cache
-  integrator.fsalfirst = fsalfirst
-  integrator.fsallast = k
+  integrator.fsalfirst = cache.fsalfirst
+  integrator.fsallast = cache.k
   integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
 end
 
-function perform_step!(integrator,cache::MidpointSplittingCache,f=integrator.f)
+function perform_step!(integrator, cache::MidpointSplittingCache, repeat_step=false)
   @unpack t,dt,uprev,u = integrator
   @unpack W,k,tmp = cache
   mass_matrix = integrator.sol.prob.mass_matrix
@@ -143,5 +151,4 @@ function perform_step!(integrator,cache::MidpointSplittingCache,f=integrator.f)
   end
 
   f(t+dt,u,integrator.fsallast)
-  @pack integrator = t,dt,u
 end

--- a/src/integrators/sdirk_integrators.jl
+++ b/src/integrators/sdirk_integrators.jl
@@ -75,17 +75,19 @@ end
   cache.newton_iters = iter
 
   if integrator.opts.adaptive && integrator.success_iter > 0
-    # Use 2rd divided differences a la SPICE and Shampine
+    # local truncation error (LTE) bound by dt^2/2*max|y''(t)|
+    # use 2nd divided differences (DD) a la SPICE and Shampine
 
-    # TODO: check mathematical correctness and numerical stability
+    # TODO: check numerical stability
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
 
     dt1 = dt*(t+dt-tprev)
     dt2 = (t-tprev)*(t+dt-tprev)
-    r = dt^2/6
+    c = 7/12 # default correction factor in SPICE (LTE overestimated by DD)
+    r = c*dt^2 # by mean value theorem 2nd DD equals y''(s)/2 for some s
 
-    tmp = @. r*abs((u - uprev)/dt1 + (uprev - uprev2)/dt2)
+    tmp = @. r*abs((u - uprev)/dt1 - (uprev - uprev2)/dt2)
     atmp = calculate_residuals(tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   else
@@ -217,17 +219,19 @@ end
   cache.newton_iters = iter
 
   if integrator.opts.adaptive && integrator.success_iter > 0
-    # Use 2rd divided differences a la SPICE and Shampine
+    # local truncation error (LTE) bound by dt^2/2*max|y''(t)|
+    # use 2nd divided differences (DD) a la SPICE and Shampine
 
-    # TODO: check mathematical correctness and numerical stability
+    # TODO: check numerical stability
     uprev2 = integrator.uprev2
     tprev = integrator.tprev
 
     dt1 = dt*(t+dt-tprev)
     dt2 = (t-tprev)*(t+dt-tprev)
-    r = dt^2/6
+    c = 7/12 # default correction factor in SPICE (LTE overestimated by DD)
+    r = c*dt^2 # by mean value theorem 2nd DD equals y''(s)/2 for some s
 
-    @. tmp = r*abs((u - uprev)/dt1 + (uprev - uprev2)/dt2)
+    @. tmp = r*abs((u - uprev)/dt1 - (uprev - uprev2)/dt2)
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   else
@@ -316,44 +320,6 @@ end
 
   cache.ηold = η
   cache.newton_iters = iter
-
-  #=
-  if integrator.opts.adaptive
-    if integrator.iter > 2
-      # Use 3rd divided differences a la SPICE and Shampine
-
-      # TODO: check mathematical correctness and numerical stability
-      uprev2 = integrator.uprev2
-      tprev = integrator.tprev
-      uprev3 = cache.uprev3
-      tprev2 = cache.tprev2
-
-      dt1 = dt*(t+dt-tprev)
-      dt2 = (t-tprev)*(t+dt-tprev)
-      dt3 = (t-tprev)*(t-tprev2)
-      dt4 = (tprev-tprev2)*(t-tprev2)
-      dt5 = t+dt-tprev2
-      r = dt^3/12
-
-      # tmp = @. r*abs(((u - uprev)/dt1 + (uprev - uprev2)/dt2) - ((uprev - uprev2)/dt3 + (uprev2 - uprev3)/dt4)/dt5)
-      DD31 = @. (u - uprev)/dt1 + (uprev - uprev2)/dt2
-      DD30 = @. (uprev - uprev2)/dt3 + (uprev2 - uprev3)/dt4
-      tmp = @. r*abs((DD31 - DD30)/dt5)
-      atmp = calculate_residuals(tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
-      integrator.EEst = integrator.opts.internalnorm(atmp)
-      if integrator.EEst <= 1
-        cache.uprev3 = uprev2
-        cache.tprev2 = tprev
-      end
-    elseif integrator.success_iter > 0
-      integrator.EEst = 1
-      cache.uprev3 = integrator.uprev2
-      cache.tprev2 = integrator.tprev
-    else
-      integrator.EEst = 1
-    end
-  end
-  =#
 
   integrator.fsallast = f(t+dt,u)
   integrator.k[1] = integrator.fsalfirst
@@ -483,46 +449,6 @@ end
   cache.ηold = η
   cache.newton_iters = iter
 
-  #=
-  if integrator.opts.adaptive
-    if integrator.iter > 2
-      # Use 3rd divided differences a la SPICE and Shampine
-
-      # TODO: check mathematical correctness and numerical stability
-      uprev2 = integrator.uprev2
-      tprev = integrator.tprev
-      uprev3 = cache.uprev3
-      tprev2 = cache.tprev2
-
-      dt1 = dt*(t+dt-tprev)
-      dt2 = (t-tprev)*(t+dt-tprev)
-      dt3 = (t-tprev)*(t-tprev2)
-      dt4 = (tprev-tprev2)*(t-tprev2)
-      dt5 = t+dt-tprev2
-      r = dt^3/12
-
-      # @. tmp = r*abs(((u - uprev)/dt1 + (uprev - uprev2)/dt2) - ((uprev - uprev2)/dt3 + (uprev2 - uprev3)/dt4)/dt5)
-      @inbounds for i in eachindex(u)
-        DD31 = (u[i] - uprev[i])/dt1 + (uprev[i] - uprev2[i])/dt2
-        DD30 = (uprev[i] - uprev2[i])/dt3 + (uprev2[i] - uprev3[i])/dt4
-        tmp[i] = r*abs((DD31 - DD30)/dt5)
-      end
-      calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
-      integrator.EEst = integrator.opts.internalnorm(atmp)
-      if integrator.EEst <= 1
-        copy!(cache.uprev3,uprev2)
-        cache.tprev2 = tprev
-      end
-    elseif integrator.success_iter > 0
-      integrator.EEst = 1
-      copy!(cache.uprev3,integrator.uprev2)
-      cache.tprev2 = integrator.tprev
-    else
-      integrator.EEst = 1
-    end
-  end
-  =#
-
   f(t+dt,u,integrator.fsallast)
 end
 
@@ -604,9 +530,10 @@ end
 
   if integrator.opts.adaptive
     if integrator.iter > 2
-      # Use 3rd divided differences a la SPICE and Shampine
+      # local truncation error (LTE) bound by dt^3/12*max|y'''(t)|
+      # use 3rd divided differences (DD) a la SPICE and Shampine
 
-      # TODO: check mathematical correctness and numerical stability
+      # TODO: check numerical stability
       uprev2 = integrator.uprev2
       tprev = integrator.tprev
       uprev3 = cache.uprev3
@@ -617,11 +544,12 @@ end
       dt3 = (t-tprev)*(t-tprev2)
       dt4 = (tprev-tprev2)*(t-tprev2)
       dt5 = t+dt-tprev2
-      r = dt^3/12
+      c = 7/12 # default correction factor in SPICE (LTE overestimated by DD)
+      r = c*dt^3/2 # by mean value theorem 3rd DD equals y'''(s)/6 for some s
 
-      # tmp = @. r*abs(((u - uprev)/dt1 + (uprev - uprev2)/dt2) - ((uprev - uprev2)/dt3 + (uprev2 - uprev3)/dt4)/dt5)
-      DD31 = @. (u - uprev)/dt1 + (uprev - uprev2)/dt2
-      DD30 = @. (uprev - uprev2)/dt3 + (uprev2 - uprev3)/dt4
+      # tmp = @. r*abs(((u - uprev)/dt1 - (uprev - uprev2)/dt2) - ((uprev - uprev2)/dt3 - (uprev2 - uprev3)/dt4)/dt5)
+      DD31 = @. (u - uprev)/dt1 - (uprev - uprev2)/dt2
+      DD30 = @. (uprev - uprev2)/dt3 - (uprev2 - uprev3)/dt4
       tmp = @. r*abs((DD31 - DD30)/dt5)
       atmp = calculate_residuals(tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
       integrator.EEst = integrator.opts.internalnorm(atmp)
@@ -763,9 +691,10 @@ end
 
   if integrator.opts.adaptive
     if integrator.iter > 2
-      # Use 3rd divided differences a la SPICE and Shampine
+      # local truncation error (LTE) bound by dt^3/12*max|y'''(t)|
+      # use 3rd divided differences (DD) a la SPICE and Shampine
 
-      # TODO: check mathematical correctness and numerical stability
+      # TODO: check numerical stability
       uprev2 = integrator.uprev2
       tprev = integrator.tprev
       uprev3 = cache.uprev3
@@ -776,12 +705,13 @@ end
       dt3 = (t-tprev)*(t-tprev2)
       dt4 = (tprev-tprev2)*(t-tprev2)
       dt5 = t+dt-tprev2
-      r = dt^3/12
+      c = 7/12 # default correction factor in SPICE (LTE overestimated by DD)
+      r = c*dt^3/2 # by mean value theorem 3rd DD equals y'''(s)/6 for some s
 
-      # @. tmp = r*abs(((u - uprev)/dt1 + (uprev - uprev2)/dt2) - ((uprev - uprev2)/dt3 + (uprev2 - uprev3)/dt4)/dt5)
+      # @. tmp = r*abs(((u - uprev)/dt1 - (uprev - uprev2)/dt2) - ((uprev - uprev2)/dt3 - (uprev2 - uprev3)/dt4)/dt5)
       @inbounds for i in eachindex(u)
-        DD31 = (u[i] - uprev[i])/dt1 + (uprev[i] - uprev2[i])/dt2
-        DD30 = (uprev[i] - uprev2[i])/dt3 + (uprev2[i] - uprev3[i])/dt4
+        DD31 = (u[i] - uprev[i])/dt1 - (uprev[i] - uprev2[i])/dt2
+        DD30 = (uprev[i] - uprev2[i])/dt3 - (uprev2[i] - uprev3[i])/dt4
         tmp[i] = r*abs((DD31 - DD30)/dt5)
       end
       calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol)


### PR DESCRIPTION
This PR changes divided additions to divided differences. Moreover, I tried to make it clear how local truncation errors can be estimated by divided differences and that overestimation is handled with a correction factor. This correction factor was previously always `1/6` and is now set to `7/12` which is the default value in SPICE.

I did some comparisons of affected methods with a non-stiff Van der Pol equation, taken from https://www.mathworks.com/help/matlab/math/solve-nonstiff-odes.html#zmw57dd0e27293:

## master
![nonstiffpol_master](https://user-images.githubusercontent.com/26102/29733200-5677c210-89ec-11e7-92ee-947e42767251.png)

## PR (i.e. `c=7/12` from SPICE)
![nonstiffpol_pr_spice](https://user-images.githubusercontent.com/26102/29733201-5e3f5508-89ec-11e7-842d-873209210f6c.png)

## PR without correction factor (i.e. `c=1`)
![nonstiffpol_pr_nocorrection](https://user-images.githubusercontent.com/26102/29733221-6b90778c-89ec-11e7-88c2-f6b2d43878de.png)

## PR with correction factor of master (i.e. `c=1/6`)
![nonstiffpol_pr](https://user-images.githubusercontent.com/26102/29733259-9afeb48e-89ec-11e7-947f-ed67eb3e1b62.png)