### PR TITLE
Fix reinit!: copy u0 and t0 to solution data

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -196,6 +196,15 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
     resize!(integrator.sol.u,resize_start)
     resize!(integrator.sol.t,resize_start)
     resize!(integrator.sol.k,resize_start)
+    if integrator.opts.save_start
+      copyat_or_push!(integrator.sol.t,1,t0)
+      if integrator.opts.save_idxs == nothing
+        copyat_or_push!(integrator.sol.u,1,u0)
+      else
+        u_initial = u0[integrator.opts.save_idxs]
+        copyat_or_push!(integrator.sol.u,1,u_initial,Val{false})
+      end
+    end
     if integrator.sol.u_analytic != nothing
       resize!(integrator.sol.u_analytic,0)
     end

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -66,3 +66,25 @@ solve!(integrator)
 
 @test u == saved_values.saveval
 @test t == saved_values.t
+
+@testset "set u0" begin
+  prob = prob_ode_2Dlinear
+  integrator = init(prob,Tsit5())
+  u0 = prob.u0 .+ 1  # just make it different
+  @test u0 != prob.u0
+  reinit!(integrator, u0)
+  @test integrator.u == u0
+  @test integrator.sol.u[1] == u0
+  @test integrator.sol.interp.timeseries[1] == u0
+end
+
+@testset "set t0" begin
+  prob = prob_ode_2Dlinear
+  integrator = init(prob,Tsit5())
+  t0 = prob.tspan[1] - 1  # just make it different
+  @test t0 != prob.tspan[1]
+  reinit!(integrator; t0=t0)
+  @test integrator.t == t0
+  @test integrator.sol.t[1] == t0
+  @test integrator.sol.interp.ts[1] == t0
+end

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -78,6 +78,18 @@ solve!(integrator)
   @test integrator.sol.interp.timeseries[1] == u0
 end
 
+@testset "set u0 with save_idxs" begin
+  save_idxs = [1]
+  prob = prob_ode_2Dlinear
+  integrator = init(prob,Tsit5(); save_idxs=save_idxs)
+  u0 = prob.u0 .+ 1  # just make it different
+  @test u0 != prob.u0
+  reinit!(integrator, u0)
+  @test integrator.u == u0
+  @test integrator.sol.u[1] == u0[save_idxs]
+  @test integrator.sol.interp.timeseries[1] == u0[save_idxs]
+end
+
 @testset "set t0" begin
   prob = prob_ode_2Dlinear
   integrator = init(prob,Tsit5())


### PR DESCRIPTION
closes #246

The code I added in `reinit!` doesn't touch `integrator.sol.k` but the relevant part in `init` seems to be just allocating arrays for it. So I guessed that it was not required. But I'm not very confident about it.