### PR TITLE
Fix `alg_autodiff` error for `CompositeAlgorithm`

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -42,10 +42,12 @@ qmax_default(alg::DP8) = 6
 get_chunksize(alg::OrdinaryDiffEqAlgorithm) = error("This algorithm does not have a chunk size defined.")
 get_chunksize{CS,AD}(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD}) = CS
 get_chunksize{CS,AD}(alg::OrdinaryDiffEqImplicitAlgorithm{CS,AD}) = CS
+get_chunksize(alg::CompositeAlgorithm) = get_chunksize(alg.algs[alg.current_alg])
 
 alg_autodiff(alg::OrdinaryDiffEqAlgorithm) = error("This algorithm does not have an autodifferentiation option defined.")
 alg_autodiff{CS,AD}(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD}) = AD
 alg_autodiff{CS,AD}(alg::OrdinaryDiffEqImplicitAlgorithm{CS,AD}) = AD
+alg_autodiff(alg::CompositeAlgorithm) = alg_autodiff(alg.algs[alg.current_alg])
 
 alg_extrapolates(alg::OrdinaryDiffEqAlgorithm) = false
 alg_extrapolates(alg::GenericImplicitEuler) = true

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -625,10 +625,12 @@ struct ETDRK4 <: OrdinaryDiffEqExponentialAlgorithm end
 
 #########################################
 
-struct CompositeAlgorithm{T,F} <: OrdinaryDiffEqCompositeAlgorithm
+mutable struct CompositeAlgorithm{T,F} <: OrdinaryDiffEqCompositeAlgorithm
   algs::T
   choice_function::F
+  current_alg::Int
 end
+CompositeAlgorithm(a::T, b::F) where {T,F} = CompositeAlgorithm(a, b, 1)
 
 ################################################################################
 

--- a/src/perform_step/composite_perform_step.jl
+++ b/src/perform_step/composite_perform_step.jl
@@ -51,6 +51,7 @@ function choose_algorithm!(integrator,cache::CompositeCache)
     reset_alg_dependent_opts!(integrator,integrator.alg.algs[cache.current],integrator.alg.algs[new_current])
     transfer_cache!(integrator,integrator.cache.caches[cache.current],integrator.cache.caches[new_current])
     cache.current = new_current
+    integrator.alg.current_alg = new_current
   end
 end
 


### PR DESCRIPTION
The PR is going to fix the error

```julia
julia> alg = AutoRodas5(Tsit5(); maxstiffstep=10, maxnonstiffstep=10, tol=12//10);

julia> sol = solve(prob_ode_brusselator_2d, alg, saveat=[1.5, 11.5]);
ERROR: This algorithm does not have an autodifferentiation option defined.
...
```