### PR TITLE
Tests for complex ODEs

### DIFF
--- a/test/complex_tests.jl
+++ b/test/complex_tests.jl
@@ -1,0 +1,32 @@
+# Solve the Landau-Zener problem i ψ' = H(t) ψ, with H(t) = [t 1;1 -t]
+
+using Base.Test
+using StaticArrays
+using OrdinaryDiffEq, DiffEqBase
+
+
+H(t) = -im*(@SMatrix [t 1;1 -t])
+
+fun(ψ,p,t) = H(t)*ψ
+fun_inplace(dψ,ψ,p,t) = (dψ .= H(t)*ψ)
+
+T = 0.1
+tspan = (0,T)
+explicit = [Midpoint(),RK4(),DP5(),Tsit5(),Vern7()]
+implicit_autodiff = [ImplicitEuler(),Trapezoid(),Kvaerno3(),Rosenbrock23()]
+implicit_noautodiff = [ImplicitEuler(autodiff=false),Trapezoid(autodiff=false),Kvaerno3(autodiff=false),Rosenbrock23(autodiff=false)]
+
+@test_broken begin
+    for alg in (explicit..., implicit_autodiff..., implicit_noautodiff...)
+        for f in (fun, fun_inplace)
+            ψ0 = [1.0+0.0im; 0.0]
+            prob = ODEProblem(f,ψ0,(-T,T))
+            sol = solve(prob,alg)
+            @test abs(norm(sol(T)) - 1.0) < 1e-2
+        end
+        ψ0 = @SArray [1.0+0.0im; 0.0]
+        prob = ODEProblem(fun,ψ0,(-T,T))
+        sol = solve(prob,alg)
+        @test abs(norm(sol(T)) - 1.0) < 1e-2
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,6 @@ end
 #Start Test Script
 
 tic()
-
 if group == "All" || group == "Interface"
     @time @testset "Discrete Tests" begin include("discrete_algorithm_test.jl") end
     @time @testset "Tstops Tests" begin include("ode/ode_tstops_tests.jl") end
@@ -37,6 +36,7 @@ if group == "All" || group == "Interface"
     @time @testset "u_modifed Tests" begin include("umodified_test.jl") end
     @time @testset "Composite Algorithm Tests" begin include("composite_algorithm_test.jl") end
     @time @testset "Integrator Interface Tests" begin include("integrator_interface_tests.jl") end
+    @time @testset "Complex Tests" begin include("complex_tests.jl") end
 end
 
 if group == "All" || group == "Regression"


### PR DESCRIPTION
This tests explicit and implicit solvers for a simple complex ODE (Schrödinger equation), using various combinations of inplace, out of place, static arrays, autodiff and finite differences. Ref https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/263, https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/259

I put in a random selection of ODE solvers (wanted to enumerate all subtypes of OrdinaryDiffEqAlgorithm but that had a number of tricks to it). Explicit solvers are working, implicit are not.

Btw, the Schrödinger equation i psi' = H(t) psi / eps with eps small is a pretty fun equation (the solution stays on the eigenstates of H(t) for eps small) that is highly oscillatory and therefore tricky to solve. If working, it would make for a cute showcase of DifferentialEquations's unique capabilities (complex numbers, stiff solvers with autodiff, matrix exponentials...)