### PR TITLE
Add the max norm estimation for the largest eigval on `Rodas5`

### DIFF
--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -734,11 +734,12 @@ end
     g6 = tmp
     g7 = u
     # Hairer II, page 22
-    @. utilde = k7 - k6
-    ϱu = integrator.opts.internalnorm(utilde)
-    @. utilde = g7 - g6
-    ϱd = integrator.opts.internalnorm(utilde)
-    integrator.eigen_est = ϱu/ϱd
+    ϱu, ϱd = zero(eltype(k7)), zero(eltype(k7))
+    @inbounds for i in eachindex(k7)
+      ϱu += (k7[i] - k6[i])^2
+      ϱd += (g7[i] - g6[i])^2
+    end
+    integrator.eigen_est = sqrt(ϱu/ϱd)
   end
   if integrator.opts.adaptive
     @tight_loop_macros for i in uidx

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -1469,9 +1469,18 @@ end
   @. linsolve_tmp = fsalfirst + dtd1*dT
 
   # Jacobian
-  if has_invW(f) && !(typeof(integrator.alg) <: CompositeAlgorithm)
+  if has_invW(f)
     # skip calculation of inv(W) if step is repeated
     !repeat_step && f(Val{:invW_t}, W, uprev, p, dtgamma, t) # W == inverse W
+    if typeof(integrator.alg) <: CompositeAlgorithm
+      if has_jac(f)
+        f(Val{:jac}, J, uprev, p, t)
+      else
+        uf.t = t
+        jacobian!(J, uf, uprev, du1, integrator, jac_config)
+      end
+      integrator.eigen_est = norm(J, Inf)
+    end
 
     A_mul_B!(vectmp, W, linsolve_tmp_vec)
   else


### PR DESCRIPTION
I am not sure about whether `if has_invW(f) && !(typeof(integrator.alg) <: CompositeAlgorithm)` is a good idea (probably bad), since it will introduce a matrix factorization for every `!repeat_step` step, even if the user provides an inverse W matrix for the system. However, one needs to have the Jacobian to do the largest eigenvalue estimation. @ChrisRackauckas 