### PR TITLE
Fix dtacc units and units in Midpoint, RK4, and ExplicitRK

### DIFF
--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -73,31 +73,30 @@ struct RalstonConstantCache <: OrdinaryDiffEqConstantCache end
 
 alg_cache(alg::Ralston,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{false}}) = RalstonConstantCache()
 
-struct MidpointCache{uType,rateType} <: OrdinaryDiffEqMutableCache
+struct MidpointCache{uType,rateType,uEltypeNoUnits} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
   tmp::uType
-  utilde::rateType
+  atmp::uEltypeNoUnits
   fsalfirst::rateType
 end
 
-u_cache(c::MidpointCache) = ()
-du_cache(c::MidpointCache) = (c.k,c.fsalfirst,c.utilde)
+u_cache(c::MidpointCache) = (c.atmp,)
+du_cache(c::MidpointCache) = (c.k,c.fsalfirst)
 
 struct MidpointConstantCache <: OrdinaryDiffEqConstantCache end
 
 function alg_cache(alg::Midpoint,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{true}})
-  tmp = similar(u)
+  tmp = similar(u); atmp = similar(u, uEltypeNoUnits)
   k = zeros(rate_prototype)
-  utilde = zeros(rate_prototype)
   fsalfirst = zeros(rate_prototype)
-  MidpointCache(u,uprev,k,tmp,utilde,fsalfirst)
+  MidpointCache(u,uprev,k,tmp,atmp,fsalfirst)
 end
 
 alg_cache(alg::Midpoint,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{false}}) = MidpointConstantCache()
 
-struct RK4Cache{uType,rateType} <: OrdinaryDiffEqMutableCache
+struct RK4Cache{uType,rateType,uEltypeNoUnits} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   fsalfirst::rateType
@@ -106,9 +105,10 @@ struct RK4Cache{uType,rateType} <: OrdinaryDiffEqMutableCache
   k₄::rateType
   k::rateType
   tmp::uType
+  atmp::uEltypeNoUnits
 end
 
-u_cache(c::RK4Cache) = ()
+u_cache(c::RK4Cache) = (c.atmp,)
 du_cache(c::RK4Cache) = (c.fsalfirst,c.k₂,c.k₃,c.k₄,c.k)
 
 struct RK4ConstantCache <: OrdinaryDiffEqConstantCache end
@@ -119,8 +119,8 @@ function alg_cache(alg::RK4,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,u
   k₃ = zeros(rate_prototype)
   k₄ = zeros(rate_prototype)
   k  = zeros(rate_prototype)
-  tmp = similar(u)
-  RK4Cache(u,uprev,k₁,k₂,k₃,k₄,k,tmp)
+  tmp = similar(u); atmp = similar(u, uEltypeNoUnits)
+  RK4Cache(u,uprev,k₁,k₂,k₃,k₄,k,tmp,atmp)
 end
 
 alg_cache(alg::RK4,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,::Type{Val{false}}) = RK4ConstantCache()

--- a/src/integrators/explicit_rk_integrator.jl
+++ b/src/integrators/explicit_rk_integrator.jl
@@ -42,12 +42,11 @@ end
   u = @. uprev + dt*utilde
 
   if integrator.opts.adaptive
-    utilde = (α[1]-αEEst[1])*kk[1]
+    utilde = (α[1]-αEEst[1]).*kk[1]
     for i = 2:stages
       utilde = @. utilde + (α[i]-αEEst[i])*kk[i]
     end
-    utilde = dt*utilde
-    atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
+    atmp = calculate_residuals(dt .* utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
 
@@ -107,8 +106,8 @@ end
     for i = 2:stages
       @. utilde = utilde + (α[i]-αEEst[i])*kk[i]
     end
-    @. utilde = dt*utilde
-    calculate_residuals!(atmp, utilde, uprev, u,
+    @. tmp = dt*utilde
+    calculate_residuals!(atmp, tmp, uprev, u,
                          integrator.opts.abstol, integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end

--- a/src/integrators/fixed_timestep_integrators.jl
+++ b/src/integrators/fixed_timestep_integrators.jl
@@ -183,8 +183,9 @@ end
   integrator.fsallast = f(t+dt,u) # For interpolation, then FSAL'd
   if integrator.opts.adaptive
       utilde = @. dt*(integrator.fsalfirst - k)
-      tmp = @. utilde/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
-      integrator.EEst = integrator.opts.internalnorm(tmp)
+      integrator.EEst = integrator.opts.internalnorm(
+          calculate_residuals(utilde, uprev, u, integrator.opts.abstol,
+                              integrator.opts.reltol))
   end
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -204,15 +205,16 @@ end
 
 @muladd function perform_step!(integrator,cache::MidpointCache,repeat_step=false)
   @unpack t,dt,uprev,u,f = integrator
-  @unpack tmp,k,fsalfirst,utilde = cache
+  @unpack tmp,k,fsalfirst,atmp = cache
   halfdt = dt/2
   @. tmp = uprev + halfdt*fsalfirst
   f(t+halfdt,tmp,k)
   @. u = uprev + dt*k
   if integrator.opts.adaptive
-      @. utilde = dt*(fsalfirst - k)
-      @. utilde = (utilde)/(integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)
-      integrator.EEst = integrator.opts.internalnorm(utilde)
+      @. tmp = dt*(fsalfirst - k)
+      calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol,
+                           integrator.opts.reltol)
+      integrator.EEst = integrator.opts.internalnorm(atmp)
   end
   f(t+dt,u,k)
 end
@@ -271,7 +273,7 @@ end
 
 @muladd function perform_step!(integrator,cache::RK4Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f = integrator
-  @unpack tmp,fsalfirst,k₂,k₃,k₄,k = cache
+  @unpack tmp,fsalfirst,k₂,k₃,k₄,k,atmp = cache
   k₁ = fsalfirst
   halfdt = dt/2
   ttmp = t+halfdt
@@ -289,21 +291,23 @@ end
       σ₁ = 1/2 - sqrt(3)/6
       σ₂ = 1/2 + sqrt(3)/6
       @tight_loop_macros for i in eachindex(u)
-          @inbounds p[i] = (1-σ₁)*uprev[i]+σ₁*u[i]+σ₁*(σ₁-1)*((1-2σ₁)*(u[i]-uprev[i])+(σ₁-1)*dt*k₁[i] + σ₁*dt*k₅[i])
+          @inbounds tmp[i] = (1-σ₁)*uprev[i]+σ₁*u[i]+σ₁*(σ₁-1)*((1-2σ₁)*(u[i]-uprev[i])+(σ₁-1)*dt*k₁[i] + σ₁*dt*k₅[i])
           @inbounds pprime[i] = k₁[i] + σ₁*(-4*dt*k₁[i] - 2*dt*k₅[i] - 6*uprev[i] +
                     σ₁*(3*dt*k₁[i] + 3*dt*k₅[i] + 6*uprev[i] - 6*u[i]) + 6*u[i])/dt
       end
-      f(t+σ₁*dt,p,tmp)
-      calculate_residuals!(p, dt*(tmp - pprime), uprev, u, integrator.opts.abstol, integrator.opts.reltol)
-      e1 = integrator.opts.internalnorm(p)
+      f(t+σ₁*dt,tmp,p)
+      calculate_residuals!(atmp, dt*(p - pprime), uprev, u, integrator.opts.abstol,
+                           integrator.opts.reltol)
+      e1 = integrator.opts.internalnorm(atmp)
       @tight_loop_macros for i in eachindex(u)
-        @inbounds p[i] = (1-σ₂)*uprev[i]+σ₂*u[i]+σ₂*(σ₂-1)*((1-2σ₂)*(u[i]-uprev[i])+(σ₂-1)*dt*k₁[i] + σ₂*dt*k₅[i])
+        @inbounds tmp[i] = (1-σ₂)*uprev[i]+σ₂*u[i]+σ₂*(σ₂-1)*((1-2σ₂)*(u[i]-uprev[i])+(σ₂-1)*dt*k₁[i] + σ₂*dt*k₅[i])
         @inbounds pprime[i] = k₁[i] + σ₂*(-4*dt*k₁[i] - 2*dt*k₅[i] - 6*uprev[i] +
                   σ₂*(3*dt*k₁[i] + 3*dt*k₅[i] + 6*uprev[i] - 6*u[i]) + 6*u[i])/dt
       end
-      f(t+σ₂*dt,p,tmp)
-      calculate_residuals!(p, dt*(tmp - pprime), uprev, u, integrator.opts.abstol, integrator.opts.reltol)
-      e2 = integrator.opts.internalnorm(p)
+      f(t+σ₂*dt,tmp,p)
+      calculate_residuals!(atmp, dt*(p - pprime), uprev, u, integrator.opts.abstol,
+                           integrator.opts.reltol)
+      e2 = integrator.opts.internalnorm(atmp)
       integrator.EEst = 2.1342*max(e1,e2)
   end
 end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -64,7 +64,7 @@ mutable struct ODEIntegrator{algType<:OrdinaryDiffEqAlgorithm,uType,tType,tTypeN
   qold::tTypeNoUnits
   q11::tTypeNoUnits
   erracc::tTypeNoUnits
-  dtacc::tTypeNoUnits
+  dtacc::tType
   success_iter::Int
   iter::Int
   saveiter::Int

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -260,7 +260,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
   q11 = tTypeNoUnits(1)
   success_iter = 0
   erracc = tTypeNoUnits(1)
-  dtacc = tTypeNoUnits(1)
+  dtacc = tType(1)
 
   integrator = ODEIntegrator{algType,uType,tType,
                              tTypeNoUnits,typeof(tdir),typeof(k),SolType,


### PR DESCRIPTION
This PR fixes https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/190. It breaks DelayDiffEq, in which similar changes are required. Moreover, with the help of https://github.com/JuliaDiffEq/OrdinaryDiffEqExtendedTests.jl I discovered incorrect units in Midpoint, RK4, and ExplicitRK. These issues are also resolved by this PR (thus the extended tests all pass now).