### PR TITLE
Updates for DDEs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6.0
-DiffEqBase 1.20.0
+DiffEqBase 1.23.0
 Parameters 0.5.0
 ForwardDiff 0.5.0
 GenericSVD 0.0.2

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,12 +1,12 @@
 # Use Recursion to find the first callback for type-stability
 
 # Base Case: Only one callback
-function find_first_continuous_callback(integrator,callback::ContinuousCallback)
+function find_first_continuous_callback(integrator, callback::AbstractContinuousCallback)
   (find_callback_time(integrator,callback)...,1,1)
 end
 
 # Starting Case: Compute on the first callback
-function find_first_continuous_callback(integrator,callback::ContinuousCallback,args...)
+function find_first_continuous_callback(integrator, callback::AbstractContinuousCallback, args...)
   find_first_continuous_callback(integrator,find_callback_time(integrator,callback)...,1,1,args...)
 end
 

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -347,7 +347,7 @@ function apply_step!(integrator)
 
   # Update fsal if needed
   if !isempty(integrator.opts.d_discontinuities) &&
-      typeof(integrator.t)(top(integrator.opts.d_discontinuities)) == integrator.t
+      top(integrator.opts.d_discontinuities) == integrator.t
 
       handle_discontinuities!(integrator)
       isfsal(integrator.alg) && reset_fsal!(integrator)

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -1,4 +1,4 @@
-mutable struct DEOptions{uEltype,uEltypeNoUnits,tTypeNoUnits,tType,F2,F3,F4,F5,F6,tstopsType,ECType,SType,MI}
+mutable struct DEOptions{uEltype,uEltypeNoUnits,tTypeNoUnits,tType,F2,F3,F4,F5,F6,tstopsType,discType,ECType,SType,MI}
   maxiters::MI
   timeseries_steps::Int
   save_everystep::Bool
@@ -17,7 +17,7 @@ mutable struct DEOptions{uEltype,uEltypeNoUnits,tTypeNoUnits,tType,F2,F3,F4,F5,F
   save_idxs::SType
   tstops::tstopsType
   saveat::tstopsType
-  d_discontinuities::tstopsType
+  d_discontinuities::discType
   userdata::ECType
   progress::Bool
   progress_steps::Int

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -1,10 +1,10 @@
-mutable struct DEOptions{uEltype,uEltypeNoUnits,tTypeNoUnits,tType,F2,F3,F4,F5,F6,tstopsType,discType,ECType,SType,MI}
+mutable struct DEOptions{absType,relType,tTypeNoUnits,tType,F2,F3,F4,F5,F6,tstopsType,discType,ECType,SType,MI}
   maxiters::MI
   timeseries_steps::Int
   save_everystep::Bool
   adaptive::Bool
-  abstol::uEltype
-  reltol::uEltypeNoUnits
+  abstol::absType
+  reltol::relType
   gamma::tTypeNoUnits
   qmax::tTypeNoUnits
   qmin::tTypeNoUnits

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -71,7 +71,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     error("Timespan is trivial")
   end
 
-  tstops_vec = collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*x≤tdir*tspan[end],Iterators.flatten((tstops,d_discontinuities,tspan[end]))))
+  tstops_vec = collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*tType(x)≤tdir*tspan[end],Iterators.flatten((tstops,d_discontinuities,tspan[end]))))
 
   if tdir>0
     tstops_internal = binary_minheap(tstops_vec)
@@ -163,7 +163,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     saveat_internal = binary_maxheap(saveat_vec)
   end
 
-  d_discontinuities_vec =  collect(tType,d_discontinuities)
+  d_discontinuities_vec =  collect(d_discontinuities)
 
   if tdir>0
     d_discontinuities_internal = binary_minheap(d_discontinuities_vec)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -71,7 +71,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     error("Timespan is trivial")
   end
 
-  tstops_vec = collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*tType(x)≤tdir*tspan[end],Iterators.flatten((tstops,d_discontinuities,tspan[end]))))
+  tstops_vec = vec(collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*tType(x)≤tdir*tspan[end],Iterators.flatten((tstops,d_discontinuities,tspan[end])))))
 
   if tdir>0
     tstops_internal = binary_minheap(tstops_vec)
@@ -154,7 +154,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     saveat_vec = collect(tType,tspan[1]+saveat:saveat:(tspan[end]-saveat))
     # Exclude the endpoint because of floating point issues
   else
-    saveat_vec = collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*x<tdir*tspan[end],saveat))
+    saveat_vec = vec(collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*x<tdir*tspan[end],saveat)))
   end
 
   if tdir>0
@@ -163,7 +163,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     saveat_internal = binary_maxheap(saveat_vec)
   end
 
-  d_discontinuities_vec =  collect(d_discontinuities)
+  d_discontinuities_vec =  vec(collect(d_discontinuities))
 
   if tdir>0
     d_discontinuities_internal = binary_minheap(d_discontinuities_vec)
@@ -209,18 +209,21 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     saveiter_dense = 0
   end
 
-  opts = DEOptions(maxiters,timeseries_steps,save_everystep,adaptive,abstol_internal,
-    reltol_internal,tTypeNoUnits(gamma),tTypeNoUnits(qmax),tTypeNoUnits(qmin),
-    tTypeNoUnits(qsteady_max),tTypeNoUnits(qsteady_min),
-    tTypeNoUnits(failfactor),tType(dtmax),tType(dtmin),internalnorm,save_idxs,
-    tstops_internal,saveat_internal,d_discontinuities_internal,
-    userdata,
-    progress,progress_steps,
-    progress_name,progress_message,
-    timeseries_errors,dense_errors,
-    tTypeNoUnits(beta1),tTypeNoUnits(beta2),tTypeNoUnits(qoldinit),dense,save_start,
-    callbacks_internal,isoutofdomain,unstable_check,verbose,calck,force_dtmin,
-    advance_to_tstop,stop_at_next_tstop)
+  opts = DEOptions{typeof(abstol_internal),typeof(reltol_internal),tTypeNoUnits,tType,
+                   typeof(internalnorm),typeof(callbacks_internal),typeof(isoutofdomain),
+                   typeof(progress_message),typeof(unstable_check),typeof(tstops_internal),
+                   typeof(d_discontinuities_internal),typeof(userdata),typeof(save_idxs),
+                   typeof(maxiters)}(
+                       maxiters,timeseries_steps,save_everystep,adaptive,abstol_internal,
+                       reltol_internal,tTypeNoUnits(gamma),tTypeNoUnits(qmax),
+                       tTypeNoUnits(qmin),tTypeNoUnits(qsteady_max),
+                       tTypeNoUnits(qsteady_min),tTypeNoUnits(failfactor),tType(dtmax),
+                       tType(dtmin),internalnorm,save_idxs,tstops_internal,saveat_internal,
+                       d_discontinuities_internal,userdata,progress,progress_steps,
+                       progress_name,progress_message,timeseries_errors,dense_errors,
+                       tTypeNoUnits(beta1),tTypeNoUnits(beta2),tTypeNoUnits(qoldinit),dense,
+                       save_start,callbacks_internal,isoutofdomain,unstable_check,verbose,
+                       calck,force_dtmin,advance_to_tstop,stop_at_next_tstop)
 
   progress ? (prog = Juno.ProgressBar(name=progress_name)) : prog = nothing
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -71,7 +71,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     error("Timespan is trivial")
   end
 
-  tstops_vec = vec(collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*tType(x)≤tdir*tspan[end],Iterators.flatten((tstops,d_discontinuities,tspan[end])))))
+  tstops_vec = vec(collect(tType,Iterators.filter(x->tdir*tspan[1]<tdir*x≤tdir*tspan[end],Iterators.flatten((tstops,d_discontinuities,tspan[end])))))
 
   if tdir>0
     tstops_internal = binary_minheap(tstops_vec)
@@ -163,7 +163,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
     saveat_internal = binary_maxheap(saveat_vec)
   end
 
-  d_discontinuities_vec =  vec(collect(d_discontinuities))
+  d_discontinuities_vec = vec(collect(d_discontinuities))
 
   if tdir>0
     d_discontinuities_internal = binary_minheap(d_discontinuities_vec)


### PR DESCRIPTION
This adds support of `AbstractContinuousCallback`, a keyword `reduce_size` to `savevalues`, as proposed in https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/34, a method `handle_discontinuities!` to avoid a complete copy of `apply_step!` in DelayDiffEq, support for (almost) arbitrary discontinuity types, and the possibility to skip evaluation and application of discrete callbacks by setting `force_stepfail` in continuous callbacks.

Both https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/34 and https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/35 depend on this PR.