### PR TITLE
Krylov Method Swtich in Exponential Integrators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -13,3 +13,4 @@ Compat 0.18.0
 Reexport
 MuladdMacro 0.0.2
 StaticArrays
+Expokit

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -20,7 +20,7 @@ module OrdinaryDiffEq
   using Parameters, GenericSVD, ForwardDiff, RecursiveArrayTools,
         NLsolve, Juno, Roots, DataStructures, DiffEqDiffTools
 
-  using Expokit: expmv, expmv!
+  using Expokit: expmv, expmv!, phimv, phimv!
 
   import Base: linspace
 

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -20,6 +20,8 @@ module OrdinaryDiffEq
   using Parameters, GenericSVD, ForwardDiff, RecursiveArrayTools,
         NLsolve, Juno, Roots, DataStructures, DiffEqDiffTools
 
+  using Expokit: expmv, expmv!
+
   import Base: linspace
 
   import Base: start, next, done, eltype

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -597,7 +597,10 @@ struct GenericIIF2{F} <: OrdinaryDiffEqExponentialAlgorithm
 end
 Base.@pure GenericIIF2(;nlsolve=NLSOLVEJL_SETUP()) = GenericIIF2{typeof(nlsolve)}(nlsolve)
 
-struct LawsonEuler <: OrdinaryDiffEqExponentialAlgorithm end
+struct LawsonEuler <: OrdinaryDiffEqExponentialAlgorithm 
+  krylov::Bool
+end
+Base.@pure LawsonEuler(;krylov=false) = LawsonEuler(krylov)
 struct NorsettEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -601,7 +601,10 @@ struct LawsonEuler <: OrdinaryDiffEqExponentialAlgorithm
   krylov::Bool
 end
 Base.@pure LawsonEuler(;krylov=false) = LawsonEuler(krylov)
-struct NorsettEuler <: OrdinaryDiffEqExponentialAlgorithm end
+struct NorsettEuler <: OrdinaryDiffEqExponentialAlgorithm
+  krylov::Bool
+end
+Base.@pure NorsettEuler(;krylov=false) = NorsettEuler(krylov)
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -120,20 +120,25 @@ struct NorsettEulerCache{uType,rateType,expType} <: OrdinaryDiffEqMutableCache
 end
 
 function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  A = f.f1
-  if typeof(A.A) <: Diagonal
-      _expA = expm(A*dt)
-      phi1 = Diagonal(Float64.((big.(_expA)-I)/A.A))
-      expA = Diagonal(_expA)
-
-      # Fix zero eigenvalues
-      for i in 1:size(phi1,1)
-          phi1[i,i] = ifelse(A[i,i]==0,dt,phi1[i,i])
-      end
-
+  if alg.krylov
+    expA = nothing
+    phi1 = nothing
   else
-      expA = expm(A*dt)
-      phi1 = ((expA-I)/A)
+    A = f.f1
+    if typeof(A.A) <: Diagonal
+        _expA = expm(A*dt)
+        phi1 = Diagonal(Float64.((big.(_expA)-I)/A.A))
+        expA = Diagonal(_expA)
+
+        # Fix zero eigenvalues
+        for i in 1:size(phi1,1)
+            phi1[i,i] = ifelse(A[i,i]==0,dt,phi1[i,i])
+        end
+
+    else
+        expA = expm(A*dt)
+        phi1 = ((expA-I)/A)
+    end
   end
   NorsettEulerCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),expA,phi1,zeros(rate_prototype))
 end

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -92,8 +92,12 @@ struct LawsonEulerCache{uType,rateType,expType} <: OrdinaryDiffEqMutableCache
 end
 
 function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  A = f.f1
-  expA = expm(A*dt)
+  if alg.krylov
+    expA = nothing # no caching
+  else
+    A = f.f1
+    expA = expm(A*dt)
+  end
   LawsonEulerCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),expA,zeros(rate_prototype))
 end
 

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -14,7 +14,11 @@ function perform_step!(integrator, cache::LawsonEulerConstantCache, repeat_step=
   @unpack t,dt,uprev,u,f,p = integrator
   rtmp = integrator.fsalfirst
   A = f.f1
-  @muladd u = expm(dt*A)*(uprev + dt*rtmp)
+  if integrator.alg.krylov
+    @muladd u = expmv(dt, A, uprev + dt*rtmp; tol=integrator.opts.reltol)
+  else
+    @muladd u = expm(dt*A)*(uprev + dt*rtmp)
+  end
   rtmp = f.f2(u,p,t+dt)
   k = A*u + rtmp # For the interpolation, needs k at the updated point
   integrator.fsallast = rtmp
@@ -31,17 +35,21 @@ function initialize!(integrator, cache::LawsonEulerCache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = fsalfirst # this is wrong, since it's just rtmp. Should fsal this value though
   integrator.k[2] = k
-  A = integrator.f.f1(k,integrator.u,integrator.p,integrator.t)
+  integrator.f.f1(k,integrator.u,integrator.p,integrator.t)
   integrator.f.f2(rtmp,integrator.uprev,integrator.p,integrator.t) # For the interpolation, needs k at the updated point
   @. integrator.fsalfirst = k + rtmp
 end
 
 function perform_step!(integrator, cache::LawsonEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,rtmp,tmp,expA = cache
+  @unpack k,rtmp,tmp = cache
   A = f.f1
   @muladd @. tmp = uprev + dt*integrator.fsalfirst
-  A_mul_B!(u,expA,tmp)
+  if integrator.alg.krylov
+    expmv!(u,dt,A,tmp; tol=integrator.opts.reltol)
+  else
+    A_mul_B!(u,cache.expA,tmp)
+  end
   A_mul_B!(tmp,A,u)
   f.f2(rtmp,u,p,t+dt)
   @. k = tmp + rtmp

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -11,6 +11,10 @@ krylov_f2! = (du,u,p,t) -> du .= -0.1*u
 prob = SplitODEProblem(L,krylov_f2,u0,(0.0,1.0))
 prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
 
+# Ad-hoc fix for SplitFunction miscalssified as having analytic solutions
+DiffEqBase.has_analytic(::typeof(prob.f)) = false
+DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
+
 sol = solve(prob, LawsonEuler(); dt=dt)
 sol_krylov = solve(prob, LawsonEuler(krylov=true); dt=dt, reltol=reltol)
 @test isapprox(sol.u,sol_krylov.u; rtol=reltol)

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -1,0 +1,20 @@
+using OrdinaryDiffEq, Base.Test, DiffEqOperators
+N = 100
+dx = 1.0; dt=0.01
+srand(0); u0 = rand(N)
+reltol = 1e-4
+# L = DerivativeOperator{Float64}(2,2,dx,N,:Dirichlet0,:Dirichlet0) # error for caching version at the moment
+dd = -2.0 * ones(N); du = 1.0 * ones(N-1)
+A = diagm(du,-1) + diagm(dd,0) + diagm(du,1); L = DiffEqArrayOperator(A)
+krylov_f2 = (u,p,t) -> -0.1*u
+krylov_f2! = (du,u,p,t) -> du .= -0.1*u
+prob = SplitODEProblem(L,krylov_f2,u0,(0.0,1.0))
+prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
+
+sol = solve(prob, LawsonEuler(); dt=dt)
+sol_krylov = solve(prob, LawsonEuler(krylov=true); dt=dt, reltol=reltol)
+@test isapprox(sol.u,sol_krylov.u; rtol=reltol)
+
+sol_ip = solve(prob_inplace, LawsonEuler(); dt=0.01)
+sol_ip_krylov = solve(prob_inplace, LawsonEuler(krylov=true); dt=dt, reltol=reltol)
+@test isapprox(sol_ip.u,sol_ip_krylov.u; rtol=reltol)

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -15,10 +15,13 @@ prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
 DiffEqBase.has_analytic(::typeof(prob.f)) = false
 DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
 
-sol = solve(prob, LawsonEuler(); dt=dt)
-sol_krylov = solve(prob, LawsonEuler(krylov=true); dt=dt, reltol=reltol)
-@test isapprox(sol.u,sol_krylov.u; rtol=reltol)
+Algs = [LawsonEuler,NorsettEuler]
+for Alg in Algs
+    sol = solve(prob, Alg(); dt=dt)
+    sol_krylov = solve(prob, Alg(krylov=true); dt=dt, reltol=reltol)
+    @test isapprox(sol.u,sol_krylov.u; rtol=reltol)
 
-sol_ip = solve(prob_inplace, LawsonEuler(); dt=0.01)
-sol_ip_krylov = solve(prob_inplace, LawsonEuler(krylov=true); dt=dt, reltol=reltol)
-@test isapprox(sol_ip.u,sol_ip_krylov.u; rtol=reltol)
+    sol_ip = solve(prob_inplace, Alg(); dt=0.01)
+    sol_ip_krylov = solve(prob_inplace, Alg(krylov=true); dt=dt, reltol=reltol)
+    @test isapprox(sol_ip.u,sol_ip_krylov.u; rtol=reltol)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,8 +52,8 @@ if group == "All" || group == "AlgConvergence"
     @time @testset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
     @time @testset "Split Methods Tests" begin include("split_methods_tests.jl") end
     #@time @testset "Linear Methods Tests" begin include("linear_method_tests.jl") end
-    @time @testset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
     @time @testset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
+    @time @testset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
 end
 
 toc()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ if group == "All" || group == "AlgConvergence"
     @time @testset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
     @time @testset "Split Methods Tests" begin include("split_methods_tests.jl") end
     #@time @testset "Linear Methods Tests" begin include("linear_method_tests.jl") end
+    @time @testset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
     @time @testset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
 end
 


### PR DESCRIPTION
Second attempt at adding Krylov methods support to the existing exponential integrators.

The basic idea is to add a `krylov` argument to the algorithms' constructor. If it is set to `true`, no caching will be done at the initialization step and `expmv`/`expmv!` from _Expokit_ will be called in the iteration steps. This would also allow for further development using other lazy matrix function-vector application techniques, for example Chebyshev approximation, by adding other arguments to the algorithm while retaining the basic structure of the caches/iterations.

The exponential Krylov integrators should work nicely with the large-dimension derivative operators from _DiffEqOperators_ because they naturally support the _Expokit_ interface. (There's a minor problem that the derivative operators currently won't work with the caching version because `dt*L` yields a `LinearCombinations` and `expm(dt*L)` is not defined for the type. This should be easy to fix though).

Other low-order exponential methods can be modified similarly using `expmv` and `phimv` from _Expokit_, while methods using higher-order phi functions require more work.

A note about the tests: there's a peculiar problem that if I run the Krylov tests *after* the linear-nonlinear convergence tests there will be error. This may have something to do with the analytic solution defined in the linear-nonlinear convergence tests somehow polluting the global namespace. I need to take a deeper look into this. 