### PR TITLE
Fix u_modified in discrete callbacks

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -191,8 +191,8 @@ end
       savevalues!(integrator,true)
       saved_in_cb = true
     end
-    callback.affect!(integrator)
     integrator.u_modified = true
+    callback.affect!(integrator)
     @inbounds if callback.save_positions[2]
       savevalues!(integrator,true)
       saved_in_cb = true


### PR DESCRIPTION
This fixes a bug in the application of discrete callbacks which results in `integrator.u_modified` always set to `true`. This is pretty bad in cases such as the `AutoAbstol` callback in `DiffEqCallbacks` which explicitly set `u_modified!(false)` without any effect. This just hasn't caused any issues in the event tests in DelayDiffEq yet since wrongly new discontinuities calculated by `handle_callback_modifiers!` are not added to `tstops` as well. Event tests with fixed DelayDiffEq resulted in a complete hang of the integration because in every step multiple entries were added to `tstops`. By the way, this seems to indicate that OrdinaryDiffEq currently does not skip time stops if they are too close to each other and rather get's stuck in a loop somehow.