### PR TITLE
Improve save_idxs

### DIFF
--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -108,7 +108,7 @@ function ode_interpolation(tvals,id,idxs,deriv)
   if typeof(idxs) <: Number
     vals = Vector{eltype(first(timeseries))}(length(tvals))
   elseif typeof(idxs) <: AbstractArray
-    vals = Vector{Array{eltype(first(timeseries)),dims(idxs)}}(length(tvals))
+    vals = Vector{Array{eltype(first(timeseries)),ndims(idxs)}}(length(tvals))
   else
     vals = Vector{eltype(timeseries)}(length(tvals))
   end

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -107,8 +107,8 @@ function ode_interpolation(tvals,id,idxs,deriv)
   tdir*tvals[idx[1]] < tdir*ts[1] && error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
   if typeof(idxs) <: Number
     vals = Vector{eltype(first(timeseries))}(length(tvals))
-  elseif typeof(idxs) <: AbstractVector
-     vals = Vector{Vector{eltype(first(timeseries))}}(length(tvals))
+  elseif typeof(idxs) <: AbstractArray
+    vals = Vector{Array{eltype(first(timeseries)),dims(idxs)}}(length(tvals))
   else
     vals = Vector{eltype(timeseries)}(length(tvals))
   end

--- a/src/dense/interpolants.jl
+++ b/src/dense/interpolants.jl
@@ -37,23 +37,27 @@ Hairer Norsett Wanner Solving Ordinary Differential Euations I - Nonstiff Proble
 @inline @muladd function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{DP5Cache,DP5ThreadedCache},idxs,T::Type{Val{0}})
   Θ1 = 1-Θ
   if out == nothing
-    return @. y₀[idxs] + dt*Θ*(k[1][idxs]+Θ1*(k[2][idxs]+Θ*(k[3][idxs]+Θ1*k[4][idxs])))
+    if idxs == nothing
+      return @. y₀ + dt*Θ*(k[1]+Θ1*(k[2]+Θ*(k[3]+Θ1*k[4])))
+    else
+      return @. y₀[idxs] + dt*Θ*(k[1][idxs]+Θ1*(k[2][idxs]+Θ*(k[3][idxs]+Θ1*k[4][idxs])))
+    end
   elseif idxs == nothing
-    #@. out = y₀ + dt*Θ*(k[1]+Θ1*(k[2]+Θ*(k[3]+Θ1*k[4])))
-    @inbounds for i in eachindex(out)
-      out[i] = y₀[i] + dt*Θ*(k[1][i]+Θ1*(k[2][i]+Θ*(k[3][i]+Θ1*k[4][i])))
-    end
+    @. out = y₀ + dt*Θ*(k[1]+Θ1*(k[2]+Θ*(k[3]+Θ1*k[4])))
   else
-    #@views @. out = y₀[idxs] + dt*Θ*(k[1][idxs]+Θ1*(k[2][idxs]+Θ*(k[3][idxs]+Θ1*k[4][idxs])))
-    @inbounds for (j,i) in enumerate(idxs)
-      out[j] = y₀[i] + dt*Θ*(k[1][i]+Θ1*(k[2][i]+Θ*(k[3][i]+Θ1*k[4][i])))
-    end
+    @views @. out = y₀[idxs] + dt*Θ*(k[1][idxs]+Θ1*(k[2][idxs]+Θ*(k[3][idxs]+Θ1*k[4][idxs])))
   end
 end
 
 @inline @muladd function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{DP5Cache,DP5ThreadedCache},idxs,T::Type{Val{1}})
   if out == nothing
-    return k[1][idxs] + k[2][idxs]*(1 - 2*Θ) + Θ*(2*k[3][idxs] + 2*k[4][idxs] + Θ*(-3*k[3][idxs] - 6*k[4][idxs] + 4*k[4][idxs]*Θ))
+    if idxs == nothing
+      # return @. k[1] + k[2]*(1 - 2*Θ) + Θ*(2*k[3] + 2*k[4] + Θ*(-3*k[3] - 6*k[4] + 4*k[4]*Θ))
+      return k[1] + k[2]*(1 - 2*Θ) + Θ*(2*k[3] + 2*k[4] + Θ*(-3*k[3] - 6*k[4] + 4*k[4]*Θ))
+    else
+      # return @. k[1][idxs] + k[2][idxs]*(1 - 2*Θ) + Θ*(2*k[3][idxs] + 2*k[4][idxs] + Θ*(-3*k[3][idxs] - 6*k[4][idxs] + 4*k[4][idxs]*Θ))
+      return k[1][idxs] + k[2][idxs]*(1 - 2*Θ) + Θ*(2*k[3][idxs] + 2*k[4][idxs] + Θ*(-3*k[3][idxs] - 6*k[4][idxs] + 4*k[4][idxs]*Θ))
+    end
   elseif idxs == nothing
     #@. out = k[1] + k[2]*(1 - 2*Θ) + Θ*(2*k[3] + 2*k[4] + Θ*(-3*k[3] - 6*k[4] + 4*k[4]*Θ))
     @inbounds for i in eachindex(out)
@@ -95,7 +99,13 @@ end
 @inline @muladd function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{SSPRK22Cache,SSPRK33Cache,SSPRK432Cache},idxs,T::Type{Val{0}})
   Θ1 = 1-Θ
   if out == nothing
-    return @. (1-Θ^2)*y₀[idxs] + Θ^2*y₁[idxs] + Θ*(1-Θ)*dt*k[1][idxs]
+    if idxs == nothing
+      # return @. (1-Θ^2)*y₀ + Θ^2*y₁ + Θ*(1-Θ)*dt*k[1]
+      return (1-Θ^2)*y₀ + Θ^2*y₁ + Θ*(1-Θ)*dt*k[1]
+    else
+      # return @. (1-Θ^2)*y₀[idxs] + Θ^2*y₁[idxs] + Θ*(1-Θ)*dt*k[1][idxs]
+      return (1-Θ^2)*y₀[idxs] + Θ^2*y₁[idxs] + Θ*(1-Θ)*dt*k[1][idxs]
+    end
   elseif idxs == nothing
     #@. out = (1-Θ^2)*y₀ + Θ^2*y₁ + Θ*(1-Θ)*dt*k[1]
     @inbounds for i in eachindex(out)
@@ -112,7 +122,13 @@ end
 @inline @muladd function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{SSPRK22Cache,SSPRK33Cache,SSPRK432Cache},idxs,T::Type{Val{1}})
   Θ1 = 1-Θ
   if out == nothing
-    return @. -2Θ/dt*y₀[idxs] + 2Θ/dt*y₁[idxs] + (1-2Θ)*k[1][idxs]
+    if idxs == nothing
+      # return @. -2Θ/dt*y₀ + 2Θ/dt*y₁ + (1-2Θ)*k[1]
+      return -2Θ/dt*y₀ + 2Θ/dt*y₁ + (1-2Θ)*k[1]
+    else
+      # return @. -2Θ/dt*y₀[idxs] + 2Θ/dt*y₁[idxs] + (1-2Θ)*k[1][idxs]
+      return -2Θ/dt*y₀[idxs] + 2Θ/dt*y₁[idxs] + (1-2Θ)*k[1][idxs]
+    end
   elseif idxs == nothing
     #@. out = -2Θ/dt*y₀ + 2Θ/dt*y₁ + (1-2Θ)*k[1]
     @inbounds for i in eachindex(out)
@@ -144,7 +160,13 @@ Ch. Tsitouras
   b7Θ = @evalpoly(Θ, 0,   0, r72, r73, r74)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
+      return y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
+    else
+      # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ)
+      return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ)
+    end
   elseif idxs == nothing
     #@. out = y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
     @inbounds for i in eachindex(out)
@@ -170,7 +192,13 @@ end
   b7Θdiff = @evalpoly(Θ,   0, 2*r72, 3*r73, 4*r74)
 
   if out == nothing
-    return k[1][idxs]*b1Θdiff + k[2][idxs]*b2Θdiff + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff
+    if idxs == nothing
+      # return @. k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
+      return k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
+    else
+      # return @. k[1][idxs]*b1Θdiff + k[2][idxs]*b2Θdiff + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff
+      return k[1][idxs]*b1Θdiff + k[2][idxs]*b2Θdiff + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff
+    end
   elseif idxs == nothing
     #@. out = k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
     @inbounds for i in eachindex(out)
@@ -222,11 +250,12 @@ end
   b6Θdiff = @evalpoly(Θ,   0, 2*r62, 3*r63, 4*r64)
   b7Θdiff = @evalpoly(Θ,   0, 2*r72, 3*r73, 4*r74)
 
-  #@. k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
   if idxs == nothing
+    # return @. k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
     return k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff +
            k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
   else
+    # return @. k[1][idxs]*b1Θdiff + k[2][idxs]*b2Θdiff + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff
     return k[1][idxs]*b1Θdiff + k[2][idxs]*b2Θdiff + k[3][idxs]*b3Θdiff +
            k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff +
            k[7][idxs]*b7Θdiff
@@ -242,9 +271,9 @@ end
   b4Θ  = @evalpoly(Θ, 0, 0, -1, 1)
 
   if idxs == nothing
-    return y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
+    return @. y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
   else
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ +
+    return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ +
            k[4][idxs]*b4Θ)
   end
 end
@@ -258,16 +287,16 @@ end
   b4Θ  = @evalpoly(Θ, 0, 0, -1, 1)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ +
-           k[4][idxs]*b4Θ)
+    if idxs == nothing
+      return @. y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
+    else
+      return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ +
+                               k[4][idxs]*b4Θ)
+    end
   elseif idxs == nothing
-    @inbounds for i in eachindex(out)
-      out[i] = y₀[i] + dt*(k[1][i]*b1Θ  + k[2][i]*b2Θ + k[3][i]*b3Θ + k[4][i]*b4Θ)
-    end
+    @. out = y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
   else
-    @inbounds for (j,i) in enumerate(idxs)
-        out[j] = y₀[i] + dt*(k[1][i]*b1Θ  + k[2][i]*b2Θ + k[3][i]*b3Θ + k[4][i]*b4Θ)
-    end
+    @. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[2][idxs]*b2Θ + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ)
   end
 end
 
@@ -281,10 +310,13 @@ end
   b6Θ  = @evalpoly(Θ, 0, 0, r62, r63, r64)
 
   if idxs == nothing
+    # return @. y₀ + dt*(k[1]*b1Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
     return y₀ + dt*(k[1]*b1Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
   else
+    # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[3][idxs]*b3Θ +
+    #                          k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
     return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[3][idxs]*b3Θ +
-           k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
+                          k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
   end
 end
 
@@ -298,14 +330,24 @@ end
   b6Θ  = @evalpoly(Θ, 0, 0, r62, r63, r64)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
-           k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
+      return y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
+    else
+      # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+      #                          k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
+      return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+                            k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
+    end
   elseif idxs == nothing
+    # @. out = y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
     @inbounds for i in eachindex(out)
       out[i] = y₀[i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ +
-               k[5][i]*b5Θ + k[6][i]*b6Θ)
+                           k[5][i]*b5Θ + k[6][i]*b6Θ)
     end
   else
+    # @. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+    #                         k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
     @inbounds for (j,i) in enumerate(idxs)
         out[j] = y₀[i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ +
                  k[5][i]*b5Θ + k[6][i]*b6Θ)
@@ -325,12 +367,17 @@ end
   b8Θ  = @evalpoly(Θ, 0, 0, r82, r83, r84, r85)
 
   if idxs == nothing
-    return y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ
-           + k[7]*b7Θ + k[8]*b8Θ)
+    # return @. y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+    #                    k[7]*b7Θ + k[8]*b8Θ)
+    return y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+                    k[7]*b7Θ + k[8]*b8Θ)
   else
+    # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+    #                          k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
+    #                          k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
     return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
-           k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
-           k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
+                          k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
+                          k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
   end
 end
 
@@ -346,15 +393,30 @@ end
   b8Θ  = @evalpoly(Θ, 0, 0, r82, r83, r84, r85)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
-           k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
-           k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+      #                    k[7]*b7Θ + k[8]*b8Θ)
+      return y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+                      k[7]*b7Θ + k[8]*b8Θ)
+    else
+      # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+      #                          k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
+      #                          k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
+      return y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+                            k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
+                            k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
+    end
   elseif idxs == nothing
+    # @. out = y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+    #                          k[7]*b7Θ + k[8]*b8Θ)
     @inbounds for i in eachindex(out)
       out[i] = y₀[i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ +
-               k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ + k[8][i]*b8Θ)
+                           k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ + k[8][i]*b8Θ)
     end
   else
+    # @. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+    #                                k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ +
+    #                                k[7][idxs]*b7Θ + k[8][idxs]*b8Θ)
     @inbounds for (j,i) in enumerate(idxs)
         out[j] = y₀[i] + dt*(k[1][i]*b1Θ + k[3][i]*b3Θ + k[4][i]*b4Θ +
                  k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ + k[8][i]*b8Θ)
@@ -379,14 +441,17 @@ Coefficients taken from RKSuite
   b10Θ = @evalpoly(Θ, 0, 0, r102, r103, r104, r105, r106)
   b11Θ = @evalpoly(Θ, 0, 0, r112, r113, r114, r115, r116)
 
-  #@. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
   if idxs == nothing
+    # return @. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
     return y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ +
-           k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
+                                k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
   else
+    # return @. y₀[idxs] + dt*Θ*k[1][idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+    #                                            k[4][idxs]*b4Θ  + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ +
+    #                                            k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ)
     return y₀[idxs] + dt*Θ*k[1][idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
-           k[4][idxs]*b4Θ  + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ +
-           k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ)
+                                            k[4][idxs]*b4Θ  + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ +
+                                            k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ)
   end
 end
 
@@ -403,12 +468,16 @@ end
   b10Θdiff = @evalpoly(Θ, 0, 2*r102, 3*r103, 4*r104, 5*r105, 6*r106)
   b11Θdiff = @evalpoly(Θ, 0, 2*r112, 3*r113, 4*r114, 5*r115, 6*r116)
 
-  #@. k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
   if idxs == nothing
+    # return @. k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
     return k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff +
            k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff +
            k[10]*b10Θdiff + k[11]*b11Θdiff
   else
+    # return @. k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff +
+    #     k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff +
+    #     k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff +
+    #     k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff
     return k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff +
            k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff +
            k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff +
@@ -434,7 +503,13 @@ Coefficients taken from RKSuite
   b11Θ = @evalpoly(Θ, 0, 0, r112, r113, r114, r115, r116)
 
   if out == nothing
-    return y₀[idxs] + dt*Θ*k[1][idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ  + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
+      return y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
+    else
+      # return @. y₀[idxs] + dt*Θ*k[1][idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ  + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ)
+      return y₀[idxs] + dt*Θ*k[1][idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ + k[4][idxs]*b4Θ  + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ)
+    end
   elseif idxs == nothing
     #@. out = y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
     @inbounds for i in eachindex(out)
@@ -463,7 +538,13 @@ end
   b11Θdiff = @evalpoly(Θ, 0, 2*r112, 3*r113, 4*r114, 5*r115, 6*r116)
 
   if out == nothing
-    return k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff
+    if idxs == nothing
+      # return @. k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
+      return k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
+    else
+      # return @. k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff
+      return k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff + k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff
+    end
   elseif idxs == nothing
     #@. out = k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
     @inbounds for i in eachindex(out)
@@ -524,7 +605,13 @@ end
   b12Θdiff = @evalpoly(Θ,    0, 2*r122, 3*r123, 4*r124, 5*r125, 6*r126)
 
   if out == nothing
-    return k[1][idxs]*b1Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff
+    if idxs == nothing
+      # return @. k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff
+      return k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff
+    else
+      # return @. k[1][idxs]*b1Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff
+      return k[1][idxs]*b1Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff
+    end
   elseif idxs == nothing
     #@. out = k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff
     @inbounds for i in eachindex(out)
@@ -679,14 +766,20 @@ end
   b16Θ = @evalpoly(Θ, 0,    0, r162, r163, r164, r165, r166, r167)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
+      return y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
+    else
+      # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ)
+      return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ)
+    end
   elseif idxs == nothing
-    #@. out = y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
+    # @. out = y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
     @inbounds for i in eachindex(out)
       out[i] = y₀[i] + dt*(k[1][i]*b1Θ + k[4][i]*b4Θ + k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ + k[8][i]*b8Θ + k[9][i]*b9Θ + k[11][i]*b11Θ + k[12][i]*b12Θ + k[13][i]*b13Θ + k[14][i]*b14Θ + k[15][i]*b15Θ + k[16][i]*b16Θ)
     end
   else
-    @views @. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ)
+    # @views @. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ)
     @inbounds for (j,i) in enumerate(idxs)
       out[j] = y₀[i] + dt*(k[1][i]*b1Θ + k[4][i]*b4Θ + k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ + k[8][i]*b8Θ + k[9][i]*b9Θ + k[11][i]*b11Θ + k[12][i]*b12Θ + k[13][i]*b13Θ + k[14][i]*b14Θ + k[15][i]*b15Θ + k[16][i]*b16Θ)
     end
@@ -711,7 +804,13 @@ end
   b16Θdiff = @evalpoly(Θ,    0, 2*r162, 3*r163, 4*r164, 5*r165, 6*r166, 7*r167)
 
   if out == nothing
-    return k[1][idxs]*b1Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[13][idxs]*b13Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[16][idxs]*b16Θdiff
+    if idxs == nothing
+      # return @. k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff
+      return k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff
+    else
+      # return @. k[1][idxs]*b1Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[13][idxs]*b13Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[16][idxs]*b16Θdiff
+      return k[1][idxs]*b1Θdiff + k[4][idxs]*b4Θdiff + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[13][idxs]*b13Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[16][idxs]*b16Θdiff
+    end
   elseif idxs == nothing
     #@. out = k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff
     @inbounds for i in eachindex(out)
@@ -824,7 +923,13 @@ end
   b21Θ = @evalpoly(Θ, 0,    0, r212, r213, r214, r215, r216, r217, r218)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ + k[17][idxs]*b17Θ + k[18][idxs]*b18Θ + k[19][idxs]*b19Θ + k[20][idxs]*b20Θ + k[21][idxs]*b21Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
+      return y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
+    else
+      # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ + k[17][idxs]*b17Θ + k[18][idxs]*b18Θ + k[19][idxs]*b19Θ + k[20][idxs]*b20Θ + k[21][idxs]*b21Θ)
+      return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[6][idxs]*b6Θ + k[7][idxs]*b7Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[16][idxs]*b16Θ + k[17][idxs]*b17Θ + k[18][idxs]*b18Θ + k[19][idxs]*b19Θ + k[20][idxs]*b20Θ + k[21][idxs]*b21Θ)
+    end
   elseif idxs == nothing
     #@. out = y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
     @inbounds for i in eachindex(out)
@@ -859,7 +964,13 @@ end
   b21Θdiff = @evalpoly(Θ,    0, 2*r212, 3*r213, 4*r214, 5*r215, 6*r216, 7*r217, 8*r218)
 
   if out == nothing
-    return k[1][idxs]*b1Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[16][idxs]*b16Θdiff + k[17][idxs]*b17Θdiff + k[18][idxs]*b18Θdiff + k[19][idxs]*b19Θdiff + k[20][idxs]*b20Θdiff + k[21][idxs]*b21Θdiff
+    if idxs == nothing
+      # return @. k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
+      return k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
+    else
+      # return @. k[1][idxs]*b1Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[16][idxs]*b16Θdiff + k[17][idxs]*b17Θdiff + k[18][idxs]*b18Θdiff + k[19][idxs]*b19Θdiff + k[20][idxs]*b20Θdiff + k[21][idxs]*b21Θdiff
+      return k[1][idxs]*b1Θdiff + k[6][idxs]*b6Θdiff + k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[16][idxs]*b16Θdiff + k[17][idxs]*b17Θdiff + k[18][idxs]*b18Θdiff + k[19][idxs]*b19Θdiff + k[20][idxs]*b20Θdiff + k[21][idxs]*b21Θdiff
+    end
   elseif idxs == nothing
     #@. out = k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
     @inbounds for i in eachindex(out)
@@ -986,7 +1097,13 @@ end
   b26Θ = @evalpoly(Θ, 0,    0, r262, r263, r264, r265, r266, r267, r268, r269)
 
   if out == nothing
-    return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[17][idxs]*b17Θ + k[18][idxs]*b18Θ + k[19][idxs]*b19Θ + k[20][idxs]*b20Θ + k[21][idxs]*b21Θ + k[22][idxs]*b22Θ + k[23][idxs]*b23Θ + k[24][idxs]*b24Θ + k[25][idxs]*b25Θ + k[26][idxs]*b26Θ)
+    if idxs == nothing
+      # return @. y₀ + dt*(k[1]*b1Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ + k[22]*b22Θ + k[23]*b23Θ + k[24]*b24Θ + k[25]*b25Θ + k[26]*b26Θ)
+      return y₀ + dt*(k[1]*b1Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ + k[22]*b22Θ + k[23]*b23Θ + k[24]*b24Θ + k[25]*b25Θ + k[26]*b26Θ)
+    else
+      # return @. y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[17][idxs]*b17Θ + k[18][idxs]*b18Θ + k[19][idxs]*b19Θ + k[20][idxs]*b20Θ + k[21][idxs]*b21Θ + k[22][idxs]*b22Θ + k[23][idxs]*b23Θ + k[24][idxs]*b24Θ + k[25][idxs]*b25Θ + k[26][idxs]*b26Θ)
+      return y₀[idxs] + dt*(k[1][idxs]*b1Θ + k[8][idxs]*b8Θ + k[9][idxs]*b9Θ + k[10][idxs]*b10Θ + k[11][idxs]*b11Θ + k[12][idxs]*b12Θ + k[13][idxs]*b13Θ + k[14][idxs]*b14Θ + k[15][idxs]*b15Θ + k[17][idxs]*b17Θ + k[18][idxs]*b18Θ + k[19][idxs]*b19Θ + k[20][idxs]*b20Θ + k[21][idxs]*b21Θ + k[22][idxs]*b22Θ + k[23][idxs]*b23Θ + k[24][idxs]*b24Θ + k[25][idxs]*b25Θ + k[26][idxs]*b26Θ)
+    end
   elseif idxs == nothing
     #@. out = y₀ + dt*(k[1]*b1Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ + k[22]*b22Θ + k[23]*b23Θ + k[24]*b24Θ + k[25]*b25Θ + k[26]*b26Θ)
     @inbounds for i in eachindex(out)
@@ -1024,7 +1141,13 @@ end
   b26Θdiff = @evalpoly(Θ,    0, 2*r262, 3*r263, 4*r264, 5*r265, 6*r266, 7*r267, 8*r268, 9*r269)
 
   if out == nothing
-    return k[1][idxs]*b1Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[13][idxs]*b13Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[17][idxs]*b17Θdiff + k[18][idxs]*b18Θdiff + k[19][idxs]*b19Θdiff + k[20][idxs]*b20Θdiff + k[21][idxs]*b21Θdiff + k[22][idxs]*b22Θdiff + k[23][idxs]*b23Θdiff + k[24][idxs]*b24Θdiff + k[25][idxs]*b25Θdiff + k[26][idxs]*b26Θdiff
+    if idxs == nothing
+      # return @. k[1]*b1Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff + k[22]*b22Θdiff + k[23]*b23Θdiff + k[24]*b24Θdiff + k[25]*b25Θdiff + k[26]*b26Θdiff
+      return k[1]*b1Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff + k[22]*b22Θdiff + k[23]*b23Θdiff + k[24]*b24Θdiff + k[25]*b25Θdiff + k[26]*b26Θdiff
+    else
+      # return @. k[1][idxs]*b1Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[13][idxs]*b13Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[17][idxs]*b17Θdiff + k[18][idxs]*b18Θdiff + k[19][idxs]*b19Θdiff + k[20][idxs]*b20Θdiff + k[21][idxs]*b21Θdiff + k[22][idxs]*b22Θdiff + k[23][idxs]*b23Θdiff + k[24][idxs]*b24Θdiff + k[25][idxs]*b25Θdiff + k[26][idxs]*b26Θdiff
+      return k[1][idxs]*b1Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff + k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff + k[12][idxs]*b12Θdiff + k[13][idxs]*b13Θdiff + k[14][idxs]*b14Θdiff + k[15][idxs]*b15Θdiff + k[17][idxs]*b17Θdiff + k[18][idxs]*b18Θdiff + k[19][idxs]*b19Θdiff + k[20][idxs]*b20Θdiff + k[21][idxs]*b21Θdiff + k[22][idxs]*b22Θdiff + k[23][idxs]*b23Θdiff + k[24][idxs]*b24Θdiff + k[25][idxs]*b25Θdiff + k[26][idxs]*b26Θdiff
+    end
   elseif idxs == nothing
     #@. out = k[1]*b1Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff + k[22]*b22Θdiff + k[23]*b23Θdiff + k[24]*b24Θdiff + k[25]*b25Θdiff + k[26]*b26Θdiff
     @inbounds for i in eachindex(out)
@@ -1083,7 +1206,13 @@ end
 @inline @muladd function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP8Cache,idxs,T::Type{Val{0}})
   Θ1 = 1-Θ
   if out == nothing
-    return y₀[idxs] + dt*Θ*(k[1][idxs] + Θ1*(k[2][idxs] + Θ*(k[3][idxs]+Θ1*(k[4][idxs] + Θ*(k[5][idxs] + Θ1*(k[6][idxs]+Θ*k[7][idxs]))))))
+    if idxs == nothing
+      # return @. y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
+      return y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
+    else
+      # return @. y₀[idxs] + dt*Θ*(k[1][idxs] + Θ1*(k[2][idxs] + Θ*(k[3][idxs]+Θ1*(k[4][idxs] + Θ*(k[5][idxs] + Θ1*(k[6][idxs]+Θ*k[7][idxs]))))))
+      return y₀[idxs] + dt*Θ*(k[1][idxs] + Θ1*(k[2][idxs] + Θ*(k[3][idxs]+Θ1*(k[4][idxs] + Θ*(k[5][idxs] + Θ1*(k[6][idxs]+Θ*k[7][idxs]))))))
+    end
   elseif idxs == nothing
     #@. out = y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
     @inbounds for i in eachindex(out)
@@ -1099,14 +1228,25 @@ end
 
 @inline @muladd function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP8Cache,idxs,T::Type{Val{1}})
   if out == nothing
-    b1diff = k[1][idxs] + k[2][idxs]
-    b2diff = -2*k[2][idxs] + 2*k[3][idxs] + 2*k[4][idxs]
-    b3diff = -3*k[3][idxs] - 6*k[4][idxs] + 3*k[5][idxs] + 3*k[6][idxs]
-    b4diff = 4*k[4][idxs] - 8*k[5][idxs] - 12*k[6][idxs] + 4*k[7][idxs]
-    b5diff = 5*k[5][idxs] + 15*k[6][idxs] - 15*k[7][idxs]
-    b6diff = -6*k[6][idxs] + 18*k[7][idxs]
-    return b1diff + Θ*(b2diff + Θ*(b3diff + Θ*(b4diff +
-           Θ*(b5diff + Θ*(b6diff - 7*k[7][idxs]*Θ)))))
+    if idxs == nothing
+      b1diff = @. k[1] + k[2]
+      b2diff = @. -2*k[2] + 2*k[3] + 2*k[4]
+      b3diff = @. -3*k[3] - 6*k[4] + 3*k[5] + 3*k[6]
+      b4diff = @. 4*k[4] - 8*k[5] - 12*k[6] + 4*k[7]
+      b5diff = @. 5*k[5] + 15*k[6] - 15*k[7]
+      b6diff = @. -6*k[6] + 18*k[7]
+      b7diff = @. -7*k[7]
+    else
+      b1diff = @. k[1][idxs] + k[2][idxs]
+      b2diff = @. -2*k[2][idxs] + 2*k[3][idxs] + 2*k[4][idxs]
+      b3diff = @. -3*k[3][idxs] - 6*k[4][idxs] + 3*k[5][idxs] + 3*k[6][idxs]
+      b4diff = @. 4*k[4][idxs] - 8*k[5][idxs] - 12*k[6][idxs] + 4*k[7][idxs]
+      b5diff = @. 5*k[5][idxs] + 15*k[6][idxs] - 15*k[7][idxs]
+      b6diff = @. -6*k[6][idxs] + 18*k[7][idxs]
+      b7diff = @. -7*k[7][idxs]
+    end
+    # return @. b1diff + Θ*(b2diff + Θ*(b3diff + Θ*(b4diff + Θ*(b5diff + Θ*(b6diff + Θ*b7diff)))))
+    return b1diff + Θ*(b2diff + Θ*(b3diff + Θ*(b4diff + Θ*(b5diff + Θ*(b6diff + Θ*b7diff)))))
   elseif idxs == nothing
     for i in eachindex(out)
       b1diff = k[1][i] + k[2][i]
@@ -1152,11 +1292,27 @@ end
   bp6Θ  = @evalpoly(Θ, 0   , rp61, rp62, rp63, rp64)
 
   @inbounds if out == nothing
-    return uprev[idxs] + dt*Θ*(duprev[idxs] + dt*Θ*(b1Θ*k1.x[2][idxs] +
-                 b3Θ*k3.x[2][idxs] +
-                 b4Θ*k4.x[2][idxs] + b5Θ*k5.x[2][idxs] + b6Θ*k6.x[2][idxs])),
-           duprev[idxs] + dt*Θ*(bp1Θ*k1.x[2][idxs] + bp3Θ*k3.x[2][idxs] +
-               bp4Θ*k4.x[2][idxs] + bp5Θ*k5.x[2][idxs] + bp6Θ*k6.x[2][idxs])
+    if idxs == nothing
+      # return @. uprev + dt*Θ*(duprev + dt*Θ*(b1Θ*k1.x[2] + b3Θ*k3.x[2] +
+      #                                     b4Θ*k4.x[2] + b5Θ*k5.x[2] + b6Θ*k6.x[2])),
+      #        @. duprev + dt*Θ*(bp1Θ*k1.x[2] + bp3Θ*k3.x[2] +
+      #                          bp4Θ*k4.x[2] + bp5Θ*k5.x[2] + bp6Θ*k6.x[2])
+      return uprev + dt*Θ*(duprev + dt*Θ*(b1Θ*k1.x[2] + b3Θ*k3.x[2] +
+                                          b4Θ*k4.x[2] + b5Θ*k5.x[2] + b6Θ*k6.x[2])),
+            duprev + dt*Θ*(bp1Θ*k1.x[2] + bp3Θ*k3.x[2] +
+                            bp4Θ*k4.x[2] + bp5Θ*k5.x[2] + bp6Θ*k6.x[2])
+    else
+      # return @. uprev[idxs] + dt*Θ*(duprev[idxs] + dt*Θ*(b1Θ*k1.x[2][idxs] +
+      #                                                    b3Θ*k3.x[2][idxs] +
+      #                                                    b4Θ*k4.x[2][idxs] + b5Θ*k5.x[2][idxs] + b6Θ*k6.x[2][idxs])),
+      #        @. duprev[idxs] + dt*Θ*(bp1Θ*k1.x[2][idxs] + bp3Θ*k3.x[2][idxs] +
+      #                                bp4Θ*k4.x[2][idxs] + bp5Θ*k5.x[2][idxs] + bp6Θ*k6.x[2][idxs])
+      return uprev[idxs] + dt*Θ*(duprev[idxs] + dt*Θ*(b1Θ*k1.x[2][idxs] +
+                  b3Θ*k3.x[2][idxs] +
+                  b4Θ*k4.x[2][idxs] + b5Θ*k5.x[2][idxs] + b6Θ*k6.x[2][idxs])),
+            duprev[idxs] + dt*Θ*(bp1Θ*k1.x[2][idxs] + bp3Θ*k3.x[2][idxs] +
+                bp4Θ*k4.x[2][idxs] + bp5Θ*k5.x[2][idxs] + bp6Θ*k6.x[2][idxs])
+    end
   elseif idxs == nothing
     for i in eachindex(out.x[2])
       out.x[1][i]  = uprev[i] + dt*Θ*(duprev[i] + dt*Θ*(b1Θ*k1.x[2][i] +

--- a/src/dense/rosenbrock_interpolants.jl
+++ b/src/dense/rosenbrock_interpolants.jl
@@ -24,7 +24,11 @@ From MATLAB ODE Suite by Shampine
   c1 = Θ*(1-Θ)/(1-2d)
   c2 = Θ*(Θ-2d)/(1-2d)
   if out == nothing
-    return @. y₀[idxs] + dt*(c1*k[1][idxs] + c2*k[2][idxs])
+    if idxs == nothing
+      return @. y₀ + dt*(c1*k[1] + c2*k[2])
+    else
+      return @. y₀[idxs] + dt*(c1*k[1][idxs] + c2*k[2][idxs])
+    end
   elseif idxs == nothing
     @. out = y₀ + dt*(c1*k[1] + c2*k[2])
   else
@@ -37,7 +41,11 @@ end
   c1diff = (1-2*Θ)/(1-2*d)
   c2diff = (2*Θ-2*d)/(1-2*d)
   if out == nothing
-    return @. c1diff*k[1][idxs] + c2diff*k[2][idxs]
+    if idxs == nothing
+      return @. c1diff*k[1] + c2diff*k[2]
+    else
+      return @. c1diff*k[1][idxs] + c2diff*k[2][idxs]
+    end
   elseif idxs == nothing
     @. out = c1diff*k[1] + c2diff*k[2]
   else
@@ -56,7 +64,11 @@ From MATLAB ODE Suite by Shampine
 @muladd @inline function ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Rodas4Cache,idxs,T::Type{Val{0}})
   Θ1 = 1 - Θ
   if out == nothing
-    return @. Θ1*y₀[idxs] + Θ*(y₁[idxs] + Θ1*(k[1][idxs] + Θ*k[2][idxs]))
+    if idxs == nothing
+      return @. Θ1*y₀ + Θ*(y₁ + Θ1*(k[1] + Θ*k[2]))
+    else
+      return @. Θ1*y₀[idxs] + Θ*(y₁[idxs] + Θ1*(k[1][idxs] + Θ*k[2][idxs]))
+    end
   elseif idxs == nothing
     @. out = Θ1*y₀ + Θ*(y₁ + Θ1*(k[1] + Θ*k[2]))
   else

--- a/src/integrators/explicit_rk_integrator.jl
+++ b/src/integrators/explicit_rk_integrator.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator, cache::ExplicitRKConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -64,7 +64,7 @@ function initialize!(integrator, cache::ExplicitRKCache)
   integrator.kshortsize = 2
   integrator.fsallast = cache.fsallast
   integrator.fsalfirst = cache.kk[1]
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal

--- a/src/integrators/exponential_rk_integrators.jl
+++ b/src/integrators/exponential_rk_integrators.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator, cache::LawsonEulerConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   rtmp = integrator.f.f2(integrator.t,integrator.uprev)
   integrator.fsalfirst = rtmp # Pre-start fsal
 
@@ -28,7 +28,7 @@ function initialize!(integrator, cache::LawsonEulerCache)
   @unpack k,fsalfirst,rtmp = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = rtmp
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = fsalfirst # this is wrong, since it's just rtmp. Should fsal this value though
   integrator.k[2] = k
   A = integrator.f.f1(integrator.t,integrator.u,k)
@@ -49,7 +49,7 @@ end
 
 function initialize!(integrator, cache::NorsettEulerConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   rtmp = integrator.f.f2(integrator.t, integrator.uprev)
   integrator.fsalfirst = rtmp # Pre-start fsal
 
@@ -77,7 +77,7 @@ function initialize!(integrator, cache::NorsettEulerCache)
   @unpack k,fsalfirst,rtmp = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = rtmp
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = fsalfirst
   integrator.k[2] = k
   integrator.f.f1(integrator.t,integrator.u,k)

--- a/src/integrators/feagin_rk_integrators.jl
+++ b/src/integrators/feagin_rk_integrators.jl
@@ -1,7 +1,7 @@
 function initialize!(integrator, cache::Feagin10ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -164,7 +164,7 @@ function initialize!(integrator, cache::Feagin10Cache)
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal
@@ -306,7 +306,7 @@ end
 function initialize!(integrator, cache::Feagin12ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -521,7 +521,7 @@ function initialize!(integrator, cache::Feagin12Cache)
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal
@@ -711,7 +711,7 @@ end
 function initialize!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
   integrator.fsalfirst = f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -982,7 +982,7 @@ function initialize!(integrator, cache::Feagin14Cache)
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal

--- a/src/integrators/fixed_timestep_integrators.jl
+++ b/src/integrators/fixed_timestep_integrators.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator,cache::DiscreteConstantCache)
   integrator.kshortsize = 0
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 end
 
 function perform_step!(integrator,cache::DiscreteConstantCache,repeat_step=false)
@@ -15,7 +15,7 @@ end
 
 function initialize!(integrator,cache::DiscreteCache)
   integrator.kshortsize = 0
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
 end
 
 function perform_step!(integrator,cache::DiscreteCache,repeat_step=false)
@@ -36,7 +36,7 @@ end
 
 function initialize!(integrator,cache::EulerConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -60,7 +60,7 @@ function initialize!(integrator,cache::EulerCache)
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -74,7 +74,7 @@ end
 
 function initialize!(integrator,cache::Union{HeunConstantCache,RalstonConstantCache})
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -125,7 +125,7 @@ function initialize!(integrator,cache::Union{HeunCache,RalstonCache})
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -167,7 +167,7 @@ end
 function initialize!(integrator,cache::MidpointConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -196,7 +196,7 @@ function initialize!(integrator,cache::MidpointCache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
@@ -220,7 +220,7 @@ end
 function initialize!(integrator,cache::RK4ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -263,7 +263,7 @@ function initialize!(integrator,cache::RK4Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # pre-start FSAL

--- a/src/integrators/general_rosenbrock_integrator.jl
+++ b/src/integrators/general_rosenbrock_integrator.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator, cache::GenRosen4ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays

--- a/src/integrators/generic_implicit_integrators.jl
+++ b/src/integrators/generic_implicit_integrators.jl
@@ -30,7 +30,7 @@ function initialize!(integrator,
                      cache::Union{GenericImplicitEulerConstantCache,GenericTrapezoidConstantCache})
   cache.uhold[1] = integrator.uprev; cache.C[1] = integrator.uprev
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -92,7 +92,7 @@ function initialize!(integrator,
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
 end
@@ -143,7 +143,7 @@ function initialize!(integrator, cache::GenericTrapezoidConstantCache)
   cache.uhold[1] = integrator.uprev; cache.C[1] = integrator.uprev
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -220,7 +220,7 @@ function initialize!(integrator, cache::GenericTrapezoidCache)
   integrator.fsallast = cache.k
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
 end

--- a/src/integrators/high_order_rk_integrators.jl
+++ b/src/integrators/high_order_rk_integrators.jl
@@ -1,7 +1,7 @@
 function initialize!(integrator,cache::TanYam7ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -120,7 +120,7 @@ function initialize!(integrator, cache::TanYam7Cache)
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal
@@ -221,7 +221,7 @@ end
 
 function initialize!(integrator, cache::DP8ConstantCache)
   integrator.kshortsize = 7
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -444,7 +444,8 @@ end
 
 function initialize!(integrator, cache::DP8Cache)
   integrator.kshortsize = 7
-  integrator.k = [cache.udiff,cache.bspl,cache.dense_tmp3,cache.dense_tmp4,cache.dense_tmp5,cache.dense_tmp6,cache.dense_tmp7]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [cache.udiff,cache.bspl,cache.dense_tmp3,cache.dense_tmp4,cache.dense_tmp5,cache.dense_tmp6,cache.dense_tmp7]
   integrator.fsalfirst = cache.k1
   integrator.fsallast = cache.k13
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # Pre-start fsal
@@ -620,7 +621,7 @@ end
 function initialize!(integrator, cache::TsitPap8ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -758,7 +759,7 @@ function initialize!(integrator, cache::TsitPap8Cache)
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal

--- a/src/integrators/iif_integrators.jl
+++ b/src/integrators/iif_integrators.jl
@@ -12,7 +12,7 @@ end
 
 function initialize!(integrator,cache::Union{GenericIIF1ConstantCache,GenericIIF2ConstantCache})
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   A = integrator.f.f1
   cache.uhold[1] = integrator.f.f2(integrator.t,integrator.uprev)
   integrator.fsalfirst = integrator.f.f1(integrator.t,integrator.uprev) .+ cache.uhold[1]
@@ -69,7 +69,7 @@ function initialize!(integrator,cache::Union{GenericIIF1Cache,GenericIIF2Cache})
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   A = integrator.f.f1
   integrator.f.f2(integrator.t,integrator.uprev,cache.rtmp1)
   A_mul_B!(cache.k,A,integrator.uprev)

--- a/src/integrators/linear_integrators.jl
+++ b/src/integrators/linear_integrators.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator, cache::LinearImplicitEulerConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -55,7 +55,7 @@ function initialize!(integrator, cache::LinearImplicitEulerCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -120,7 +120,7 @@ function initialize!(integrator, cache::MidpointSplittingCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point

--- a/src/integrators/low_order_rk_integrators.jl
+++ b/src/integrators/low_order_rk_integrators.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator, cache::BS3ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -31,7 +31,7 @@ end
 
 function initialize!(integrator, cache::BS3Cache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k4
   integrator.k[1] = integrator.fsalfirst
@@ -61,7 +61,7 @@ end
 
 function initialize!(integrator, cache::OwrenZen3ConstantCache)
     integrator.kshortsize = 4
-    integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+    integrator.k = typeof(integrator.k)(integrator.kshortsize)
     integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
     # Avoid undefined entries if k is an array of arrays
@@ -94,7 +94,7 @@ end
 
 function initialize!(integrator, cache::OwrenZen3Cache)
     integrator.kshortsize = 4
-    integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+    resize!(integrator.k, integrator.kshortsize)
     integrator.k[1]=cache.k1; integrator.k[2]=cache.k2;
     integrator.k[3]=cache.k3; integrator.k[4]=cache.k4;
     integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k4  # setup pointers
@@ -121,7 +121,7 @@ end
 
 function initialize!(integrator, cache::OwrenZen4ConstantCache)
   integrator.kshortsize = 6
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -212,7 +212,7 @@ end
 
 function initialize!(integrator,cache::OwrenZen4Cache,f=integrator.f)
   integrator.kshortsize = 6
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1]=cache.k1; integrator.k[2]=cache.k2;
   integrator.k[3]=cache.k3; integrator.k[4]=cache.k4;
   integrator.k[5]=cache.k5; integrator.k[6]=cache.k6;
@@ -281,7 +281,7 @@ end
 
 function initialize!(integrator, cache::OwrenZen5ConstantCache)
   integrator.kshortsize = 8
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -383,7 +383,7 @@ end
 
 function initialize!(integrator, cache::OwrenZen5Cache)
   integrator.kshortsize = 8
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1]=cache.k1; integrator.k[2]=cache.k2;
   integrator.k[3]=cache.k3; integrator.k[4]=cache.k4;
   integrator.k[5]=cache.k5; integrator.k[6]=cache.k6;
@@ -465,7 +465,7 @@ end
 
 function initialize!(integrator, cache::BS5ConstantCache)
   integrator.kshortsize = 8
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -581,7 +581,7 @@ end
 
 function initialize!(integrator, cache::BS5Cache)
   integrator.kshortsize = 8
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1]=cache.k1; integrator.k[2]=cache.k2;
   integrator.k[3]=cache.k3; integrator.k[4]=cache.k4;
   integrator.k[5]=cache.k5; integrator.k[6]=cache.k6;
@@ -673,7 +673,7 @@ end
 
 function initialize!(integrator, cache::Tsit5ConstantCache)
   integrator.kshortsize = 7
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -782,7 +782,7 @@ end
 function initialize!(integrator, cache::Tsit5Cache)
   integrator.kshortsize = 7
   integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k7 # setup pointers
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   # Setup k pointers
   integrator.k[1] = cache.k1
   integrator.k[2] = cache.k2
@@ -861,7 +861,7 @@ end
 
 function initialize!(integrator, cache::DP5ConstantCache)
   integrator.kshortsize = 4
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -978,7 +978,8 @@ end
 
 function initialize!(integrator, cache::DP5Cache)
   integrator.kshortsize = 4
-  integrator.k = [cache.update,cache.bspl,cache.dense_tmp3,cache.dense_tmp4]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [cache.update,cache.bspl,cache.dense_tmp3,cache.dense_tmp4]
   integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k7
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal
 end

--- a/src/integrators/rkn_integrators.jl
+++ b/src/integrators/rkn_integrators.jl
@@ -18,7 +18,7 @@ function initialize!(integrator,cache::NystromDefaultInitialization)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f.f1(integrator.t,uprev,duprev,integrator.k[2].x[1])

--- a/src/integrators/rosenbrock_integrators.jl
+++ b/src/integrators/rosenbrock_integrators.jl
@@ -3,7 +3,8 @@ function initialize!(integrator, cache::Rosenbrock23Cache)
   @unpack k₁,k₂,fsalfirst,fsallast = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = fsallast
-  integrator.k = [k₁,k₂]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [k₁,k₂]
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 end
 
@@ -119,7 +120,8 @@ function initialize!(integrator, cache::Rosenbrock32Cache)
   @unpack k₁,k₂,fsalfirst,fsallast = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = fsallast
-  integrator.k = [k₁,k₂]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [k₁,k₂]
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 end
 
@@ -231,8 +233,7 @@ end
 
 function initialize!(integrator, cache::Rosenbrock23ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -287,8 +288,7 @@ end
 
 function initialize!(integrator, cache::Rosenbrock32ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -346,8 +346,7 @@ end
 
 function initialize!(integrator, cache::Rosenbrock33ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -421,7 +420,8 @@ function initialize!(integrator, cache::Rosenbrock33Cache)
   @unpack fsalfirst,fsallast = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = fsallast
-  integrator.k = [fsalfirst,fsallast]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [fsalfirst,fsallast]
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 end
 
@@ -543,8 +543,7 @@ end
 
 function initialize!(integrator, cache::Rosenbrock34ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -624,7 +623,8 @@ function initialize!(integrator, cache::Rosenbrock34Cache)
   @unpack fsalfirst,fsallast = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = fsallast
-  integrator.k = [fsalfirst,fsallast]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [fsalfirst,fsallast]
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 end
 
@@ -777,8 +777,7 @@ end
 
 function initialize!(integrator, cache::Rosenbrock4ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -859,7 +858,8 @@ function initialize!(integrator, cache::Rosenbrock4Cache)
   @unpack fsalfirst,fsallast = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = fsallast
-  integrator.k = [fsalfirst,fsallast]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [fsalfirst,fsallast]
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 end
 
@@ -1003,8 +1003,7 @@ end
 
 function initialize!(integrator, cache::Rodas4ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   # Avoid undefined entries if k is an array of arrays
   integrator.k[1] = zero(integrator.u)
   integrator.k[2] = zero(integrator.u)
@@ -1107,7 +1106,8 @@ end
 function initialize!(integrator, cache::Rodas4Cache)
   integrator.kshortsize = 2
   @unpack dense1,dense2 = cache
-  integrator.k = [dense1,dense2]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [dense1,dense2]
 end
 
 @muladd function perform_step!(integrator, cache::Rodas4Cache, repeat_step=false)
@@ -1309,8 +1309,7 @@ end
 
 function initialize!(integrator, cache::Rosenbrock5ConstantCache)
   integrator.kshortsize = 2
-  k = eltype(integrator.sol.k)(2)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev)
 
   # Avoid undefined entries if k is an array of arrays
@@ -1477,7 +1476,8 @@ function initialize!(integrator, cache::Rosenbrock5Cache)
   @unpack fsalfirst,fsallast,dense1,dense2 = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = fsallast
-  integrator.k = [fsalfirst,fsallast]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [fsalfirst,fsallast]
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst)
 end
 

--- a/src/integrators/sdirk_integrators.jl
+++ b/src/integrators/sdirk_integrators.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator, cache::ImplicitEulerConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -104,7 +104,7 @@ function initialize!(integrator, cache::ImplicitEulerCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -243,7 +243,7 @@ end
 
 function initialize!(integrator, cache::ImplicitMidpointConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -331,7 +331,7 @@ function initialize!(integrator, cache::ImplicitMidpointCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -454,7 +454,7 @@ end
 
 function initialize!(integrator, cache::TrapezoidConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -576,7 +576,7 @@ function initialize!(integrator, cache::TrapezoidCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -734,7 +734,7 @@ end
 
 function initialize!(integrator, cache::TRBDF2ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -878,7 +878,7 @@ function initialize!(integrator, cache::TRBDF2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -1061,7 +1061,7 @@ end
 
 function initialize!(integrator, cache::SDIRK2ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -1204,7 +1204,7 @@ function initialize!(integrator, cache::SDIRK2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -1385,7 +1385,7 @@ end
 
 function initialize!(integrator, cache::SSPSDIRK2ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -1522,7 +1522,7 @@ function initialize!(integrator, cache::SSPSDIRK2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -1691,7 +1691,7 @@ end
 
 function initialize!(integrator, cache::Union{Kvaerno3ConstantCache,KenCarp3ConstantCache})
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -1875,7 +1875,7 @@ function initialize!(integrator, cache::Union{Kvaerno3Cache,KenCarp3Cache})
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -2112,7 +2112,7 @@ end
 
 function initialize!(integrator, cache::Cash4ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -2386,7 +2386,7 @@ function initialize!(integrator, cache::Cash4Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -2730,7 +2730,7 @@ end
 
 function initialize!(integrator, cache::Hairer4ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -2993,7 +2993,7 @@ function initialize!(integrator, cache::Hairer4Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -3338,7 +3338,7 @@ end
 
 function initialize!(integrator, cache::Kvaerno4ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -3568,7 +3568,7 @@ function initialize!(integrator, cache::Kvaerno4Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -3857,7 +3857,7 @@ end
 
 function initialize!(integrator, cache::KenCarp4ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -4125,7 +4125,7 @@ function initialize!(integrator, cache::KenCarp4Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -4469,7 +4469,7 @@ end
 
 function initialize!(integrator, cache::Kvaerno5ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -4780,7 +4780,7 @@ function initialize!(integrator, cache::Kvaerno5Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point
@@ -5180,7 +5180,7 @@ end
 
 function initialize!(integrator, cache::KenCarp5ConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -5533,7 +5533,7 @@ function initialize!(integrator, cache::KenCarp5Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # For the interpolation, needs k at the updated point

--- a/src/integrators/split_integrators.jl
+++ b/src/integrators/split_integrators.jl
@@ -1,6 +1,6 @@
 function initialize!(integrator,cache::SplitEulerConstantCache)
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f[1](integrator.t,integrator.uprev) + integrator.f[2](integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -23,7 +23,7 @@ function initialize!(integrator,cache::SplitEulerCache)
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f[1](integrator.t,integrator.uprev,integrator.fsalfirst) # For the interpolation, needs k at the updated point

--- a/src/integrators/ssprk_integrators.jl
+++ b/src/integrators/ssprk_integrators.jl
@@ -1,7 +1,7 @@
 function initialize!(integrator,cache::SSPRK22ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -27,7 +27,7 @@ function initialize!(integrator,cache::SSPRK22Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
@@ -51,7 +51,7 @@ end
 function initialize!(integrator,cache::SSPRK33ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -80,7 +80,7 @@ function initialize!(integrator,cache::SSPRK33Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
@@ -108,7 +108,7 @@ end
 function initialize!(integrator,cache::SSPRK53ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -144,7 +144,7 @@ function initialize!(integrator,cache::SSPRK53Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
@@ -180,7 +180,7 @@ end
 function initialize!(integrator,cache::SSPRK63ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -219,7 +219,7 @@ function initialize!(integrator,cache::SSPRK63Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
@@ -259,7 +259,7 @@ end
 function initialize!(integrator,cache::SSPRK73ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -301,7 +301,7 @@ function initialize!(integrator,cache::SSPRK73Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
@@ -345,7 +345,7 @@ end
 function initialize!(integrator,cache::SSPRK83ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -390,7 +390,7 @@ function initialize!(integrator,cache::SSPRK83Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
 end
@@ -437,7 +437,7 @@ end
 
 function initialize!(integrator,cache::SSPRK432ConstantCache)
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -475,7 +475,7 @@ end
 
 function initialize!(integrator,cache::SSPRK432Cache)
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
   integrator.k[1] = integrator.fsalfirst
@@ -519,7 +519,7 @@ end
 
 function initialize!(integrator,cache::SSPRK932ConstantCache)
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
 
   # Avoid undefined entries if k is an array of arrays
@@ -576,7 +576,7 @@ end
 
 function initialize!(integrator,cache::SSPRK932Cache)
   integrator.kshortsize = 1
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
   integrator.k[1] = integrator.fsalfirst
@@ -646,7 +646,7 @@ end
 function initialize!(integrator,cache::SSPRK54ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -684,7 +684,7 @@ function initialize!(integrator,cache::SSPRK54Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation
@@ -721,7 +721,7 @@ end
 function initialize!(integrator,cache::SSPRK104ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t,integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -766,7 +766,7 @@ function initialize!(integrator,cache::SSPRK104Cache)
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.f(integrator.t,integrator.uprev,integrator.fsalfirst) # FSAL for interpolation

--- a/src/integrators/symplectic_integrators.jl
+++ b/src/integrators/symplectic_integrators.jl
@@ -1,11 +1,11 @@
 # http://www.chimica.unipd.it/antonino.polimeno/pubblica/downloads/JChemPhys_101_4062.pdf
 
-function initialize!(integrator,cache::SymplecticEulerConstantCache,repeat_step=false)
+function initialize!(integrator,cache::SymplecticEulerConstantCache)
   integrator.kshortsize = 2
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   # Do the calculation pre
@@ -33,12 +33,12 @@ end
   integrator.fsallast = ku
 end
 
-function initialize!(integrator,cache::SymplecticEulerCache,repeat_step=false)
+function initialize!(integrator,cache::SymplecticEulerCache)
   integrator.kshortsize = 2
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   # Do the calculation pre
@@ -67,7 +67,7 @@ end
   f.f1(t,uprev,du,ku)
 end
 
-function initialize!(integrator,cache::C,repeat_step=false) where
+function initialize!(integrator,cache::C) where
     {C<:Union{VelocityVerletCache,Symplectic2Cache,Symplectic3Cache,Symplectic4Cache,
               Symplectic45Cache,Symplectic5Cache,Symplectic6Cache,Symplectic62Cache,
               McAte8Cache,KahanLi8Cache,SofSpa10Cache}}
@@ -75,7 +75,7 @@ function initialize!(integrator,cache::C,repeat_step=false) where
   integrator.fsallast = cache.k
 
   integrator.kshortsize = 2
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
 

--- a/src/integrators/threaded_rk_integrators.jl
+++ b/src/integrators/threaded_rk_integrators.jl
@@ -1,6 +1,7 @@
 function initialize!(integrator, cache::DP5ThreadedCache)
   integrator.kshortsize = 4
-  integrator.k = [cache.update,cache.bspl,cache.dense_tmp3,cache.dense_tmp4]
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k .= [cache.update,cache.bspl,cache.dense_tmp3,cache.dense_tmp4]
   integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k7
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal
 end

--- a/src/integrators/verner_rk_integrators.jl
+++ b/src/integrators/verner_rk_integrators.jl
@@ -1,7 +1,7 @@
 function initialize!(integrator, cache::Vern6ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.t, integrator.uprev) # Pre-start fsal
   integrator.kshortsize = 9
-  integrator.k = eltype(integrator.sol.k)(integrator.kshortsize)
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
@@ -117,11 +117,11 @@ end
 function initialize!(integrator, cache::Vern6Cache)
   integrator.kshortsize = 9
   integrator.fsalfirst = cache.k1 ; integrator.fsallast = cache.k9
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
+  @unpack k = integrator
+  resize!(k, integrator.kshortsize)
   k[1]=cache.k1; k[2]=cache.k2; k[3]=cache.k3;
   k[4]=cache.k4; k[5]=cache.k5; k[6]=cache.k6;
   k[7]=cache.k7; k[8]=cache.k8; k[9]=cache.k9 # Set the pointers
-  integrator.k = k
   integrator.f(integrator.t, integrator.uprev, integrator.fsalfirst) # Pre-start fsal
 end
 
@@ -204,8 +204,7 @@ end
 
 function initialize!(integrator, cache::Vern7ConstantCache)
   integrator.kshortsize = 10
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   @inbounds for i in eachindex(integrator.k)
@@ -326,10 +325,10 @@ end
 
 function initialize!(integrator, cache::Vern7Cache)
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10 = cache
+  @unpack k = integrator
   integrator.kshortsize = 10
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(k, integrator.kshortsize)
   k[1]=k1;k[2]=k2;k[3]=k3;k[4]=k4;k[5]=k5;k[6]=k6;k[7]=k7;k[8]=k8;k[9]=k9;k[10]=k10 # Setup pointers
-  integrator.k = k
 end
 
 #=
@@ -423,8 +422,7 @@ end
 
 function initialize!(integrator, cache::Vern8ConstantCache)
   integrator.kshortsize = 13
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   @inbounds for i in eachindex(integrator.k)
@@ -567,10 +565,10 @@ end
 
 function initialize!(integrator, cache::Vern8Cache)
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13 = cache
+  @unpack k = integrator
   integrator.kshortsize = 13
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(k, integrator.kshortsize)
   k[1]=k1;k[2]=k2;k[3]=k3;k[4]=k4;k[5]=k5;k[6]=k6;k[7]=k7;k[8]=k8;k[9]=k9;k[10]=k10;k[11]=k11;k[12]=k12;k[13]=k13 # Setup pointers
-  integrator.k = k
 end
 
 #=
@@ -682,8 +680,7 @@ end
 
 function initialize!(integrator, cache::Vern9ConstantCache)
   integrator.kshortsize = 16
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
-  integrator.k = k
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
 
   # Avoid undefined entries if k is an array of arrays
   @inbounds for i in eachindex(integrator.k)
@@ -846,10 +843,10 @@ end
 
 function initialize!(integrator, cache::Vern9Cache)
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16 = cache
+  @unpack k = integrator
   integrator.kshortsize = 16
-  k = eltype(integrator.sol.k)(integrator.kshortsize)
+  resize!(k, integrator.kshortsize)
   k[1]=k1;k[2]=k2;k[3]=k3;k[4]=k4;k[5]=k5;k[6]=k6;k[7]=k7;k[8]=k8;k[9]=k9;k[10]=k10;k[11]=k11;k[12]=k12;k[13]=k13;k[14]=k14;k[15]=k15;k[16]=k16 # Setup pointers
-  integrator.k = k
 end
 
 #=

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -175,10 +175,20 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
 
 
   ### Algorithm-specific defaults ###
-  ksEltype = Vector{rateType}
+  if save_idxs == nothing
+    ksEltype = Vector{rateType}
+  else
+    ks_prototype = rate_prototype[save_idxs]
+    ksEltype = Vector{typeof(ks_prototype)}
+  end
 
   # Have to convert incase passed in wrong.
-  timeseries = convert(Vector{uType},timeseries_init)
+  if save_idxs == nothing
+    timeseries = convert(Vector{uType},timeseries_init)
+  else
+    u_initial = u[save_idxs]
+    timeseries = convert(Vector{typeof(u_initial)},timeseries_init)
+  end
   ts = convert(Vector{tType},ts_init)
   ks = convert(Vector{ksEltype},ks_init)
   alg_choice = Int[]
@@ -189,10 +199,11 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     copyat_or_push!(ts,1,t)
     if save_idxs == nothing
       copyat_or_push!(timeseries,1,u)
+      copyat_or_push!(ks,1,[rate_prototype])
     else
-      copyat_or_push!(timeseries,1,u[save_idxs],Val{false})
+      copyat_or_push!(timeseries,1,u_initial,Val{false})
+      copyat_or_push!(ks,1,[ks_prototype])
     end
-    copyat_or_push!(ks,1,[rate_prototype])
   else
     saveiter = 0 # Starts at 0 so first save is at 1
     saveiter_dense = 0
@@ -215,7 +226,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
 
   notsaveat_idxs = Int[1]
 
-  k = ksEltype[]
+  k = rateType[]
 
   if uType <: Array
     uprev = copy(u)
@@ -281,7 +292,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
   dtacc = tTypeNoUnits(1)
 
   integrator = ODEIntegrator{algType,uType,tType,
-                             tTypeNoUnits,typeof(tdir),eltype(ks),SolType,
+                             tTypeNoUnits,typeof(tdir),typeof(k),SolType,
                              typeof(rate_prototype),FType,typeof(prog),cacheType,
                              typeof(opts),fsal_typeof(alg,rate_prototype)}(
                              sol,u,k,t,tType(dt),f,uprev,uprev2,tprev,

--- a/test/ode/ode_saveidxs_tests.jl
+++ b/test/ode/ode_saveidxs_tests.jl
@@ -1,0 +1,27 @@
+using OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+
+# scalar, not in-place
+prob = prob_ode_linear
+sol = solve(prob, DP5(); save_idxs=1)
+sol(0.5) # test interpolation
+
+# vector, not in-place
+prob2 = ODEProblem(DiffEqProblemLibrary.linear, [0.5], (0., 1.))
+sol2 = solve(prob2, DP5(); save_idxs=1)
+@test sol.t == sol2.t && sol.u == sol2.u
+sol2(0.5)
+
+sol2b = solve(prob2, DP5(); save_idxs=[1])
+@test sol.t == sol2b.t && sol.u == [u[1] for u in sol2b.u]
+sol2b(0.5)
+
+# vector, in-place
+prob3 = ODEProblem(DiffEqProblemLibrary.f_2dlinear, [0.5], (0., 1.))
+sol3 = solve(prob3, DP5(); save_idxs=1)
+@test sol.t == sol3.t && sol.u == sol3.u
+sol3(0.5)
+
+sol3b = solve(prob3, DP5(); save_idxs=[1])
+@test sol.t == sol3b.t && sol2b.u == sol3b.u
+sol3b(0.5)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ tic()
 @time @testset "Events Tests" begin include("ode/ode_event_tests.jl") end
 @time @testset "Cache Tests" begin include("ode/ode_cache_tests.jl") end
 @time @testset "saveat Tests" begin include("ode/ode_saveat_tests.jl") end
+@time @testset "save_idxs Tests" begin include("ode/ode_saveidxs_tests.jl") end
 
 @time @testset "Number Type Tests" begin include("ode/ode_numbertype_tests.jl") end
 @time @testset "Static Array Tests" begin include("static_array_tests.jl") end


### PR DESCRIPTION
When I wrote a notebook of benchmarks for DelayDiffEq, I discovered that `save_idxs` does not seem to work completely correct. First I thought this is a problem in DelayDiffEq (and there might still be issues there), but it is at least partly also a problem in OrdinaryDiffEq: Using `save_idxs` such that `typeof(u[save_idxs]) != typeof(u)` does not work. So e.g. it is not possible to extract single components of the state vector with scalars, and maybe even worse it is not possible to extract a vector or vectorized component of a matrix. When I had fixed this issue and finally could extract arbitrary components I noticed another issue: it is not possible to plot solutions retrieved by scalar indexing since the interpolation of exactly that case is broken. Hence this PR additionally includes an improved interpolation that covers this case. Use cases and examples are given in the added test file.
