### PR TITLE
Bugfixes and more event tests

### DIFF
--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -249,7 +249,7 @@ struct OwrenZen3Cache{uType,uArrayType,rateType,uEltypeNoUnits,TabType} <: Ordin
 end
 
 u_cache(c::OwrenZen3Cache) = (c.atmp,c.utilde)
-du_cache(c::OwrenZen3Cache) = (c.fsalfirst,c.k2,c.k3,c.k4)
+du_cache(c::OwrenZen3Cache) = (c.k1,c.k2,c.k3,c.k4)
 
 function alg_cache(alg::OwrenZen3,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{true}})
   tab = OwrenZen3ConstantCache(real(uEltypeNoUnits),real(tTypeNoUnits))
@@ -281,7 +281,7 @@ struct OwrenZen4Cache{uType,uArrayType,rateType,uEltypeNoUnits,TabType} <: Ordin
 end
 
 u_cache(c::OwrenZen4Cache) = (c.atmp,c.utilde)
-du_cache(c::OwrenZen4Cache) = (c.fsalfirst,c.k2,c.k3,c.k4,c.k5,c.k6)
+du_cache(c::OwrenZen4Cache) = (c.k1,c.k2,c.k3,c.k4,c.k5,c.k6)
 
 function alg_cache(alg::OwrenZen4,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{true}})
   tab = OwrenZen4ConstantCache(real(uEltypeNoUnits),real(tTypeNoUnits))
@@ -317,7 +317,7 @@ struct OwrenZen5Cache{uType,uArrayType,rateType,uEltypeNoUnits,TabType} <: Ordin
 end
 
 u_cache(c::OwrenZen5Cache) = (c.atmp,c.utilde)
-du_cache(c::OwrenZen5Cache) = (c.fsalfirst,c.k2,c.k3,c.k4,c.k5,c.k6,c.k7,c.k8)
+du_cache(c::OwrenZen5Cache) = (c.k1,c.k2,c.k3,c.k4,c.k5,c.k6,c.k7,c.k8)
 
 function alg_cache(alg::OwrenZen5,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{true}})
   tab = OwrenZen5ConstantCache(real(uEltypeNoUnits),real(tTypeNoUnits))

--- a/src/dense/low_order_rk_addsteps.jl
+++ b/src/dense/low_order_rk_addsteps.jl
@@ -338,17 +338,19 @@ end
   nothing
 end
 
-function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen3Cache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
+@muladd function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen3Cache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
   if length(k)<4 || calcVal
     @unpack k1,k2,k3,k4,tmp = cache
     @unpack a21,a31,a32,a41,a42,a43,c1,c2 = cache.tab
+    # NOTE: k1 does not need to be evaluated since it is aliased with integrator.fsalfirst.
     a1 = dt*a21
     @. tmp = uprev+a1*k1
     f(t+c1*dt,tmp,k2)
     @. tmp = uprev+dt*(a31*k1+a32*k2)
     f(t+c2*dt,tmp,k3)
-    @. u = uprev+dt*(a41*k1+a42*k2+a43*k3)
-    f(t+dt,u,k4)
+    # NOTE: We should not change u here.
+    @. tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
+    f(t+dt,tmp,k4)
     copyat_or_push!(k,1,k1)
     copyat_or_push!(k,2,k2)
     copyat_or_push!(k,3,k3)
@@ -358,7 +360,7 @@ function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZ
 end
 
 @muladd function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen4ConstantCache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
-  if length(k)<4 || calcVal
+  if length(k)<6 || calcVal
     @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a63,a64,a65,c1,c2,c3,c4 = cache
     k1 = f(t,uprev)
     a = dt*a21
@@ -379,9 +381,11 @@ end
 end
 
 @muladd function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen4Cache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
-  if length(k)<4 || calcVal
+  if length(k)<6 || calcVal
+    uidx = eachindex(uprev)
     @unpack k1,k2,k3,k4,k5,k6,tmp = cache
     @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a63,a64,a65,c1,c2,c3,c4 = cache.tab
+    # NOTE: k1 does not need to be evaluated since it is aliased with integrator.fsalfirst.
     a = dt*a21
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+a*k1[i]
@@ -399,10 +403,11 @@ end
       @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
     end
     f(t+c4*dt,tmp,k5)
+    # NOTE: We should not change u here.
     @tight_loop_macros for i in uidx
-      @inbounds u[i] = uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
+      @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
     end
-    f(t+dt,u,k6)
+    f(t+dt,tmp,k6)
     copyat_or_push!(k,1,k1)
     copyat_or_push!(k,2,k2)
     copyat_or_push!(k,3,k3)
@@ -414,7 +419,7 @@ end
 end
 
 @muladd function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen5ConstantCache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
-  if length(k)<4 || calcVal
+  if length(k)<8 || calcVal
     @unpack a21,a31,a32,a41,a42,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,c1,c2,c3,c4,c5,c6 = cache
     k1 = f(t,uprev)
     a = dt*a21
@@ -439,10 +444,11 @@ end
 end
 
 @muladd function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen5Cache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
-  if length(k)<4 || calcVal
+  if length(k)<8 || calcVal
     uidx = eachindex(uprev)
     @unpack k1,k2,k3,k4,k5,k6,k7,k8,tmp = cache
     @unpack a21,a31,a32,a41,a42,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,c1,c2,c3,c4,c5,c6 = cache.tab
+    # NOTE: k1 does not need to be evaluated since it is aliased with integrator.fsalfirst.
     a = dt*a21
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+a*k1[i]
@@ -463,21 +469,24 @@ end
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
     end
-    f(t+dt,tmp,k6)
+    f(t+c5*dt,tmp,k6)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a71*k1[i]+a72*k2[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
     end
     f(t+c6*dt,tmp,k7)
+    # NOTE: We should not change u here.
     @tight_loop_macros for i in uidx
-      @inbounds u[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
+      @inbounds tmp[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
     end
-    f(t+dt,u,k8)
+    f(t+dt,tmp,k8)
     copyat_or_push!(k,1,k1)
     copyat_or_push!(k,2,k2)
     copyat_or_push!(k,3,k3)
     copyat_or_push!(k,4,k4)
     copyat_or_push!(k,5,k5)
     copyat_or_push!(k,6,k6)
+    copyat_or_push!(k,7,k7)
+    copyat_or_push!(k,8,k8)
   end
   nothing
 end

--- a/src/dense/low_order_rk_addsteps.jl
+++ b/src/dense/low_order_rk_addsteps.jl
@@ -6,6 +6,22 @@ function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::Discre
   nothing
 end
 
+function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::Union{SSPRK22ConstantCache,SSPRK33ConstantCache,SSPRK432ConstantCache},always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
+  if length(k)<1 || calcVal
+    copyat_or_push!(k,1,f(t,uprev))
+  end
+  nothing
+end
+
+function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::Union{SSPRK22Cache,SSPRK33Cache,SSPRK432Cache},always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
+  if length(k)<1 || calcVal
+    rtmp = similar(u, eltype(eltype(k)))
+    f(t,uprev,rtmp)
+    copyat_or_push!(k,1,rtmp)
+  end
+  nothing
+end
+
 #=
 @muladd function ode_addsteps!{calcVal,calcVal2,calcVal3}(k,t,uprev,u,dt,f,cache::OwrenZen4ConstantCache,always_calc_begin::Type{Val{calcVal}} = Val{false},allow_calc_end::Type{Val{calcVal2}} = Val{true},force_calc_end::Type{Val{calcVal3}} = Val{false})
   if length(k)<4 || calcVal

--- a/src/interp_func.jl
+++ b/src/interp_func.jl
@@ -35,6 +35,15 @@ end
 function DiffEqBase.interp_summary{cacheType<:Union{SSPRK22,SSPRK22ConstantCache,SSPRK33,SSPRK33ConstantCache,SSPRK432,SSPRK432ConstantCache}}(interp::OrdinaryDiffEqInterpolation{cacheType})
   interp.dense ? "2nd order \"free\" SSP interpolation" : "1st order linear"
 end
+function DiffEqBase.interp_summary{cacheType<:Union{OwrenZen3Cache,OwrenZen3ConstantCache}}(interp::OrdinaryDiffEqInterpolation{cacheType})
+  interp.dense ? "specialized 3rd order \"free\" interpolation" : "1st order linear"
+end
+function DiffEqBase.interp_summary{cacheType<:Union{OwrenZen4Cache,OwrenZen4ConstantCache}}(interp::OrdinaryDiffEqInterpolation{cacheType})
+  interp.dense ? "specialized 4th order \"free\" interpolation" : "1st order linear"
+end
+function DiffEqBase.interp_summary{cacheType<:Union{OwrenZen5Cache,OwrenZen5ConstantCache}}(interp::OrdinaryDiffEqInterpolation{cacheType})
+  interp.dense ? "specialized 5th order \"free\" interpolation" : "1st order linear"
+end
 function DiffEqBase.interp_summary{cacheType<:Union{Tsit5Cache,Tsit5ConstantCache}}(interp::OrdinaryDiffEqInterpolation{cacheType})
   interp.dense ? "specialized 4th order \"free\" interpolation" : "1st order linear"
 end

--- a/test/ode/ode_event_tests.jl
+++ b/test/ode/ode_event_tests.jl
@@ -227,6 +227,9 @@ end
 
 @test test_callback_inplace(BS3())
 @test test_callback_inplace(BS5())
+@test test_callback_inplace(OwrenZen3())
+@test test_callback_inplace(OwrenZen4())
+@test test_callback_inplace(OwrenZen5())
 @test test_callback_inplace(DP5())
 @test test_callback_inplace(DP8())
 @test test_callback_inplace(Feagin10())
@@ -244,6 +247,9 @@ end
 
 @test test_callback_outofplace(BS3())
 @test test_callback_outofplace(BS5())
+@test test_callback_outofplace(OwrenZen3())
+@test test_callback_outofplace(OwrenZen4())
+@test test_callback_outofplace(OwrenZen5())
 @test test_callback_outofplace(DP5())
 @test test_callback_outofplace(DP8())
 @test test_callback_outofplace(Feagin10())
@@ -261,6 +267,9 @@ end
 
 @test test_callback_scalar(BS3())
 @test test_callback_scalar(BS5())
+@test test_callback_scalar(OwrenZen3())
+@test test_callback_scalar(OwrenZen4())
+@test test_callback_scalar(OwrenZen5())
 @test test_callback_scalar(DP5())
 @test test_callback_scalar(DP8())
 @test test_callback_scalar(Feagin10())
@@ -278,6 +287,9 @@ end
 
 @test test_callback_svector(BS3())
 @test test_callback_svector(BS5())
+@test test_callback_svector(OwrenZen3())
+@test test_callback_svector(OwrenZen4())
+@test test_callback_svector(OwrenZen5())
 @test test_callback_svector(DP5())
 @test test_callback_svector(DP8())
 @test test_callback_svector(Feagin10())
@@ -295,6 +307,9 @@ end
 
 @test test_callback_mvector(BS3())
 @test test_callback_mvector(BS5())
+@test test_callback_mvector(OwrenZen3())
+@test test_callback_mvector(OwrenZen4())
+@test test_callback_mvector(OwrenZen5())
 @test test_callback_mvector(DP5())
 @test test_callback_mvector(DP8())
 @test test_callback_mvector(Feagin10())

--- a/test/ode/ode_event_tests.jl
+++ b/test/ode/ode_event_tests.jl
@@ -227,6 +227,8 @@ end
 
 @test test_callback_inplace(BS3())
 @test test_callback_inplace(BS5())
+@test test_callback_inplace(SSPRK432())
+@test test_callback_inplace(SSPRK932())
 @test test_callback_inplace(OwrenZen3())
 @test test_callback_inplace(OwrenZen4())
 @test test_callback_inplace(OwrenZen5())
@@ -247,6 +249,8 @@ end
 
 @test test_callback_outofplace(BS3())
 @test test_callback_outofplace(BS5())
+@test test_callback_outofplace(SSPRK432())
+@test test_callback_outofplace(SSPRK932())
 @test test_callback_outofplace(OwrenZen3())
 @test test_callback_outofplace(OwrenZen4())
 @test test_callback_outofplace(OwrenZen5())
@@ -267,6 +271,8 @@ end
 
 @test test_callback_scalar(BS3())
 @test test_callback_scalar(BS5())
+@test test_callback_scalar(SSPRK432())
+@test test_callback_scalar(SSPRK932())
 @test test_callback_scalar(OwrenZen3())
 @test test_callback_scalar(OwrenZen4())
 @test test_callback_scalar(OwrenZen5())
@@ -287,6 +293,8 @@ end
 
 @test test_callback_svector(BS3())
 @test test_callback_svector(BS5())
+@test test_callback_svector(SSPRK432())
+@test test_callback_svector(SSPRK932())
 @test test_callback_svector(OwrenZen3())
 @test test_callback_svector(OwrenZen4())
 @test test_callback_svector(OwrenZen5())
@@ -307,6 +315,8 @@ end
 
 @test test_callback_mvector(BS3())
 @test test_callback_mvector(BS5())
+@test test_callback_mvector(SSPRK432())
+@test test_callback_mvector(SSPRK932())
 @test test_callback_mvector(OwrenZen3())
 @test test_callback_mvector(OwrenZen4())
 @test test_callback_mvector(OwrenZen5())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ const LONGER_TESTS = false
 const CACHE_TEST_ALGS = [Euler(),Midpoint(),RK4(),SSPRK22(),SSPRK33(),SSPRK53(),
   SSPRK63(),SSPRK73(),SSPRK83(),SSPRK432(),SSPRK932(),SSPRK54(),SSPRK104(),CarpenterKennedy2N54(),
   BS3(),BS5(),DP5(),DP5Threaded(),DP8(),Feagin10(),Feagin12(),Feagin14(),TanYam7(),
-  Tsit5(),TsitPap8(),Vern6(),Vern7(),Vern8(),Vern9()]
+  Tsit5(),TsitPap8(),Vern6(),Vern7(),Vern8(),Vern9(),OwrenZen3(),OwrenZen4(),OwrenZen5()]
 
 #Start Test Script
 


### PR DESCRIPTION
This includes some bugfixes for `OwrenZen` methods and more event tests. This also adds `ode_addsteps!` for SSPRK methods and fixes part of #123.

Note: There has been a typo in `OwrenZen5` methods for non-autonomous ODEs. Thus, all benchmarks including these methods may be redone.