### PR TITLE
[WIP] ETD2 Integrator

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -152,7 +152,7 @@ module OrdinaryDiffEq
 
   export GenericIIF1, GenericIIF2
 
-  export LawsonEuler, NorsettEuler, ETDRK4
+  export LawsonEuler, NorsettEuler, ETD1, ETDRK4
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -17,7 +17,7 @@ module OrdinaryDiffEq
 
   using DiffEqOperators: normbound, DiffEqArrayOperator
 
-  import RecursiveArrayTools: chain
+  import RecursiveArrayTools: chain, recursivecopy!
 
   using Parameters, GenericSVD, ForwardDiff, RecursiveArrayTools,
         NLsolve, Juno, Roots, DataStructures, DiffEqDiffTools

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -152,7 +152,7 @@ module OrdinaryDiffEq
 
   export GenericIIF1, GenericIIF2
 
-  export LawsonEuler, NorsettEuler, ETD1, ETDRK4
+  export LawsonEuler, NorsettEuler, ETD1, ETD2, ETDRK4
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -14,6 +14,7 @@ isfsal(alg::Vern9) = false
 fsal_typeof(alg::OrdinaryDiffEqAlgorithm,rate_prototype) = typeof(rate_prototype)
 #fsal_typeof(alg::LawsonEuler,rate_prototype) = Vector{typeof(rate_prototype)}
 #fsal_typeof(alg::NorsettEuler,rate_prototype) = Vector{typeof(rate_prototype)}
+fsal_typeof(alg::ETD2,rate_prototype) = ETD2Fsal{typeof(rate_prototype)}
 
 isimplicit(alg::OrdinaryDiffEqAlgorithm) = false
 isimplicit(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm) = true
@@ -24,8 +25,10 @@ isdtchangeable(alg::GenericIIF1) = false
 isdtchangeable(alg::GenericIIF2) = false
 isdtchangeable(alg::LawsonEuler) = false
 isdtchangeable(alg::NorsettEuler) = false
+isdtchangeable(alg::ETD2) = false
 
 ismultistep(alg::OrdinaryDiffEqAlgorithm) = false
+ismultistep(alg::ETD2) = true
 
 isadaptive(alg::OrdinaryDiffEqAlgorithm) = false
 isadaptive(alg::OrdinaryDiffEqAdaptiveAlgorithm) = true
@@ -77,6 +80,7 @@ alg_order(alg::Ralston) = 2
 alg_order(alg::LawsonEuler) = 1
 alg_order(alg::NorsettEuler) = 1
 alg_order(alg::SplitEuler) = 1
+alg_order(alg::ETD2) = 2
 alg_order(alg::ETDRK4) = 4
 
 alg_order(alg::SymplecticEuler) = 1

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -614,6 +614,7 @@ struct NorsettEuler <: OrdinaryDiffEqExponentialAlgorithm
   m::Int
 end
 Base.@pure NorsettEuler(;krylov=false, m=30) = NorsettEuler(krylov, m)
+ETD1 = NorsettEuler # alias
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -616,6 +616,7 @@ end
 Base.@pure NorsettEuler(;krylov=false, m=30) = NorsettEuler(krylov, m)
 ETD1 = NorsettEuler # alias
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
+struct ETD2 <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 
 #########################################

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -160,6 +160,12 @@ mutable struct ETD2Fsal{rateType}
   nl::rateType
   nlprev::rateType
 end
+ETD2Fsal(rate_prototype) = ETD2Fsal(zero(rate_prototype),zero(rate_prototype),zero(rate_prototype))
+function recursivecopy!(dest::ETD2Fsal, src::ETD2Fsal)
+  recursivecopy!(dest.lin, src.lin)
+  recursivecopy!(dest.nl, src.nl)
+  recursivecopy!(dest.nlprev, src.nlprev)
+end
 
 struct ETD2ConstantCache{expType} <: OrdinaryDiffEqConstantCache
   exphA::expType

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -185,6 +185,33 @@ function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   ETD2ConstantCache(exphA, phihA, B1, B0)
 end
 
+struct ETD2Cache{uType,rateType,expType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  utmp::uType
+  rtmp1::rateType
+  rtmp2::rateType
+  exphA::expType
+  phihA::expType
+  B1::expType
+  B0::expType
+end
+
+function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  A = f.f1
+  if isa(A, DiffEqArrayOperator)
+    _A = A.A * A.α.coeff # .* does not return Diagonal for A.A Diagonal
+  else
+    _A = full(A)
+  end
+  exphA, phihA, B1, B0 = get_etd2_operators(dt, _A)
+  ETD2Cache(u,uprev,zero(u),zero(rate_prototype),zero(rate_prototype),exphA,phihA,B1,B0)
+end
+
+# TODO: what should these be?
+u_cache(c::ETD2Cache) = ()
+du_cache(c::ETD2Cache) = (c.k,c.fsalfirst)
+
 #=
   Computes the update coeffiicents for the time stepping
 

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -151,15 +151,6 @@ struct NorsettEulerConstantCache <: OrdinaryDiffEqConstantCache end
 
 alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = NorsettEulerConstantCache()
 
-struct ETDRK4ConstantCache{matType} <: OrdinaryDiffEqMutableCache
-  E::matType
-  E2::matType
-  a::matType
-  b::matType
-  c::matType
-  Q::matType
-end
-
 #=
   Fsal separately the linear and nonlinear part, as well as the nonlinear 
   part in the previous time step.
@@ -231,6 +222,15 @@ function get_etd2_operators(h::Real, A::AbstractMatrix)
   B1 = ((hA + I)*exphA - I - 2*hA) / hA2
   B0 = (I + hA - exphA) / hA2
   return exphA, phihA, B1, B0
+end
+
+struct ETDRK4ConstantCache{matType} <: OrdinaryDiffEqMutableCache
+  E::matType
+  E2::matType
+  a::matType
+  b::matType
+  c::matType
+  Q::matType
 end
 
 function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -126,9 +126,10 @@ function initialize!(integrator,cache::ETD2ConstantCache)
   integrator.fsalfirst = ETD2Fsal(lin, nl, nlprev)
     
   # Avoid undefined entries if k is an array of arrays
-  integrator.fsallast = ETD2Fsal(zero(lin), zero(nl), zero(nlprev))
+  rate_prototype = lin
+  integrator.fsallast = ETD2Fsal(rate_prototype)
   integrator.k[1] = lin + nl
-  integrator.k[2] = zero(lin) + zero(nl)
+  integrator.k[2] = zero(rate_prototype)
 end
 
 function perform_step!(integrator,cache::ETD2ConstantCache,repeat_step=false)

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -47,6 +47,9 @@ sim  = test_convergence(dts,prob,LawsonEuler())
 sim  = test_convergence(dts,prob,NorsettEuler())
 @test abs(sim.𝒪est[:l2]-1) < 0.1
 
+sim  = test_convergence(dts,prob,ETD2())
+@test abs(sim.𝒪est[:l2]-2) < 0.1
+
 sim  = test_convergence(dts,prob,ETDRK4(),dense_errors=true)
 @test abs(sim.𝒪est[:l2]-4) < 0.1
 @test abs(sim.𝒪est[:L2]-4) < 0.1

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -15,6 +15,8 @@ sim  = test_convergence(dts,prob,LawsonEuler())
 @test abs(sim.𝒪est[:l2]-1) < 0.2
 sim  = test_convergence(dts,prob,NorsettEuler())
 @test abs(sim.𝒪est[:l2]-1) < 0.2
+sim  = test_convergence(dts,prob,ETD2())
+@test abs(sim.𝒪est[:l2]-2) < 0.2
 sim  = test_convergence(dts,prob,ETDRK4(),dense_errors=true)
 @test abs(sim.𝒪est[:l2]-4) < 0.2
 


### PR DESCRIPTION
I have finished the out-of-place portion of the `ETD2` integrator and could use some suggestions & review.

As a reference, the ETD2 time stepping is:

![ETD2](https://i.imgur.com/mb047mH.png)

One of the major problems for existing exp methods is that only the nonlinear part of the right hand side is FSALed, which means we either have to spend extra time computing `k` in each time or use incorrect derivative values (which the methods currently do).

Fortunately the integrator interface supports custom fsal types, so I defined a `ETD2Fsal` (which is essentially a named tuple) to store both the linear and nonlinear part. The interpolating `k` value at each interval is computed by summing the two parts, which should be relatively fast.

I have also decided to store the previous nonlinear part (Nn in the formula) in the FSAL, which is different from the approach @sipah00 used in AB methods. They both work because FSAL acts somewhat like an additional cache, but my rationale for not storing the previous time steps in the cache is:

- The traditional role of FSAL in RK methods is to carry over the derivative calculations to the next time step, which can be extended naturally to also include the previous time steps for multistep methods.

- If we store the previous time steps in the cache, then the cache would need to be mutable (which is the case for `AB3ConstantCache`). This kinda violates the "constant" assumption of the constant cache.

Finally, unlike `LawsonEuler` and `NorsettEuler` but like `ETDRK4`, the out-of-place style also caches the operator exponentials. In fact, now that I've written `ETD2` I find it weird that the first order methods choose to not cache the operators (they are time-independent anyways). Like `ETDRK4`, I included special handling when the linear operator is scalar or Diagonal, but I could probably further improve the accuracy for small `dt` by switching to `expm1` using.

