### PR TITLE
Refactoring of exponential integrators

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -12,7 +12,7 @@ isfsal(alg::Vern8) = false
 isfsal(alg::Vern9) = false
 
 fsal_typeof(alg::OrdinaryDiffEqAlgorithm,rate_prototype) = typeof(rate_prototype)
-fsal_typeof(alg::Union{LawsonEuler,NorsettEuler},rate_prototype) = ExpRKFsal{typeof(rate_prototype)}
+fsal_typeof(alg::Union{LawsonEuler,NorsettEuler,ETDRK4},rate_prototype) = ExpRKFsal{typeof(rate_prototype)}
 fsal_typeof(alg::ETD2,rate_prototype) = ETD2Fsal{typeof(rate_prototype)}
 
 isimplicit(alg::OrdinaryDiffEqAlgorithm) = false

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -12,8 +12,7 @@ isfsal(alg::Vern8) = false
 isfsal(alg::Vern9) = false
 
 fsal_typeof(alg::OrdinaryDiffEqAlgorithm,rate_prototype) = typeof(rate_prototype)
-#fsal_typeof(alg::LawsonEuler,rate_prototype) = Vector{typeof(rate_prototype)}
-#fsal_typeof(alg::NorsettEuler,rate_prototype) = Vector{typeof(rate_prototype)}
+fsal_typeof(alg::Union{LawsonEuler,NorsettEuler},rate_prototype) = ExpRKFsal{typeof(rate_prototype)}
 fsal_typeof(alg::ETD2,rate_prototype) = ETD2Fsal{typeof(rate_prototype)}
 
 isimplicit(alg::OrdinaryDiffEqAlgorithm) = false

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -318,7 +318,7 @@ function get_etd2_operators(h::Real, A::AbstractMatrix)
   return exphA, phihA, B1, B0
 end
 
-struct ETDRK4ConstantCache{matType} <: OrdinaryDiffEqMutableCache
+struct ETDRK4ConstantCache{matType} <: OrdinaryDiffEqConstantCache
   E::matType
   E2::matType
   a::matType
@@ -330,7 +330,7 @@ end
 function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   A = f.f1
   if isa(A, DiffEqArrayOperator)
-    L = A.A .* A.α.coeff # has special handling is A.A is Diagonal
+    L = A.A .* A.α.coeff # has special handling if A.A is Diagonal
   else
     L = full(A)
   end
@@ -367,11 +367,9 @@ struct ETDRK4Cache{uType,rateType,matType} <: OrdinaryDiffEqMutableCache
   tmp::uType
   s1::uType
   tmp2::rateType
-  k1::rateType
   k2::rateType
   k3::rateType
   k4::rateType
-  fsalfirst::rateType
   E::matType
   E2::matType
   a::matType
@@ -383,17 +381,16 @@ end
 function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   A = f.f1
   tmp = similar(u)
-  tmp2 = zeros(rate_prototype); fsalfirst = zeros(rate_prototype)
-  k1 = zeros(rate_prototype); k2 = zeros(rate_prototype)
-  k3 = zeros(rate_prototype); k4 = zeros(rate_prototype)
+  tmp2 = zeros(rate_prototype)
+  k2 = zeros(rate_prototype); k3 = zeros(rate_prototype); k4 = zeros(rate_prototype)
   s1 = similar(u)
   if isa(A, DiffEqArrayOperator)
-    L = A.A .* A.α.coeff # has specail handling is A.A is Diagonal
+    L = A.A .* A.α.coeff # has special handling if A.A is Diagonal
   else
     L = full(A)
   end
   E,E2,a,b,c,Q = get_etdrk4_operators(dt,L)
-  ETDRK4Cache(u,uprev,tmp,s1,tmp2,k1,k2,k3,k4,fsalfirst,E,E2,a,b,c,Q)
+  ETDRK4Cache(u,uprev,tmp,s1,tmp2,k2,k3,k4,E,E2,a,b,c,Q)
 end
 
 u_cache(c::ETDRK4Cache) = ()

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -187,15 +187,17 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
 end
 
 function get_etd1_operators(h::Real, A::T) where {T <: Number}
-  hA = h * A
+  # Use BigFloat to avoid loss of precision
+  _hA = big(h) * big(A)
   oneT = one(T)
-  if hA == zero(T)
+  _oneT = big(oneT)
+  if iszero(_hA)
     exphA = oneT
     phihA = oneT
   else
-    exphA = exp(hA)
-    # Compute phi using BigFloat to avoid loss of precision
-    phihA = T((big(exphA) - big(oneT)) / hA)
+    _exphA = exp(_hA)
+    exphA = T(_exphA)
+    phihA = T((_exphA - _oneT) / _hA)
   end
   return exphA, phihA
 end
@@ -205,10 +207,13 @@ function get_etd1_operators(h::Real, A::Diagonal)
   phihA = Diagonal(map(x -> x[2]), coeffs)
   return exphA, phihA
 end
-function get_etd1_operators(h::Real, A::AbstractMatrix)
-  hA = h * A
+function get_etd1_operators(h::Real, A::AbstractMatrix{T}) where T
+  # Use BigFloat to avoid loss of precision
+  _hA = big(h) * big.(A)
+  hA = T.(_hA)
   exphA = expm(hA)
-  phihA = (exphA - I) / hA
+  _exphA = big.(exphA)
+  phihA = T.((_exphA - I) / _hA)
   return exphA, phihA
 end
 
@@ -284,19 +289,22 @@ du_cache(c::ETD2Cache) = (c.rtmp1,c.rtmp2)
   TODO: use expm1 for A close to 0?
 =#
 function get_etd2_operators(h::Real, A::T) where {T <: Number}
-  hA = h * A
+  # Use BigFloat to avoid loss of precision
+  _hA = big(h) * big(A)
   oneT = one(T)
-  if hA == zero(T)
+  _oneT = big(oneT)
+  if iszero(_hA)
     exphA = oneT
     phihA = oneT
     B1 = 1.5 * oneT
     B0 = -0.5 * oneT
   else
-    hA2 = hA * hA
-    exphA = exp(hA)
-    phihA = (exphA - oneT) / hA # x - I for scalar x is deprecated
-    B1 = ((hA + oneT)*exphA - oneT - 2*hA) / hA2
-    B0 = (oneT + hA - exphA) / hA2
+    _hA2 = _hA * _hA
+    _exphA = exp(_hA)
+    exphA = T(_exphA)
+    phihA = T((_exphA - _oneT) / _hA) # x - I for scalar x is deprecated
+    B1 = T(((_hA + _oneT)*_exphA - _oneT - 2*_hA) / _hA2)
+    B0 = T((_oneT + _hA - _exphA) / _hA2)
   end
   return exphA, phihA, B1, B0
 end
@@ -308,13 +316,16 @@ function get_etd2_operators(h::Real, A::Diagonal)
   B0 = Diagonal(map(x -> x[4], coeffs))
   return exphA, phihA, B1, B0
 end
-function get_etd2_operators(h::Real, A::AbstractMatrix)
-  hA = h * A
-  hA2 = hA * hA
+function get_etd2_operators(h::Real, A::AbstractMatrix{T}) where T
+  # Use BigFLoat to avoid loss of precision
+  _hA = big(h) * big.(A)
+  hA = T.(_hA)
+  _hA2 = _hA * _hA
   exphA = expm(hA)
-  phihA = (exphA - I) / hA
-  B1 = ((hA + I)*exphA - I - 2*hA) / hA2
-  B0 = (I + hA - exphA) / hA2
+  _exphA = big.(exphA)
+  phihA = T.((_exphA - I) / _hA)
+  B1 = T.(((_hA + I)*_exphA - I - 2*_hA) / _hA2)
+  B0 = T.((I + _hA - _exphA) / _hA2)
   return exphA, phihA, B1, B0
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,7 +1,6 @@
 DiffEqDevTools 0.6.0
 DiffEqProblemLibrary
 ParameterizedFunctions 3.0.0
-SpecialMatrices
 StaticArrays
 DiffEqCallbacks
 DiffEqOperators

--- a/test/linear_method_tests.jl
+++ b/test/linear_method_tests.jl
@@ -1,6 +1,6 @@
-using OrdinaryDiffEq, Base.Test, DiffEqDevTools, SpecialMatrices, DiffEqOperators
+using OrdinaryDiffEq, Base.Test, DiffEqDevTools, DiffEqOperators
 u0 = rand(2)
-A = DiffEqArrayOperator(Strang(2))
+A = DiffEqArrayOperator([2.0 -1.0; -1.0 2.0])
 function (p::typeof(A))(::Type{Val{:analytic}},u0,p,t)
     expm(p.A*t)*u0
 end

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -30,10 +30,6 @@ function (::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t)
  expm(tmp)*u0
 end
 
-integrator = init(prob,NorsettEuler(),dt=1/10)
-step!(integrator)
-integrator.cache
-
 dts = 1./2.^(8:-1:4) #14->7 good plot
 sim  = test_convergence(dts,prob,GenericIIF1())
 @test abs(sim.𝒪est[:l2]-1) < 0.2

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Base.Test, DiffEqDevTools, SpecialMatrices, DiffEqOperators
+using OrdinaryDiffEq, Base.Test, DiffEqDevTools, DiffEqOperators
 const μ = 1.01
 linnonlin_f2 = (u,p,t) -> μ * u
 linnonlin_f1 = DiffEqArrayOperator(μ)
@@ -21,7 +21,7 @@ sim  = test_convergence(dts,prob,ETDRK4(),dense_errors=true)
 @test abs(sim.𝒪est[:l2]-4) < 0.2
 
 u0 = rand(2)
-A = full(Strang(2))
+A = [2.0 -1.0; -1.0 2.0]
 linnonlin_f1 = DiffEqArrayOperator(A)
 linnonlin_f2 = (du,u,p,t) -> du .= μ .* u
 prob = SplitODEProblem(linnonlin_f1,linnonlin_f2,u0,(0.0,1.0))


### PR DESCRIPTION
I have updated the exponential integrators using what I've learnt writing `ETD2`. The major changes are:

1. Rewrote both 1st-order algorithms to also use caching for out-of-place style, which makes more sense for constant linear operator and is consistent with what `ETDRK4` has been doing.

2. Use a common FSAL type `ExpRKFsal` for all exponential Runge-Kutta methods to handle the fsaling of the linear/nonlinear part and calculation of the derivatives used in interpolation.

3. Use the `BigFloat` approach employed by `ETDRK4` for phi-related functions to improve numerical stability for very small timestep. (The update to `NorsettEuler` solves the issue of Julia complaining about deprecation when it is used on a scalar equation).

I have also improved the test script by removing the requirement for _SpecialMatrices_. This package hasn't been updated for a while and gives warning when imported. Since only the 2x2 Strang matrix is used, I have opted to write it out explicitly and drop the requirement for the package. This, combined with the update to `NorsettEuler`, should resolve all warning for the linear-nonlinear convergence tests.