### PR TITLE
Tidying up the exponential integrators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.6
 DiffEqBase 3.3.0
+DiffEqOperators
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -15,6 +15,8 @@ module OrdinaryDiffEq
   # Internal utils
   import DiffEqBase: ODE_DEFAULT_NORM, ODE_DEFAULT_ISOUTOFDOMAIN, ODE_DEFAULT_PROG_MESSAGE, ODE_DEFAULT_UNSTABLE_CHECK
 
+  using DiffEqOperators: normbound, DiffEqArrayOperator
+
   import RecursiveArrayTools: chain
 
   using Parameters, GenericSVD, ForwardDiff, RecursiveArrayTools,

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -606,12 +606,14 @@ Base.@pure GenericIIF2(;nlsolve=NLSOLVEJL_SETUP()) = GenericIIF2{typeof(nlsolve)
 
 struct LawsonEuler <: OrdinaryDiffEqExponentialAlgorithm 
   krylov::Bool
+  m::Int
 end
-Base.@pure LawsonEuler(;krylov=false) = LawsonEuler(krylov)
+Base.@pure LawsonEuler(;krylov=false, m=30) = LawsonEuler(krylov, m)
 struct NorsettEuler <: OrdinaryDiffEqExponentialAlgorithm
   krylov::Bool
+  m::Int
 end
-Base.@pure NorsettEuler(;krylov=false) = NorsettEuler(krylov)
+Base.@pure NorsettEuler(;krylov=false, m=30) = NorsettEuler(krylov, m)
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -125,7 +125,7 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
     phi1 = nothing
   else
     A = f.f1
-    if typeof(A.A) <: Diagonal
+    if isa(A, DiffEqArrayOperator) && typeof(A.A) <: Diagonal
         _expA = expm(A*dt)
         phi1 = Diagonal(Float64.((big.(_expA)-I)/A.A))
         expA = Diagonal(_expA)

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -96,7 +96,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     expA = nothing # no caching
   else
     A = f.f1
-    expA = expm(A*dt)
+    expA = expm(full(A)*dt)
   end
   LawsonEulerCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),expA,zeros(rate_prototype))
 end
@@ -136,8 +136,9 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
         end
 
     else
-        expA = expm(A*dt)
-        phi1 = ((expA-I)/A)
+        fullA = full(A)
+        expA = expm(fullA*dt)
+        phi1 = ((expA-I)/fullA)
     end
   end
   NorsettEulerCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),expA,phi1,zeros(rate_prototype))

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -163,7 +163,7 @@ end
 function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   A = f.f1
   if isa(A, DiffEqArrayOperator)
-    L = A.A .* A.α.coeff # has specail handling is A.A is Diagonal
+    L = A.A .* A.α.coeff # has special handling is A.A is Diagonal
   else
     L = full(A)
   end

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -15,7 +15,7 @@ function perform_step!(integrator, cache::LawsonEulerConstantCache, repeat_step=
   rtmp = integrator.fsalfirst
   A = f.f1
   if integrator.alg.krylov
-    @muladd u = expmv(dt, A, uprev + dt*rtmp; tol=integrator.opts.reltol)
+    @muladd u = expmv(dt, A, uprev + dt*rtmp; tol=integrator.opts.reltol, m=min(integrator.alg.m, size(A,1)), norm=normbound)
   else
     @muladd u = expm(dt*A)*(uprev + dt*rtmp)
   end
@@ -46,7 +46,7 @@ function perform_step!(integrator, cache::LawsonEulerCache, repeat_step=false)
   A = f.f1
   @muladd @. tmp = uprev + dt*integrator.fsalfirst
   if integrator.alg.krylov
-    expmv!(u,dt,A,tmp; tol=integrator.opts.reltol)
+    expmv!(u,dt,A,tmp; tol=integrator.opts.reltol, m=min(integrator.alg.m, size(A,1)), norm=normbound)
   else
     A_mul_B!(u,cache.expA,tmp)
   end
@@ -72,7 +72,7 @@ function perform_step!(integrator, cache::NorsettEulerConstantCache, repeat_step
   rtmp = integrator.fsalfirst
   A = f.f1
   if integrator.alg.krylov
-    u = phimv(dt,A,rtmp,uprev; tol=integrator.opts.reltol)
+    u = phimv(dt,A,rtmp,uprev; tol=integrator.opts.reltol, m=min(integrator.alg.m, size(A,1)), norm=normbound)
   else
     u = uprev + ((expm(dt*A)-I)/A)*(A*uprev + rtmp)
   end
@@ -103,7 +103,7 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
   A = f.f1
 
   if integrator.alg.krylov
-    phimv!(u,dt,A,rtmp,uprev; tol=integrator.opts.reltol)
+    phimv!(u,dt,A,rtmp,uprev; tol=integrator.opts.reltol, m=min(integrator.alg.m, size(A,1)), norm=normbound)
   else
     A_mul_B!(tmp,A,uprev)
     tmp .+= rtmp

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -3,9 +3,9 @@ N = 100
 dx = 1.0; dt=0.01
 srand(0); u0 = rand(N)
 reltol = 1e-4
-# L = DerivativeOperator{Float64}(2,2,dx,N,:Dirichlet0,:Dirichlet0) # error for caching version at the moment
-dd = -2.0 * ones(N); du = 1.0 * ones(N-1)
-A = diagm(du,-1) + diagm(dd,0) + diagm(du,1); L = DiffEqArrayOperator(A)
+L1 = DerivativeOperator{Float64}(2,4,dx,N,:Dirichlet0,:Dirichlet0)
+L2 = DerivativeOperator{Float64}(4,4,dx,N,:Dirichlet0,:Dirichlet0)
+L = 1.01*L1 + 2.02*L2
 krylov_f2 = (u,p,t) -> -0.1*u
 krylov_f2! = (du,u,p,t) -> du .= -0.1*u
 prob = SplitODEProblem(L,krylov_f2,u0,(0.0,1.0))


### PR DESCRIPTION
1. Adds an option to specify the Krylov subspace size in the algorithms' constructor, which I forgot to include in the last version.

2. Uses the `normbound` estimate from `DiffEqOperators` for the Krylov methods so that they can work with linear combinations of operators (could use a more refined norm estimation in the future).

3. Compatibility fix for the linear operator part. In its current form the exponential integrators can only handle `DiffEqArrayOperator` as the linear operator and furthermore sometimes forget to account for the coefficient. After the update, they should work for all `AbstractDiffEqLinearOperator` defined in DiffEqOperators as well as their linear combinations. (Haven't touched the generic IIF methods though. They may require more work to have the derivative operators be acceptable by user-supplied `nlsolve` methods).

Needs the latest changes to `DiffEqOperators` be released for the tests to pass.

Documentation update for this:

https://github.com/JuliaDiffEq/DiffEqDocs.jl/pull/101