### PR TITLE
Initialize callbacks before integrator

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -310,8 +310,8 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
                              just_hit_tstop,accept_step,isout,reeval_fsal,
                              u_modified,opts)
   if initialize_integrator
-    initialize!(integrator,integrator.cache)
     initialize!(callbacks_internal,t,u,integrator)
+    initialize!(integrator,integrator.cache)
   end
 
   integrator


### PR DESCRIPTION
Fixes https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/211.

I've verified that tests for DiffEqCallbacks.jl, DiffEqJump.jl, and DiffEqBiological.jl (as well as OrdinaryDiffEq.jl) still pass.