### PR TITLE
[WIP] Exponential Krylov Integrators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -13,3 +13,4 @@ Compat 0.18.0
 Reexport
 MuladdMacro 0.0.2
 StaticArrays
+Expokit 0.0.1

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -26,6 +26,9 @@ module OrdinaryDiffEq
 
   import ForwardDiff.Dual
 
+  # Required by exponential Krylov methods
+  import Expokit: expmv, expmv!
+
   # Required by temporary fix in not in-place methods with 12+ broadcasts
   import StaticArrays: SArray
 
@@ -146,7 +149,7 @@ module OrdinaryDiffEq
 
   export GenericIIF1, GenericIIF2
 
-  export LawsonEuler, NorsettEuler, ETDRK4
+  export LawsonEuler, NorsettEuler, ETDRK4, LawsonEulerKrylov
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -27,7 +27,7 @@ module OrdinaryDiffEq
   import ForwardDiff.Dual
 
   # Required by exponential Krylov methods
-  import Expokit: expmv, expmv!
+  import Expokit: expmv, expmv!, phimv, phimv!
 
   # Required by temporary fix in not in-place methods with 12+ broadcasts
   import StaticArrays: SArray
@@ -149,7 +149,7 @@ module OrdinaryDiffEq
 
   export GenericIIF1, GenericIIF2
 
-  export LawsonEuler, NorsettEuler, ETDRK4, LawsonEulerKrylov
+  export LawsonEuler, NorsettEuler, ETDRK4, LawsonEulerKrylov, ExpEulerKrylov
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -25,6 +25,7 @@ isdtchangeable(alg::GenericIIF2) = false
 isdtchangeable(alg::LawsonEuler) = false
 isdtchangeable(alg::NorsettEuler) = false
 isdtchangeable(alg::LawsonEulerKrylov) = false
+isdtchangeable(alg::ExpEulerKrylov) = false
 
 ismultistep(alg::OrdinaryDiffEqAlgorithm) = false
 
@@ -79,6 +80,7 @@ alg_order(alg::LawsonEuler) = 1
 alg_order(alg::NorsettEuler) = 1
 alg_order(alg::SplitEuler) = 1
 alg_order(alg::LawsonEulerKrylov) = 1
+alg_order(alg::ExpEulerKrylov) = 1
 alg_order(alg::ETDRK4) = 4
 
 alg_order(alg::SymplecticEuler) = 1

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -24,6 +24,7 @@ isdtchangeable(alg::GenericIIF1) = false
 isdtchangeable(alg::GenericIIF2) = false
 isdtchangeable(alg::LawsonEuler) = false
 isdtchangeable(alg::NorsettEuler) = false
+isdtchangeable(alg::LawsonEulerKrylov) = false
 
 ismultistep(alg::OrdinaryDiffEqAlgorithm) = false
 
@@ -77,6 +78,7 @@ alg_order(alg::Ralston) = 2
 alg_order(alg::LawsonEuler) = 1
 alg_order(alg::NorsettEuler) = 1
 alg_order(alg::SplitEuler) = 1
+alg_order(alg::LawsonEulerKrylov) = 1
 alg_order(alg::ETDRK4) = 4
 
 alg_order(alg::SymplecticEuler) = 1

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -602,6 +602,8 @@ struct NorsettEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 
+struct LawsonEulerKrylov <: OrdinaryDiffEqExponentialAlgorithm end
+
 #########################################
 
 struct CompositeAlgorithm{T,F} <: OrdinaryDiffEqCompositeAlgorithm

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -603,6 +603,7 @@ struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 
 struct LawsonEulerKrylov <: OrdinaryDiffEqExponentialAlgorithm end
+struct ExpEulerKrylov <: OrdinaryDiffEqExponentialAlgorithm end
 
 #########################################
 

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -333,3 +333,23 @@ du_cache(c::LawsonEulerKrylovCache) = (c.k,c.fsalfirst,c.rtmp)
 struct LawsonEulerKrylovConstantCache <: OrdinaryDiffEqConstantCache end
 
 alg_cache(alg::LawsonEulerKrylov,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = LawsonEulerKrylovConstantCache()
+
+struct ExpEulerKrylovCache{uType,rateType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  tmp::uType
+  k::rateType
+  rtmp::rateType
+  fsalfirst::rateType
+end
+
+function alg_cache(alg::ExpEulerKrylov,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  ExpEulerKrylovCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),zeros(rate_prototype))
+end
+
+u_cache(c::ExpEulerKrylovCache) = ()
+du_cache(c::ExpEulerKrylovCache) = (c.k,c.fsalfirst,c.rtmp)
+
+struct ExpEulerKrylovConstantCache <: OrdinaryDiffEqConstantCache end
+
+alg_cache(alg::ExpEulerKrylov,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = ExpEulerKrylovConstantCache()

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -313,3 +313,23 @@ function get_etdrk4_operators(_h,_L::Diagonal)
 
     Diagonal(Float64.(E)),Diagonal(Float64.(E2)),Diagonal(a),Diagonal(b),Diagonal(c),Diagonal(Q)
 end
+
+struct LawsonEulerKrylovCache{uType,rateType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  tmp::uType
+  k::rateType
+  rtmp::rateType
+  fsalfirst::rateType
+end
+
+function alg_cache(alg::LawsonEulerKrylov,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  LawsonEulerKrylovCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),zeros(rate_prototype))
+end
+
+u_cache(c::LawsonEulerKrylovCache) = ()
+du_cache(c::LawsonEulerKrylovCache) = (c.k,c.fsalfirst,c.rtmp)
+
+struct LawsonEulerKrylovConstantCache <: OrdinaryDiffEqConstantCache end
+
+alg_cache(alg::LawsonEulerKrylov,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = LawsonEulerKrylovConstantCache()

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -240,3 +240,51 @@ function perform_step!(integrator, cache::LawsonEulerKrylovCache, repeat_step=fa
   f.f2(rtmp,u,p,t+dt)
   @. k = tmp + rtmp
 end
+
+function initialize!(integrator, cache::ExpEulerKrylovConstantCache)
+  integrator.kshortsize = 2
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
+  rtmp = integrator.f.f2(integrator.uprev,integrator.p,integrator.t)
+  integrator.fsalfirst = rtmp # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = zero(integrator.fsalfirst)
+end
+
+function perform_step!(integrator, cache::ExpEulerKrylovConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  rtmp = integrator.fsalfirst
+  A = f.f1
+  u = phimv(dt, A, rtmp, u; tol=integrator.opts.abstol) # abstol or reltol?
+  rtmp = f.f2(u,p,t+dt)
+  k = A*u + rtmp # For the interpolation, needs k at the updated point
+  integrator.fsallast = rtmp
+  integrator.k[1] = integrator.fsalfirst # this is wrong, since it's just rtmp. Should fsal this value though
+  integrator.k[2] = k
+  integrator.u = u
+end
+
+function initialize!(integrator, cache::ExpEulerKrylovCache)
+  integrator.kshortsize = 2
+  @unpack k,fsalfirst,rtmp = cache
+  integrator.fsalfirst = fsalfirst
+  integrator.fsallast = rtmp
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k[1] = fsalfirst # this is wrong, since it's just rtmp. Should fsal this value though
+  integrator.k[2] = k
+  A = integrator.f.f1(k,integrator.u,integrator.p,integrator.t)
+  integrator.f.f2(rtmp,integrator.uprev,integrator.p,integrator.t) # For the interpolation, needs k at the updated point
+  @. integrator.fsalfirst = k + rtmp
+end
+
+function perform_step!(integrator, cache::ExpEulerKrylovCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack k,rtmp,tmp = cache
+  A = f.f1
+  phimv!(u,dt,A,integrator.fsalfirst,uprev; tol=integrator.opts.abstol) # abstol or reltol?
+  A_mul_B!(tmp,A,u)
+  f.f2(rtmp,u,p,t+dt)
+  @. k = tmp + rtmp
+end

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -208,7 +208,7 @@ function perform_step!(integrator, cache::LawsonEulerKrylovConstantCache, repeat
   @unpack t,dt,uprev,u,f,p = integrator
   rtmp = integrator.fsalfirst
   A = f.f1
-  @muladd u = expmv(dt, A, uprev + dt*rtmp; tol=integrator.opts.abstol) # abstol or reltol?
+  @muladd u = expmv(dt, A, uprev + dt*rtmp; tol=abs(integrator.opts.abstol)) # abstol or reltol?
   rtmp = f.f2(u,p,t+dt)
   k = A*u + rtmp # For the interpolation, needs k at the updated point
   integrator.fsallast = rtmp
@@ -235,7 +235,7 @@ function perform_step!(integrator, cache::LawsonEulerKrylovCache, repeat_step=fa
   @unpack k,rtmp,tmp = cache
   A = f.f1
   @muladd @. tmp = uprev + dt*integrator.fsalfirst
-  expmv!(u,dt,A,tmp; tol=integrator.opts.abstol) # abstol or reltol?
+  expmv!(u,dt,A,tmp; tol=abs(integrator.opts.abstol)) # abstol or reltol?
   A_mul_B!(tmp,A,u)
   f.f2(rtmp,u,p,t+dt)
   @. k = tmp + rtmp
@@ -257,7 +257,7 @@ function perform_step!(integrator, cache::ExpEulerKrylovConstantCache, repeat_st
   @unpack t,dt,uprev,u,f,p = integrator
   rtmp = integrator.fsalfirst
   A = f.f1
-  u = phimv(dt, A, rtmp, u; tol=integrator.opts.abstol) # abstol or reltol?
+  u = phimv(dt, A, rtmp, u; tol=abs(integrator.opts.abstol)) # abstol or reltol?
   rtmp = f.f2(u,p,t+dt)
   k = A*u + rtmp # For the interpolation, needs k at the updated point
   integrator.fsallast = rtmp
@@ -283,7 +283,7 @@ function perform_step!(integrator, cache::ExpEulerKrylovCache, repeat_step=false
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack k,rtmp,tmp = cache
   A = f.f1
-  phimv!(u,dt,A,integrator.fsalfirst,uprev; tol=integrator.opts.abstol) # abstol or reltol?
+  phimv!(u,dt,A,integrator.fsalfirst,uprev; tol=abs(integrator.opts.abstol)) # abstol or reltol?
   A_mul_B!(tmp,A,u)
   f.f2(rtmp,u,p,t+dt)
   @. k = tmp + rtmp

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -187,3 +187,56 @@ function perform_step!(integrator, cache::ETDRK4Cache, repeat_step=false)
 
   integrator.f(tmp2, u, p, t+dt)
 end
+
+###############################################
+
+# Exponential Krylov methods
+
+function initialize!(integrator, cache::LawsonEulerKrylovConstantCache)
+  integrator.kshortsize = 2
+  integrator.k = typeof(integrator.k)(integrator.kshortsize)
+  rtmp = integrator.f.f2(integrator.uprev,integrator.p,integrator.t)
+  integrator.fsalfirst = rtmp # Pre-start fsal
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = zero(integrator.fsalfirst)
+end
+
+function perform_step!(integrator, cache::LawsonEulerKrylovConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  rtmp = integrator.fsalfirst
+  A = f.f1
+  @muladd u = expmv(dt, A, uprev + dt*rtmp; tol=integrator.opts.abstol) # abstol or reltol?
+  rtmp = f.f2(u,p,t+dt)
+  k = A*u + rtmp # For the interpolation, needs k at the updated point
+  integrator.fsallast = rtmp
+  integrator.k[1] = integrator.fsalfirst # this is wrong, since it's just rtmp. Should fsal this value though
+  integrator.k[2] = k
+  integrator.u = u
+end
+
+function initialize!(integrator, cache::LawsonEulerKrylovCache)
+  integrator.kshortsize = 2
+  @unpack k,fsalfirst,rtmp = cache
+  integrator.fsalfirst = fsalfirst
+  integrator.fsallast = rtmp
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k[1] = fsalfirst # this is wrong, since it's just rtmp. Should fsal this value though
+  integrator.k[2] = k
+  A = integrator.f.f1(k,integrator.u,integrator.p,integrator.t)
+  integrator.f.f2(rtmp,integrator.uprev,integrator.p,integrator.t) # For the interpolation, needs k at the updated point
+  @. integrator.fsalfirst = k + rtmp
+end
+
+function perform_step!(integrator, cache::LawsonEulerKrylovCache, repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack k,rtmp,tmp = cache
+  A = f.f1
+  @muladd @. tmp = uprev + dt*integrator.fsalfirst
+  expmv!(u,dt,A,tmp; tol=integrator.opts.abstol) # abstol or reltol?
+  A_mul_B!(tmp,A,u)
+  f.f2(rtmp,u,p,t+dt)
+  @. k = tmp + rtmp
+end

--- a/test/linear_nonlinear_Krylov_tests.jl
+++ b/test/linear_nonlinear_Krylov_tests.jl
@@ -13,7 +13,7 @@ Base.A_mul_B!(Y, op::MatrixOperator, B) = A_mul_B!(Y, op.A, B)
 (op::MatrixOperator)(u,p,t) = op.A * u
 (op::MatrixOperator)(du,u,p,t) = A_mul_B!(du, op.A, u)
 
-N = 100
+N = 20
 b = 0.2
 tspan = (0.0, 1.0)
 dts = 1./2.^(7:-1:4) #14->7 good plot

--- a/test/linear_nonlinear_Krylov_tests.jl
+++ b/test/linear_nonlinear_Krylov_tests.jl
@@ -13,25 +13,24 @@ Base.A_mul_B!(Y, op::MatrixOperator, B) = A_mul_B!(Y, op.A, B)
 (op::MatrixOperator)(u,p,t) = op.A * u
 (op::MatrixOperator)(du,u,p,t) = A_mul_B!(du, op.A, u)
 
-const N = 100
-const b = 0.2
+N = 100
+b = 0.2
+tspan = (0.0, 1.0)
+dts = 1./2.^(7:-1:4) #14->7 good plot
 #########################################
 # Test problem 1 (heat equation with radiative loss, u' = Au - bu)
 dd = -2 * ones(N); du = ones(N - 1)
 A = spdiagm((du,dd,du), (-1,0,1))
 f1 = MatrixOperator(A)
-f2(u,p,t) = -b * u
-f2!(du,u,p,t) = du .= -b * u
+f2 = (u,p,t) -> -b * u
 
 srand(0); u0 = rand(N)
-tspan = (0.0, 1.0)
 prob = SplitODEProblem(f1,f2,u0,tspan)
 function (::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t)
     tmp = (A - b*I)*t
     return expm(full(tmp)) * u0
 end
 
-dts = 1./2.^(7:-1:4) #14->7 good plot
 sim = test_convergence(dts,prob,LawsonEulerKrylov())
 @test abs(sim.𝒪est[:l2]-1) < 0.1
 sim = test_convergence(dts,prob,ExpEulerKrylov())
@@ -40,9 +39,9 @@ sim = test_convergence(dts,prob,ExpEulerKrylov())
 # Test problem 2 (Schrodinger Equation, iu' = -Au - bu)
 # Uses in-place functions
 f1 = MatrixOperator(1im * A)
-f2!(du,u,p,t) = du .= (1im*b) * u
+f2 = (du,u,p,t) -> du .= (1im*b) * u
 u0 = complex(u0)
-prob = SplitODEProblem(f1,f2!,u0,tspan)
+prob = SplitODEProblem(f1,f2,u0,tspan)
 function (::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t)
     tmp = (A + b*I) * (1im*t)
     return expm(full(tmp)) * u0

--- a/test/linear_nonlinear_Krylov_tests.jl
+++ b/test/linear_nonlinear_Krylov_tests.jl
@@ -1,0 +1,54 @@
+using OrdinaryDiffEq, Base.Test, DiffEqDevTools
+
+# Ad-hoc functor type for matrices
+struct MatrixOperator{T <: AbstractMatrix}
+    A::T
+end
+Base.eltype(op::MatrixOperator) = eltype(op.A)
+Base.size(op::MatrixOperator, args...) = size(op.A, args...)
+Base.norm(op::MatrixOperator, args...) = norm(op.A, args...)
+Base. *(op::MatrixOperator, B) = op.A * B
+Base. *(B, op::MatrixOperator) = B * op.A
+Base.A_mul_B!(Y, op::MatrixOperator, B) = A_mul_B!(Y, op.A, B)
+(op::MatrixOperator)(u,p,t) = op.A * u
+(op::MatrixOperator)(du,u,p,t) = A_mul_B!(du, op.A, u)
+
+const N = 100
+const b = 0.2
+#########################################
+# Test problem 1 (heat equation with radiative loss, u' = Au - bu)
+dd = -2 * ones(N); du = ones(N - 1)
+A = spdiagm((du,dd,du), (-1,0,1))
+f1 = MatrixOperator(A)
+f2(u,p,t) = -b * u
+f2!(du,u,p,t) = du .= -b * u
+
+srand(0); u0 = rand(N)
+tspan = (0.0, 1.0)
+prob = SplitODEProblem(f1,f2,u0,tspan)
+function (::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t)
+    tmp = (A - b*I)*t
+    return expm(full(tmp)) * u0
+end
+
+dts = 1./2.^(7:-1:4) #14->7 good plot
+sim = test_convergence(dts,prob,LawsonEulerKrylov())
+@test abs(sim.𝒪est[:l2]-1) < 0.1
+sim = test_convergence(dts,prob,ExpEulerKrylov())
+@test abs(sim.𝒪est[:l2]-1) < 0.1
+#########################################
+# Test problem 2 (Schrodinger Equation, iu' = -Au - bu)
+# Uses in-place functions
+f1 = MatrixOperator(1im * A)
+f2!(du,u,p,t) = du .= (1im*b) * u
+u0 = complex(u0)
+prob = SplitODEProblem(f1,f2!,u0,tspan)
+function (::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t)
+    tmp = (A + b*I) * (1im*t)
+    return expm(full(tmp)) * u0
+end
+
+sim = test_convergence(dts,prob,LawsonEulerKrylov())
+@test abs(sim.𝒪est[:l2]-1) < 0.1
+sim = test_convergence(dts,prob,ExpEulerKrylov())
+@test abs(sim.𝒪est[:l2]-1) < 0.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,6 @@ end
 #Start Test Script
 
 tic()
-
 if group == "All" || group == "Interface"
     @time @testset "Discrete Tests" begin include("discrete_algorithm_test.jl") end
     @time @testset "Tstops Tests" begin include("ode/ode_tstops_tests.jl") end
@@ -51,6 +50,7 @@ if group == "All" || group == "AlgConvergence"
     @time @testset "Rosenbrock Tests" begin include("ode/ode_rosenbrock_tests.jl") end
     @time @testset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
     @time @testset "Split Methods Tests" begin include("split_methods_tests.jl") end
+    @time @testset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_Krylov_tests.jl") end
     #@time @testset "Linear Methods Tests" begin include("linear_method_tests.jl") end
     @time @testset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
 end


### PR DESCRIPTION
This is meant to track my progress in the implementation of exponential integrators that uses Krylov methods to approximate matrix functions, as suggested by @ChrisRackauckas .

Currently I have implemented the `LawsonEulerKrylov` and `ExpEulerKrylov` methods using `LawsonEuler` as a template and the `expmv`/`phimv` functions from [Expokit.jl](https://github.com/acroy/Expokit.jl). Usage example:

```julia
using OrdinaryDiffEq, DiffEqOperators

# Need to first define norm for `DiffEqArrayOperator`
Base.norm(f::DiffEqArrayOperator, l) = norm(f.A, l)

# Solve for the test system u' = au + bu.^2
a = 1.0; b = 0.01; N = 1000

f1 = DiffEqArrayOperator(a * eye(N))
f2(u,p,t) = b * u.^2

u0 = randn(N); tspan = (0., 1.)
prob = SplitODEProblem(f1, f2, u0, tspan)
dt = 0.01

sol1 = solve(prob, LawsonEulerKrylov(); dt=dt)
sol2 = solve(prob, ExpEulerKrylov(); dt=dt)
```

I'm still having some problems with the test suites though as the convergence tests seem to fail. Also I'm not sure if this works on the nonlinear Schrödinger equation at the moment.

One problem is that the Krylov methods and the full caching methods share most of their code. It may be a good idea to restructure the code so that code reuse is familited between the two versions, while also opening up ways for us to include other approximations to matrix functions (say the Chebyshev method). For example, I can expand on the `AbstractDiffEqLinearOperator` interface (as suggested [in the docs](http://docs.juliadiffeq.org/latest/features/diffeq_operator.html)) and have a particular algorithm's `expmv`/`phimv` calls dispatched with respect to the types of its linear part. 

Finally, the documentation of `SplitODEProblem` and `DiffEqOperators` are a bit lacking at the moment, so I can also do something about that first. (By the way why is `DiffEqOperators` its own package? This makes development with split ODE problems a bit awkward.)
