### PR TITLE
NLsolve update

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ DiffEqBase 2.0.0
 Parameters 0.5.0
 ForwardDiff 0.5.0 0.6.0
 GenericSVD 0.0.2
-NLsolve 0.9.1
+NLsolve 0.12.1
 RecursiveArrayTools 0.12.0
 Juno 0.2.5
 DiffEqDiffTools

--- a/src/integrators/iif_integrators.jl
+++ b/src/integrators/iif_integrators.jl
@@ -1,13 +1,13 @@
-type RHS_IIF_Scalar{F,CType,tType,aType} <: Function
+mutable struct RHS_IIF_Scalar{F,uType,tType,aType} <: Function
   f::F
+  tmp::uType
   t::tType
   dt::tType
-  tmp::CType
   a::aType
 end
 
 function (p::RHS_IIF_Scalar)(u,resid)
-  resid[1] = first(u) - p.tmp - p.a*p.dt*first(p.f.f2(p.t+p.dt,first(u)))
+  resid[1] = first(u) .- p.tmp .- (p.a*p.dt).*first(p.f.f2(p.t+p.dt,first(u)))
 end
 
 function initialize!(integrator,cache::Union{GenericIIF1ConstantCache,GenericIIF2ConstantCache})
@@ -30,9 +30,9 @@ function perform_step!(integrator,cache::Union{GenericIIF1ConstantCache,GenericI
   # If adaptive, this should be computed after and cached
   A = integrator.f.f1
   if typeof(cache) <: GenericIIF1ConstantCache
-    tmp = expm(A*dt)*(uprev)
+    rhs.tmp = expm(A*dt)*(uprev)
   elseif typeof(cache) <: GenericIIF2ConstantCache
-    @muladd tmp = expm(A*dt)*(@. uprev + 0.5dt*uhold[1]) # This uhold only works for non-adaptive
+    @muladd rhs.tmp = expm(A*dt)*(@. uprev + 0.5dt*uhold[1]) # This uhold only works for non-adaptive
   end
 
   if integrator.success_iter > 0 && !integrator.u_modified
@@ -41,7 +41,6 @@ function perform_step!(integrator,cache::Union{GenericIIF1ConstantCache,GenericI
 
   rhs.t = t
   rhs.dt = dt
-  rhs.tmp = tmp
   nlres = integrator.alg.nlsolve(nl_rhs,uhold)
   uhold[1] = integrator.f.f2(t+dt,nlres[1])
   u = nlres[1]
@@ -51,18 +50,18 @@ function perform_step!(integrator,cache::Union{GenericIIF1ConstantCache,GenericI
   integrator.u = u
 end
 
-type RHS_IIF{F,uType,tType,DiffCacheType,aType} <: Function
+mutable struct RHS_IIF{F,uType,tType,aType,DiffCacheType} <: Function
   f::F
   tmp::uType
   t::tType
   dt::tType
-  dual_cache::DiffCacheType
   a::aType
+  dual_cache::DiffCacheType
 end
 function (p::RHS_IIF)(u,resid)
   du = get_du(p.dual_cache, eltype(u))
-  p.f.f2(p.t+p.dt,reshape(u,size(u)),du)
-  @. resid = u - p.tmp - p.a*p.dt*du
+  p.f.f2(p.t+p.dt,u,du)
+  @. resid = u - p.tmp - (p.a*p.dt)*du
 end
 
 function initialize!(integrator,cache::Union{GenericIIF1Cache,GenericIIF2Cache})
@@ -80,7 +79,7 @@ end
 
 function perform_step!(integrator,cache::Union{GenericIIF1Cache,GenericIIF2Cache},repeat_step=false)
   @unpack rtmp1,tmp,k = cache
-  @unpack uhold,rhs,nl_rhs = cache
+  @unpack rhs,nl_rhs = cache
   @unpack t,dt,uprev,u,f = integrator
 
   @. k = uprev
@@ -91,13 +90,12 @@ function perform_step!(integrator,cache::Union{GenericIIF1Cache,GenericIIF2Cache
   A_mul_B!(tmp,cache.expA,k)
 
   if integrator.success_iter > 0 && !integrator.u_modified
-    current_extrapolant!(uhold,t+dt,integrator)
+    current_extrapolant!(u,t+dt,integrator)
   end # else uhold is previous value.
 
   rhs.t = t
   rhs.dt = dt
-  rhs.tmp = tmp
-  nlres = integrator.alg.nlsolve(nl_rhs,uhold)
+  nlres = integrator.alg.nlsolve(nl_rhs,u)
 
   copy!(u,nlres)
   integrator.f.f2(t+dt,nlres,rtmp1)

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -89,14 +89,11 @@ function resize_non_user_cache!(integrator::ODEIntegrator,cache::Union{GenericIm
   for c in default_non_user_cache(integrator)
     resize!(c,i)
   end
-  for c in vecu_cache(integrator.cache)
-    resize!(c,i)
-  end
   for c in dual_cache(integrator.cache)
     resize!(c.du,i)
     resize!(c.dual_du,i)
   end
-  cache.nl_rhs = integrator.alg.nlsolve(Val{:init},cache.rhs,cache.uhold)
+  cache.nl_rhs = integrator.alg.nlsolve(Val{:init},cache.rhs,cache.u)
 end
 
 function deleteat_non_user_cache!(integrator::ODEIntegrator,cache,idxs)

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -27,11 +27,13 @@ Base.@pure function determine_chunksize(u,CS)
   end
 end
 
-function autodiff_setup{CS}(f!, initial_x::Vector, chunk_size::Type{Val{CS}})
-    permf! = (fx, x) -> f!(x, fx)
-    fx2 = copy(initial_x)
+function autodiff_setup{CS}(f!, initial_x, chunk_size::Type{Val{CS}})
+    fvec! = NLsolve.reshape_f(f!, initial_x)
+    permf! = (fx, x) -> fvec!(x, fx)
+
+    fx2 = vec(copy(initial_x))
     jac_cfg = ForwardDiff.JacobianConfig(nothing, #TODO: this has to be adapted for ForwardDiff master.: permf!,
-                                         initial_x, initial_x,
+                                         vec(initial_x), vec(initial_x),
                                          ForwardDiff.Chunk{CS}())
     g! = (x, gx) -> ForwardDiff.jacobian!(gx, permf!, fx2, x, jac_cfg)
     fg! = (x, fx, gx) -> begin
@@ -40,16 +42,16 @@ function autodiff_setup{CS}(f!, initial_x::Vector, chunk_size::Type{Val{CS}})
         DiffBase.value(jac_res)
     end
 
-    return DifferentiableMultivariateFunction(f!, g!, fg!)
+    return DifferentiableMultivariateFunction(fvec!, g!, fg!)
 end
 
-function non_autodiff_setup(f!, initial_x::Vector)
-  DifferentiableMultivariateFunction(f!)
+function non_autodiff_setup(f!, initial_x)
+  DifferentiableMultivariateFunction(f!, initial_x)
 end
 
 immutable NLSOLVEJL_SETUP{CS,AD} end
 Base.@pure NLSOLVEJL_SETUP(;chunk_size=0,autodiff=true) = NLSOLVEJL_SETUP{chunk_size,autodiff}()
-(p::NLSOLVEJL_SETUP)(f,u0) = (res=NLsolve.nlsolve(f,u0); res.zero)
+(p::NLSOLVEJL_SETUP)(f,u0; kwargs...) = (res=NLsolve.nlsolve(f,u0; kwargs...); res.zero)
 function (p::NLSOLVEJL_SETUP{CS,AD}){CS,AD}(::Type{Val{:init}},f,u0_prototype)
   if AD
     return autodiff_setup(f,u0_prototype,Val{determine_chunksize(u0_prototype,CS)})


### PR DESCRIPTION
This PR makes use of the new NLsolve release which allows `AbstractArray` instead of `Vector`. I could simplify caches of all methods that use `NLSOLVEJL_SETUP`, i.e. of `GenericImplicitEuler`, `GenericImplicitTrapezoid`, `GenericIIF1`, and `GenericIIF2`. Moreover, the proposed changes supersede the definition of `NLSOLVEJL_SETUP` in DiffEqCallbacks and hence supersede also https://github.com/JuliaDiffEq/DiffEqCallbacks.jl/pull/17.