### PR TITLE
Complex compatibility for SDIRK solvers

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -253,7 +253,3 @@ ssp_coefficient(alg::SSPRK104) = 6
 # We shouldn't do this probably.
 #ssp_coefficient(alg::ImplicitEuler) = Inf
 ssp_coefficient(alg::SSPSDIRK2) = 4
-
-# Compute type for tolerance and related values
-toltype(::Type{T}) where {T <: Real} = T
-toltype(::Type{Complex{T}}) where {T <: Real} = T

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -253,3 +253,7 @@ ssp_coefficient(alg::SSPRK104) = 6
 # We shouldn't do this probably.
 #ssp_coefficient(alg::ImplicitEuler) = Inf
 ssp_coefficient(alg::SSPSDIRK2) = 4
+
+# Compute type for tolerance and related values
+toltype(::Type{T}) where {T <: Real} = T
+toltype(::Type{Complex{T}}) where {T <: Real} = T

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -1,38 +1,39 @@
-mutable struct KenCarp3ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct KenCarp3ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   if typeof(f) <: SplitFunction
     uf = DiffEqDiffTools.UDerivativeWrapper(f.f1,t,p)
   else
     uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   end
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = KenCarp3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = KenCarp3Tableau(uToltype,real(tTypeNoUnits))
 
   KenCarp3ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct KenCarp3Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F,kType} <: OrdinaryDiffEqMutableCache
+mutable struct KenCarp3Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F,kType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -55,9 +56,9 @@ mutable struct KenCarp3Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -91,60 +92,62 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = KenCarp3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = KenCarp3Tableau(uToltype,real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   KenCarp3Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve),typeof(k1)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve),typeof(k1)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,k1,k2,k3,k4,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Kvaerno4ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct Kvaerno4ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
   uprev3 = u
   tprev2 = t
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Kvaerno4Tableau(uToltype,real(tTypeNoUnits))
 
   Kvaerno4ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Kvaerno4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F} <: OrdinaryDiffEqMutableCache
+mutable struct Kvaerno4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -164,9 +167,9 @@ mutable struct Kvaerno4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -193,64 +196,66 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Kvaerno4Tableau(uToltype,real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   Kvaerno4Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct KenCarp4ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct KenCarp4ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   if typeof(f) <: SplitFunction
     uf = DiffEqDiffTools.UDerivativeWrapper(f.f1,t,p)
   else
     uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   end
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
   uprev3 = u
   tprev2 = t
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = KenCarp4Tableau(uToltype,real(tTypeNoUnits))
 
   KenCarp4ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct KenCarp4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F,kType} <: OrdinaryDiffEqMutableCache
+mutable struct KenCarp4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F,kType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -277,9 +282,9 @@ mutable struct KenCarp4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -316,59 +321,61 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = KenCarp4Tableau(uToltype,real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   KenCarp4Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve),typeof(k1)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve),typeof(k1)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,k1,k2,k3,k4,k5,k6,
               dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Kvaerno5ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct Kvaerno5ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Kvaerno5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Kvaerno5Tableau(uToltype,real(tTypeNoUnits))
 
   Kvaerno5ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Kvaerno5Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F} <: OrdinaryDiffEqMutableCache
+mutable struct Kvaerno5Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -390,9 +397,9 @@ mutable struct Kvaerno5Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -420,62 +427,64 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Kvaerno5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Kvaerno5Tableau(uToltype,real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   Kvaerno5Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct KenCarp5ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct KenCarp5ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   if typeof(f) <: SplitFunction
     uf = DiffEqDiffTools.UDerivativeWrapper(f.f1,t,p)
   else
     uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   end
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = KenCarp5Tableau(uToltype,real(tTypeNoUnits))
 
   KenCarp5ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct KenCarp5Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F,kType} <: OrdinaryDiffEqMutableCache
+mutable struct KenCarp5Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F,kType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -506,9 +515,9 @@ mutable struct KenCarp5Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -549,23 +558,24 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   KenCarp5Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve),typeof(k1)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve),typeof(k1)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,
               k1,k2,k3,k4,k5,k6,k7,k8,
               dz,b,tmp,atmp,J,

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -163,38 +163,39 @@ function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottom
   ImplicitMidpointCache(u,uprev,du1,fsalfirst,k,z,dz,b,tmp,J,W,uf,jac_config,linsolve,ηold,κ,tol,10000)
 end
 
-mutable struct TrapezoidConstantCache{F,uEltypeNoUnits,uType,tType} <: OrdinaryDiffEqConstantCache
+mutable struct TrapezoidConstantCache{F,uToltype,uType,tType} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   uprev3::uType
   tprev2::tType
 end
 
-function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  uToltype = toltype(uBottomEltypeNoUnits)
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
   uprev3 = u
   tprev2 = t
 
   if alg.κ != nothing
     κ = alg.κ
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   TrapezoidConstantCache(uf,ηold,κ,tol,10000,uprev3,tprev2)
 end
 
-mutable struct TrapezoidCache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,tType,F} <: OrdinaryDiffEqMutableCache
+mutable struct TrapezoidCache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,tType,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
@@ -211,9 +212,9 @@ mutable struct TrapezoidCache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   uprev3::uType
   tprev2::tType
@@ -239,21 +240,22 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = toltype(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   uprev3 = similar(u)
   tprev2 = t
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   TrapezoidCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,ηold,κ,tol,10000,uprev3,tprev2)
 end

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -175,7 +175,7 @@ end
 
 function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  uToltype = toltype(uBottomEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   ηold = one(uToltype)
   uprev3 = u
@@ -240,7 +240,7 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
-  uToltype = toltype(uBottomEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
     κ = uToltype(alg.κ)
   else

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -1,4 +1,4 @@
-mutable struct ImplicitEulerCache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,F} <: OrdinaryDiffEqMutableCache
+mutable struct ImplicitEulerCache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
@@ -15,9 +15,9 @@ mutable struct ImplicitEulerCache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoU
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
@@ -39,75 +39,78 @@ function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomElt
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
   ImplicitEulerCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,ηold,κ,tol,10000)
 end
 
-mutable struct ImplicitEulerConstantCache{F,uEltypeNoUnits} <: OrdinaryDiffEqConstantCache
+mutable struct ImplicitEulerConstantCache{F,uToltype} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
 function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   ImplicitEulerConstantCache(uf,ηold,κ,tol,100000)
 end
 
-mutable struct ImplicitMidpointConstantCache{F,uEltypeNoUnits} <: OrdinaryDiffEqConstantCache
+mutable struct ImplicitMidpointConstantCache{F,uToltype} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
-function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   ImplicitMidpointConstantCache(uf,ηold,κ,tol,10000)
 end
 
-mutable struct ImplicitMidpointCache{uType,rateType,J,UF,JC,uEltypeNoUnits,F} <: OrdinaryDiffEqMutableCache
+mutable struct ImplicitMidpointCache{uType,rateType,J,UF,JC,uToltype,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -122,9 +125,9 @@ mutable struct ImplicitMidpointCache{uType,rateType,J,UF,JC,uEltypeNoUnits,F} <:
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
@@ -147,18 +150,19 @@ function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottom
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   ImplicitMidpointCache(u,uprev,du1,fsalfirst,k,z,dz,b,tmp,J,W,uf,jac_config,linsolve,ηold,κ,tol,10000)
 end
@@ -182,7 +186,7 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   tprev2 = t
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
     κ = uToltype(1//100)
   end
@@ -260,37 +264,38 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   TrapezoidCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,ηold,κ,tol,10000,uprev3,tprev2)
 end
 
-mutable struct TRBDF2ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct TRBDF2ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = TRBDF2Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = TRBDF2Tableau(uToltype,real(tTypeNoUnits))
 
   TRBDF2ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct TRBDF2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F} <: OrdinaryDiffEqMutableCache
+mutable struct TRBDF2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -308,9 +313,9 @@ mutable struct TRBDF2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Ta
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -336,55 +341,57 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = TRBDF2Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = TRBDF2Tableau(uToltype,real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   TRBDF2Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,zprev,zᵧ,z,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct SDIRK2ConstantCache{F,uEltypeNoUnits} <: OrdinaryDiffEqConstantCache
+mutable struct SDIRK2ConstantCache{F,uToltype} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
-function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   SDIRK2ConstantCache(uf,ηold,κ,tol,10000)
 end
 
-mutable struct SDIRK2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,F} <: OrdinaryDiffEqMutableCache
+mutable struct SDIRK2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -401,9 +408,9 @@ mutable struct SDIRK2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,F}
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
@@ -428,55 +435,57 @@ function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   SDIRK2Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000)
 end
 
-mutable struct SSPSDIRK2ConstantCache{F,uEltypeNoUnits} <: OrdinaryDiffEqConstantCache
+mutable struct SSPSDIRK2ConstantCache{F,uToltype} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
-function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
   uprev3 = u
   tprev2 = t
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   SSPSDIRK2ConstantCache(uf,ηold,κ,tol,10000)
 end
 
-mutable struct SSPSDIRK2Cache{uType,rateType,J,UF,JC,uEltypeNoUnits,F} <: OrdinaryDiffEqMutableCache
+mutable struct SSPSDIRK2Cache{uType,rateType,J,UF,JC,uToltype,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -492,9 +501,9 @@ mutable struct SSPSDIRK2Cache{uType,rateType,J,UF,JC,uEltypeNoUnits,F} <: Ordina
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
 end
 
@@ -519,56 +528,58 @@ function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   SSPSDIRK2Cache{typeof(u),typeof(rate_prototype),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,dz,b,tmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000)
 end
 
-mutable struct Kvaerno3ConstantCache{UF,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct Kvaerno3ConstantCache{UF,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::UF
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Kvaerno3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Kvaerno3Tableau(uToltype,real(tTypeNoUnits))
 
   Kvaerno3ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Kvaerno3Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F} <: OrdinaryDiffEqMutableCache
+mutable struct Kvaerno3Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -587,9 +598,9 @@ mutable struct Kvaerno3Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -615,58 +626,60 @@ function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   tab = Kvaerno3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   Kvaerno3Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Cash4ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct Cash4ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Cash4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Cash4Tableau(uToltype,real(tTypeNoUnits))
 
   Cash4ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Cash4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F} <: OrdinaryDiffEqMutableCache
+mutable struct Cash4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -686,9 +699,9 @@ mutable struct Cash4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -715,62 +728,64 @@ function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
-  tab = Cash4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  tab = Cash4Tableau(uToltype,real(tTypeNoUnits))
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   Cash4Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Hairer4ConstantCache{F,uEltypeNoUnits,Tab} <: OrdinaryDiffEqConstantCache
+mutable struct Hairer4ConstantCache{F,uToltype,Tab} <: OrdinaryDiffEqConstantCache
   uf::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
 
-function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,tTypeNoUnits,uBottomEltypeNoUnits,
+function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  ηold = one(uEltypeNoUnits)
+  uToltype = real(uBottomEltypeNoUnits)
+  ηold = one(uToltype)
 
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   if typeof(alg) <: Hairer4
-    tab = Hairer4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+    tab = Hairer4Tableau(uToltype,real(tTypeNoUnits))
   else
-    tab = Hairer42Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+    tab = Hairer42Tableau(uToltype,real(tTypeNoUnits))
   end
 
   Hairer4ConstantCache(uf,ηold,κ,tol,10000,tab)
 end
 
-mutable struct Hairer4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,Tab,F} <: OrdinaryDiffEqMutableCache
+mutable struct Hairer4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,Tab,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -790,9 +805,9 @@ mutable struct Hairer4Cache{uType,rateType,uNoUnitsType,J,UF,JC,uEltypeNoUnits,T
   uf::UF
   jac_config::JC
   linsolve::F
-  ηold::uEltypeNoUnits
-  κ::uEltypeNoUnits
-  tol::uEltypeNoUnits
+  ηold::uToltype
+  κ::uToltype
+  tol::uToltype
   newton_iters::Int
   tab::Tab
 end
@@ -819,27 +834,28 @@ function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,
   linsolve = alg.linsolve(Val{:init},uf,u)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
+  uToltype = real(uBottomEltypeNoUnits)
   if alg.κ != nothing
-    κ = alg.κ
+    κ = uToltype(alg.κ)
   else
-    κ = uEltypeNoUnits(1//100)
+    κ = uToltype(1//100)
   end
   if alg.tol != nothing
-    tol = alg.tol
+    tol = uToltype(alg.tol)
   else
-    tol = min(0.03,first(reltol)^(0.5))
+    tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
 
   if typeof(alg) <: Hairer4
-    tab = Hairer4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+    tab = Hairer4Tableau(uToltype,real(tTypeNoUnits))
   else # Hairer42
-    tab = Hairer42Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+    tab = Hairer42Tableau(uToltype,real(tTypeNoUnits))
   end
 
-  ηold = one(uEltypeNoUnits)
+  ηold = one(uToltype)
 
   Hairer4Cache{typeof(u),typeof(rate_prototype),typeof(atmp),typeof(J),typeof(uf),
-              typeof(jac_config),uEltypeNoUnits,typeof(tab),typeof(linsolve)}(
+              typeof(jac_config),uToltype,typeof(tab),typeof(linsolve)}(
               u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,ηold,κ,tol,10000,tab)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -111,23 +111,23 @@ function init{algType<:OrdinaryDiffEqAlgorithm,recompile_flag}(
   tTypeNoUnits   = typeof(one(tType))
 
   if typeof(alg) <: FunctionMap
-    abstol_internal = zero(u)
+    abstol_internal = real.(zero(u))
   elseif abstol == nothing
     if uBottomEltypeNoUnits == uBottomEltype || !(typeof(u) <: ArrayPartition)
-      abstol_internal = uBottomEltype(uBottomEltype(1)*1//10^6)
+      abstol_internal = real(uBottomEltype(uBottomEltype(1)*1//10^6))
     else
-      abstol_internal = ones(u).*1//10^6
+      abstol_internal = real.(ones(u).*1//10^6)
     end
   else
-    abstol_internal = abstol
+    abstol_internal = real.(abstol)
   end
 
   if typeof(alg) <: FunctionMap
-    reltol_internal = zero(first(u)/t)
+    reltol_internal = real.(zero(first(u)/t))
   elseif reltol == nothing
-    reltol_internal = uBottomEltypeNoUnits(1//10^3)
+    reltol_internal = real(uBottomEltypeNoUnits(1//10^3))
   else
-    reltol_internal = reltol
+    reltol_internal = real.(reltol)
   end
 
   dtmax > zero(dtmax) && tdir < 0 && (dtmax *= tdir) # Allow positive dtmax, but auto-convert

--- a/test/complex_tests.jl
+++ b/test/complex_tests.jl
@@ -16,14 +16,48 @@ explicit = [Midpoint(),RK4(),DP5(),Tsit5(),Vern7()]
 implicit_autodiff = [ImplicitEuler(),Trapezoid(),Kvaerno3(),Rosenbrock23()]
 implicit_noautodiff = [ImplicitEuler(autodiff=false),Trapezoid(autodiff=false),Kvaerno3(autodiff=false),Rosenbrock23(autodiff=false)]
 
+for alg in explicit
+    for f in (fun, fun_inplace)
+        ψ0 = [1.0+0.0im; 0.0]
+        prob = ODEProblem(f,ψ0,(-T,T))
+        sol = solve(prob,alg)
+        @test abs(norm(sol(T)) - 1.0) < 1e-2
+    end
+    ψ0 = @SArray [1.0+0.0im; 0.0]
+    prob = ODEProblem(fun,ψ0,(-T,T))
+    sol = solve(prob,alg)
+    @test abs(norm(sol(T)) - 1.0) < 1e-2
+end
+
 @test_broken begin
-    for alg in (explicit..., implicit_autodiff..., implicit_noautodiff...)
+    for alg in implicit_autodiff
         for f in (fun, fun_inplace)
             ψ0 = [1.0+0.0im; 0.0]
             prob = ODEProblem(f,ψ0,(-T,T))
             sol = solve(prob,alg)
             @test abs(norm(sol(T)) - 1.0) < 1e-2
         end
+        ψ0 = @SArray [1.0+0.0im; 0.0]
+        prob = ODEProblem(fun,ψ0,(-T,T))
+        sol = solve(prob,alg)
+        @test abs(norm(sol(T)) - 1.0) < 1e-2
+    end
+end
+
+for alg in implicit_noautodiff
+    ψ0 = [1.0+0.0im; 0.0]
+    prob = ODEProblem(fun_inplace,ψ0,(-T,T))
+    sol = solve(prob,alg)
+    @test abs(norm(sol(T)) - 1.0) < 1e-2
+end
+
+@test_broken begin
+    for alg in implicit_noautodiff
+        ψ0 = [1.0+0.0im; 0.0]
+        prob = ODEProblem(fun,ψ0,(-T,T))
+        sol = solve(prob,alg)
+        @test abs(norm(sol(T)) - 1.0) < 1e-2
+
         ψ0 = @SArray [1.0+0.0im; 0.0]
         prob = ODEProblem(fun,ψ0,(-T,T))
         sol = solve(prob,alg)


### PR DESCRIPTION
This is to fix the issue mentioned here:

https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/263

Current only the `Trapezoid` solver is changed. If this is ok I will do a sweep and fix all methods in _src/sdirk_caches.jl_.

```julia
using OrdinaryDiffEq
fun(du,u,p,t) = du .= 1.01 * u
u0 = complex.(rand(3), rand(3))
prob = ODEProblem(fun, u0, (0.,1.))
integrator = init(prob, Trapezoid(autodiff=false))
step!(integrator)
@show integrator.u
@show integrator.opts.abstol
@show integrator.cache.tol

integrator.u = Complex{Float64}[0.301987+0.34158im, 0.375765+0.213668im, 0.959003+0.567313im]
integrator.opts.abstol = 1.0e-6
integrator.cache.tol = 0.03
```

Note that the non in-place version still wouldn't work because it always uses autodiff and it seems `ForwardDiff` doesn't support complex numbers at the moment.

Any complex type should work fine, for example `Complex{BigFloat}`:

```julia
fun(du,u,p,t) = du .= BigFloat(1.01) * u
u0 = complex.(BigFloat.(rand(3)), BigFloat.(rand(3)))
prob = ODEProblem(fun, u0, (0.,1.))
integrator = init(prob, Trapezoid(autodiff=false))
step!(integrator)
@show integrator.u
@show integrator.opts.abstol
@show integrator.cache.tol

integrator.u = Complex{BigFloat}[2.679858206626884697903598767224898104940434506808948024123236895484489044748831e-01+3.921263588544868552646750965152075957478933078567815669442307422935384996729011e-01im, 1.88132689477089063573093699949069719988702691486065157103197451208253684743379e-01+2.253309322148819911393625846574983901669478764490170771497564706309733078302334e-01im, 8.244022822168234507675387805035939410329717133546315069417702181305616784803873e-01+2.47932958697165370811102887489999317237715898236108469078444600521011934967557e-01im]
integrator.opts.abstol = 1.000000000000000000000000000000000000000000000000000000000000000000000000000004e-06
integrator.cache.tol = 2.999999999999999888977697537484345957636833190917968750000000000000000000000000e-02
```

There's also a minor fix that corrects the ordering of arguments for the `alg_cache` function.