### PR TITLE
Fix eps() for types with units

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -260,9 +260,10 @@ function loopfooter!(integrator)
       integrator.last_stepfail = false
       dtnew = step_accept_controller!(integrator,integrator.alg,q)
       integrator.tprev = integrator.t
-      if typeof(integrator.t)<:AbstractFloat && !isempty(integrator.opts.tstops)
+      # integrator.EEst has unitless type of integrator.t
+      if typeof(integrator.EEst)<: AbstractFloat && !isempty(integrator.opts.tstops)
         tstop = top(integrator.opts.tstops)
-        abs(ttmp - tstop) < 10eps(integrator.t) ? (integrator.t = tstop) : (integrator.t = ttmp)
+        abs(ttmp - tstop) < 10eps(integrator.EEst)*oneunit(integrator.t) ? (integrator.t = tstop) : (integrator.t = ttmp)
       else
         integrator.t = ttmp
       end
@@ -271,9 +272,10 @@ function loopfooter!(integrator)
     end
   elseif !integrator.opts.adaptive #Not adaptive
     integrator.tprev = integrator.t
-    if typeof(integrator.t)<:AbstractFloat && !isempty(integrator.opts.tstops)
+    # integrator.EEst has unitless type of integrator.t
+    if typeof(integrator.EEst)<: AbstractFloat && !isempty(integrator.opts.tstops)
       tstop = top(integrator.opts.tstops)
-      abs(ttmp - tstop) < 10eps(integrator.t) ? (integrator.t = tstop) : (integrator.t = ttmp)
+      abs(ttmp - tstop) < 10eps(integrator.EEst)*oneunit(integrator.t) ? (integrator.t = tstop) : (integrator.t = ttmp)
     else
       integrator.t = ttmp
     end

--- a/src/integrators/sdirk_integrators.jl
+++ b/src/integrators/sdirk_integrators.jl
@@ -42,7 +42,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z = z .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -140,7 +140,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       for j in 1:length(u), i in 1:length(u)
         @inbounds W[i,j] = mass_matrix[i,j]-dt*J[i,j]
@@ -176,7 +176,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -288,7 +288,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z = z .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -369,7 +369,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       for j in 1:length(u), i in 1:length(u)
           @inbounds W[i,j] = mass_matrix[i,j]-dto2*J[i,j]
@@ -406,7 +406,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -496,7 +496,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z = z .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -614,7 +614,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       for j in 1:length(u), i in 1:length(u)
         @inbounds W[i,j] = mass_matrix[i,j]-dto2*J[i,j]
@@ -647,7 +647,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -781,7 +781,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   zᵧ = zᵧ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -823,7 +823,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z = z .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -916,7 +916,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -950,7 +950,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   zᵧ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -1002,7 +1002,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -1108,7 +1108,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ = z₁ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -1149,7 +1149,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -1239,7 +1239,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -1276,7 +1276,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -1327,7 +1327,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -1437,7 +1437,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ = z₁ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -1478,7 +1478,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -1562,7 +1562,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -1599,7 +1599,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -1649,7 +1649,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   fail_convergence = false
@@ -1737,7 +1737,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   fail_convergence = false
@@ -1777,7 +1777,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   fail_convergence = false
@@ -1821,7 +1821,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   fail_convergence = false
@@ -1912,7 +1912,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -1946,7 +1946,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -1998,7 +1998,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2053,7 +2053,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2156,7 +2156,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ = z₁ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -2198,7 +2198,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -2240,7 +2240,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2282,7 +2282,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2324,7 +2324,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ = z₅ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   fail_convergence = false
@@ -2425,7 +2425,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -2455,7 +2455,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -2507,7 +2507,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -2559,7 +2559,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2611,7 +2611,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2663,7 +2663,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2773,7 +2773,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ = z₁ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -2814,7 +2814,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -2855,7 +2855,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2896,7 +2896,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -2938,7 +2938,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ = z₅ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3033,7 +3033,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -3070,7 +3070,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₁ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -3121,7 +3121,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -3172,7 +3172,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3224,7 +3224,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3276,7 +3276,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3389,7 +3389,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -3430,7 +3430,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3471,7 +3471,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3513,7 +3513,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ = z₅ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3608,7 +3608,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -3643,7 +3643,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -3694,7 +3694,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3746,7 +3746,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3798,7 +3798,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3907,7 +3907,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -3948,7 +3948,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -3989,7 +3989,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4030,7 +4030,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ = z₅ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4071,7 +4071,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₆ = z₆ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   fail_convergence = false
@@ -4165,7 +4165,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -4200,7 +4200,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -4251,7 +4251,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4303,7 +4303,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   fail_convergence = false
@@ -4353,7 +4353,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4407,7 +4407,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₆ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4519,7 +4519,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -4560,7 +4560,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4601,7 +4601,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4642,7 +4642,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ = z₅ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4683,7 +4683,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₆ = z₆ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4725,7 +4725,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₇ = z₇ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4820,7 +4820,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -4855,7 +4855,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -4906,7 +4906,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -4958,7 +4958,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5009,7 +5009,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5060,7 +5060,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₆ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5118,7 +5118,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₇ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5230,7 +5230,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ = z₂ .+ dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -5271,7 +5271,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ = z₃ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5312,7 +5312,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ = z₄ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5353,7 +5353,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ = z₅ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5394,7 +5394,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₆ = z₆ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5435,7 +5435,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₇ = z₇ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5477,7 +5477,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₈ = z₈ .+ dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5573,7 +5573,7 @@ end
       end
     end
     # skip calculation of W if step is repeated
-    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps())
+    if !repeat_step && (integrator.iter < 1 || new_jac || abs(dt - (t-integrator.tprev)) > 100eps(integrator.EEst)*oneunit(integrator.t))
       new_W = true
       mass_matrix = integrator.sol.prob.mass_matrix
       for j in 1:length(u), i in 1:length(u)
@@ -5608,7 +5608,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₂ .+= dz
 
-  η = max(cache.ηold,eps(first(u)))^(0.8)
+  η = max(cache.ηold,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = integrator.success_iter == 0 || η*ndz > κtol
 
   # Newton iteration
@@ -5659,7 +5659,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₃ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5711,7 +5711,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₄ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5762,7 +5762,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₅ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5813,7 +5813,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₆ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5870,7 +5870,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₇ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration
@@ -5927,7 +5927,7 @@ end
   ndz = integrator.opts.internalnorm(dz)
   z₈ .+= dz
 
-  η = max(η,eps(first(u)))^(0.8)
+  η = max(η,eps(first(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)
 
   # Newton iteration

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -34,7 +34,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
   beta1=beta1_default(alg,beta2),
   maxiters = 1000000,
   dtmax=eltype(prob.tspan)((prob.tspan[end]-prob.tspan[1])),
-  dtmin=typeof(one(eltype(prob.tspan)) <: AbstractFloat ? eltype(prob.tspan)(10)*eps(one(eltype(prob.tspan))) : eltype(prob.tspan)(1//10^(10)),
+  dtmin=typeof(one(eltype(prob.tspan))) <: AbstractFloat ? eltype(prob.tspan)(10)*eps(one(eltype(prob.tspan))) : eltype(prob.tspan)(1//10^(10)),
   internalnorm = ODE_DEFAULT_NORM,
   isoutofdomain = ODE_DEFAULT_ISOUTOFDOMAIN,
   unstable_check = ODE_DEFAULT_UNSTABLE_CHECK,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -34,7 +34,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
   beta1=beta1_default(alg,beta2),
   maxiters = 1000000,
   dtmax=eltype(prob.tspan)((prob.tspan[end]-prob.tspan[1])),
-  dtmin=eltype(prob.tspan) <: AbstractFloat ? eltype(prob.tspan)(10)*eps(eltype(prob.tspan)) : eltype(prob.tspan)(1//10^(10)),
+  dtmin=typeof(one(eltype(prob.tspan)) <: AbstractFloat ? eltype(prob.tspan)(10)*eps(one(eltype(prob.tspan))) : eltype(prob.tspan)(1//10^(10)),
   internalnorm = ODE_DEFAULT_NORM,
   isoutofdomain = ODE_DEFAULT_ISOUTOFDOMAIN,
   unstable_check = ODE_DEFAULT_UNSTABLE_CHECK,
@@ -300,7 +300,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
                              typeof(opts),fsal_typeof(alg,rate_prototype)}(
                              sol,u,k,t,tType(dt),f,uprev,uprev2,tprev,
                              alg,notsaveat_idxs,dtcache,dtchangeable,
-                             dtpropose,tdir,EEst,qoldinit,q11,
+                             dtpropose,tdir,EEst,tTypeNoUnits(qoldinit),q11,
                              erracc,dtacc,success_iter,
                              iter,saveiter,saveiter_dense,prog,cache,
                              kshortsize,force_stepfail,last_stepfail,


### PR DESCRIPTION
This PR ensures that `eps` is called with unitless types of `t` and `u` since it is not defined for types with units. However, because of use of `eps` in SDIRK methods these methods will fail if unitless type of `t` or `u` are not subtypes of `AbstractFloat`. So maybe it would be better to completely get rid of all `eps` calls there and define minimal values before hand, similarly to `dtmin` which is either set to `10eps` or `1//(10)^10`.

Moreover, I discovered that `dtacc` should be of type `tType` instead of type `tTypeNoUnits` because of lines
https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/integrators/integrator_utils.jl#L226-L232
However, this change would break `DelayDiffEq` since it just copies `dtacc`, hence it is not included here.