### PR TITLE
Propagate initialize_save

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -136,7 +136,7 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
   saveat = integrator.opts.saveat_cache,
   d_discontinuities = integrator.opts.d_discontinuities_cache,
   reset_dt = (integrator.dtcache == zero(integrator.dt)) && integrator.opts.adaptive,
-  reinit_callbacks = true,
+  reinit_callbacks = true, initialize_save = true,
   reinit_cache = true)
 
   if isinplace(integrator.sol.prob)
@@ -199,7 +199,7 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
   end
 
   if reinit_callbacks
-    initialize_callbacks!(integrator)
+    initialize_callbacks!(integrator, initialize_save)
   end
 
   if reinit_cache

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -275,7 +275,7 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
                              just_hit_tstop,accept_step,isout,reeval_fsal,
                              u_modified,opts)
   if initialize_integrator
-    initialize_callbacks!(integrator)
+    initialize_callbacks!(integrator, initialize_save)
     initialize!(integrator,integrator.cache)
   end
 
@@ -361,7 +361,7 @@ function tstop_saveat_disc_handling(tstops,saveat,d_discontinuities,tdir,tspan,t
   tstops_internal,saveat_internal,d_discontinuities_internal
 end
 
-function initialize_callbacks!(integrator)
+function initialize_callbacks!(integrator, initialize_save = true)
   t = integrator.t
   u = integrator.u
   callbacks = integrator.opts.callback


### PR DESCRIPTION
In https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/53 I discovered that `initialize_save` is not propagated to `initialize_callbacks!`. I guess we should add tests for `initialize_callbacks!` (and not only for `reinit_callbacks`, as suggested by https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/219); according to https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/194#issuecomment-337942482 there might already exist tests in a private repo?