### PR TITLE
Implement set_{t,u,ut}! for ODEIntegrator

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -232,3 +232,35 @@ function DiffEqBase.auto_dt_reset!(integrator::ODEIntegrator)
   integrator.tdir,integrator.opts.dtmax,integrator.opts.abstol,integrator.opts.reltol,
   integrator.opts.internalnorm,integrator.sol.prob,integrator)
 end
+
+function DiffEqBase.set_t!(integrator::ODEIntegrator, t::Real)
+  if alg_extrapolates(integrator.alg) || !isdtchangeable(integrator.alg)
+    reinit!(integrator, integrator.u;
+            t0 = t,
+            reset_dt = false,
+            reinit_callbacks = false,
+            reinit_cache = false)
+  else
+    integrator.t = t
+  end
+end
+
+function DiffEqBase.set_u!(integrator::ODEIntegrator, u)
+  # TODO: define the "fast path"
+  # At the moment, fallback to reinit!:
+  reinit!(integrator, u;
+          t0 = integrator.t,
+          reset_dt = false,
+          reinit_callbacks = false,
+          reinit_cache = false)
+end
+
+function DiffEqBase.set_ut!(integrator::ODEIntegrator, u, t::Real)
+  # TODO: define the "fast path"
+  # At the moment, fallback to reinit!:
+  reinit!(integrator, u;
+          t0 = t,
+          reset_dt = false,
+          reinit_callbacks = false,
+          reinit_cache = false)
+end

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -234,6 +234,10 @@ function DiffEqBase.auto_dt_reset!(integrator::ODEIntegrator)
 end
 
 function DiffEqBase.set_t!(integrator::ODEIntegrator, t::Real)
+  if integrator.opts.save_everystep
+    error("Integrator time cannot be reset unless it is initialized",
+          " with save_everystep=false")
+  end
   if alg_extrapolates(integrator.alg) || !isdtchangeable(integrator.alg)
     reinit!(integrator, integrator.u;
             t0 = t,
@@ -246,6 +250,10 @@ function DiffEqBase.set_t!(integrator::ODEIntegrator, t::Real)
 end
 
 function DiffEqBase.set_u!(integrator::ODEIntegrator, u)
+  if integrator.opts.save_everystep
+    error("Integrator state cannot be reset unless it is initialized",
+          " with save_everystep=false")
+  end
   # TODO: define the "fast path"
   # At the moment, fallback to reinit!:
   reinit!(integrator, u;
@@ -256,6 +264,10 @@ function DiffEqBase.set_u!(integrator::ODEIntegrator, u)
 end
 
 function DiffEqBase.set_ut!(integrator::ODEIntegrator, u, t::Real)
+  if integrator.opts.save_everystep
+    error("Integrator state cannot be reset unless it is initialized",
+          " with save_everystep=false")
+  end
   # TODO: define the "fast path"
   # At the moment, fallback to reinit!:
   reinit!(integrator, u;

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -254,25 +254,11 @@ function DiffEqBase.set_u!(integrator::ODEIntegrator, u)
     error("Integrator state cannot be reset unless it is initialized",
           " with save_everystep=false")
   end
-  # TODO: define the "fast path"
-  # At the moment, fallback to reinit!:
-  reinit!(integrator, u;
-          t0 = integrator.t,
-          reset_dt = false,
-          reinit_callbacks = false,
-          reinit_cache = false)
+  integrator.u = u
+  u_modified!(integrator, true)
 end
 
 function DiffEqBase.set_ut!(integrator::ODEIntegrator, u, t::Real)
-  if integrator.opts.save_everystep
-    error("Integrator state cannot be reset unless it is initialized",
-          " with save_everystep=false")
-  end
-  # TODO: define the "fast path"
-  # At the moment, fallback to reinit!:
-  reinit!(integrator, u;
-          t0 = t,
-          reset_dt = false,
-          reinit_callbacks = false,
-          reinit_cache = false)
+  DiffEqBase.set_u!(integrator, u)
+  DiffEqBase.set_t!(integrator, t)
 end

--- a/test/integrator_interface_tests.jl
+++ b/test/integrator_interface_tests.jl
@@ -24,12 +24,9 @@ using OrdinaryDiffEq
   solve!(integrator2)
 
   @test integrator1.t == integrator2.t
-  if setter in [set_u!, set_ut!] || alg === Trapezoid
-    rtol = integrator1.opts.reltol
+  if alg === Trapezoid
+    rtol = integrator1.opts.reltol * 100
     atol = integrator1.opts.abstol
-    if alg === Trapezoid
-      rtol *= 100
-    end
     @test integrator1.u ≈ integrator2.u  rtol=rtol atol=atol
   else
     @test integrator1.u == integrator2.u

--- a/test/integrator_interface_tests.jl
+++ b/test/integrator_interface_tests.jl
@@ -1,0 +1,61 @@
+using DiffEqBase: set_t!, set_u!, set_ut!
+using OrdinaryDiffEq
+
+# set_X!(integrator, integrator.X) should not change the result.
+@testset "Trivial $setter ($alg)" for alg in [RK4, Trapezoid],
+                                   setter in [set_t!, set_u!, set_ut!]
+  f = (u,p,t) -> (2u)
+  prob = ODEProblem(f,1/2,(0.0,2.0))
+  t_half = 1.0
+
+  integrator1 = init(prob, alg())
+  integrator2 = init(prob, alg())
+
+  step!(integrator1, t_half)  # "inexact" stepping w/o tstops
+  if setter === set_t!
+    set_t!(integrator1, integrator1.t)
+  elseif setter === set_u!
+    set_u!(integrator1, integrator1.u)
+  else
+    set_ut!(integrator1, integrator1.u, integrator1.t)
+  end
+  solve!(integrator1)
+
+  solve!(integrator2)
+
+  @test integrator1.t == integrator2.t
+  if setter in [set_u!, set_ut!] || alg === Trapezoid
+    rtol = integrator1.opts.reltol
+    atol = integrator1.opts.abstol
+    if alg === Trapezoid
+      rtol *= 100
+    end
+    @test integrator1.u ≈ integrator2.u  rtol=rtol atol=atol
+  else
+    @test integrator1.u == integrator2.u
+  end
+end
+
+@testset "Resolve with $setter ($alg)" for alg in [RK4, Trapezoid],
+                                        setter in [set_t!, set_ut!]
+  f = (u,p,t) -> (2u * cos(2π * t))
+  integrator1 = init(ODEProblem(f,1/2,(0.0,1.0)), alg())
+  integrator2 = init(ODEProblem(f,1/2,(0.0,2.0)), alg())
+
+  solve!(integrator1)
+  if setter === set_t!
+    set_t!(integrator1, 0)
+  else
+    set_ut!(integrator1, integrator1.u, 0)
+  end
+  solve!(integrator1)
+
+  solve!(integrator2)
+
+  rtol = integrator1.opts.reltol
+  atol = integrator1.opts.abstol
+  if alg === Trapezoid
+    rtol *= 100
+  end
+  @test integrator1.u ≈ integrator2.u  rtol=rtol atol=atol
+end

--- a/test/integrator_interface_tests.jl
+++ b/test/integrator_interface_tests.jl
@@ -8,8 +8,8 @@ using OrdinaryDiffEq
   prob = ODEProblem(f,1/2,(0.0,2.0))
   t_half = 1.0
 
-  integrator1 = init(prob, alg())
-  integrator2 = init(prob, alg())
+  integrator1 = init(prob, alg(); save_everystep=false)
+  integrator2 = init(prob, alg(); save_everystep=false)
 
   step!(integrator1, t_half)  # "inexact" stepping w/o tstops
   if setter === set_t!
@@ -39,8 +39,8 @@ end
 @testset "Resolve with $setter ($alg)" for alg in [RK4, Trapezoid],
                                         setter in [set_t!, set_ut!]
   f = (u,p,t) -> (2u * cos(2π * t))
-  integrator1 = init(ODEProblem(f,1/2,(0.0,1.0)), alg())
-  integrator2 = init(ODEProblem(f,1/2,(0.0,2.0)), alg())
+  integrator1 = init(ODEProblem(f,1/2,(0.0,1.0)), alg(); save_everystep=false)
+  integrator2 = init(ODEProblem(f,1/2,(0.0,2.0)), alg(); save_everystep=false)
 
   solve!(integrator1)
   if setter === set_t!

--- a/test/integrator_interface_tests.jl
+++ b/test/integrator_interface_tests.jl
@@ -2,10 +2,16 @@ using DiffEqBase: set_t!, set_u!, set_ut!
 using OrdinaryDiffEq
 
 # set_X!(integrator, integrator.X) should not change the result.
-@testset "Trivial $setter ($alg)" for alg in [RK4, Trapezoid],
-                                   setter in [set_t!, set_u!, set_ut!]
-  f = (u,p,t) -> (2u)
-  prob = ODEProblem(f,1/2,(0.0,2.0))
+@testset "Trivial $setter ($alg, inplace=$iip)" for alg in [RK4, Trapezoid],
+    setter in [set_t!, set_u!, set_ut!],
+    iip in [false, true]
+  if iip
+    f = (du,u,p,t) -> (du .= 2u)
+    prob = ODEProblem{iip}(f,[1/2],(0.0,2.0))
+  else
+    f = (u,p,t) -> (2u)
+    prob = ODEProblem{iip}(f,1/2,(0.0,2.0))
+  end
   t_half = 1.0
 
   integrator1 = init(prob, alg(); save_everystep=false)
@@ -33,11 +39,19 @@ using OrdinaryDiffEq
   end
 end
 
-@testset "Resolve with $setter ($alg)" for alg in [RK4, Trapezoid],
-                                        setter in [set_t!, set_ut!]
-  f = (u,p,t) -> (2u * cos(2π * t))
-  integrator1 = init(ODEProblem(f,1/2,(0.0,1.0)), alg(); save_everystep=false)
-  integrator2 = init(ODEProblem(f,1/2,(0.0,2.0)), alg(); save_everystep=false)
+@testset "Resolve with $setter ($alg, inplace=$iip)" for alg in [RK4, Trapezoid],
+    setter in [set_t!, set_ut!],
+    iip in [false, true]
+  if iip
+    f = (du,u,p,t) -> (du .= 2u * cos(2π * t))
+    prob1 = ODEProblem{iip}(f,[1/2],(0.0,1.0))
+  else
+    f = (u,p,t) -> (2u * cos(2π * t))
+    prob1 = ODEProblem{iip}(f,1/2,(0.0,1.0))
+  end
+  prob2 = remake(prob1; tspan=(0.0,2.0))
+  integrator1 = init(prob1, alg(); save_everystep=false)
+  integrator2 = init(prob2, alg(); save_everystep=false)
 
   solve!(integrator1)
   if setter === set_t!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,5 +45,6 @@ tic()
 @time @testset "Iterator Tests" begin include("iterator_tests.jl") end
 @time @testset "u_modifed Tests" begin include("umodified_test.jl") end
 @time @testset "Composite Algorithm Tests" begin include("composite_algorithm_test.jl") end
+@time @testset "Integrator Interface Tests" begin include("integrator_interface_tests.jl") end
 
 toc()


### PR DESCRIPTION
Currently, `set_u!` and `set_ut!` just fallback to `reinit!`.

@ChrisRackauckas I just put the error check you mentioned in https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/86#issuecomment-366445767 to `set_t!`.  Probably it's faster if you implement it rather than reviewing this PR. :stuck_out_tongue_winking_eye:

Really closes #253
