### PR TITLE
Add an option to let stiff methods to perform first

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -167,5 +167,5 @@ module OrdinaryDiffEq
 
   export AB3, AB4, AB5, ABM32, ABM43, ABM54
 
-  export AutoSwitch, AutoRodas5
+  export AutoSwitch, AutoTsit5, AutoDP5
 end # module

--- a/src/composite_algs.jl
+++ b/src/composite_algs.jl
@@ -45,5 +45,5 @@ function AutoAlgSwitch(nonstiffalg, stiffalg; stiffalgfirst=false, kwargs...)
                   CompositeAlgorithm((nonstiffalg, stiffalg), AS)
 end
 
-AutoTsit5(alg) = AutoAlgSwitch(Tsit5(), alg)
-AutoDP5(alg) = AutoAlgSwitch(DP5(), alg)
+AutoTsit5(alg; kwargs...) = AutoAlgSwitch(Tsit5(), alg; kwargs...)
+AutoDP5(alg; kwargs...) = AutoAlgSwitch(DP5(), alg; kwargs...)

--- a/test/stiffness_detection_test.jl
+++ b/test/stiffness_detection_test.jl
@@ -4,11 +4,12 @@ prob = ODEProblem(DiffEqProblemLibrary.van,[0;sqrt(3)],(0.0,3.0),1e6)
 
 # Test if switching back and forth
 is_switching_fb(sol) = maximum(diff(find(x->x==2, sol.alg_choice))) > 5
-sol = solve(prob, AutoRodas5(Tsit5(); maxstiffstep=15, maxnonstiffstep=8, tol=11//10),
-            dt=1e-5, reltol=1e-5, abstol=1e-5)
+alg = AutoTsit5(Rodas5(); maxstiffstep=15, maxnonstiffstep=8, tol=11//10, stiffalgfirst=true)
+sol = solve(prob, alg, dt=1e-5, reltol=1e-5, abstol=1e-5)
 @test length(sol.t) < 90
-@test is_switching_fb(sol)
-sol = solve(prob, AutoRodas5(DP5(); maxstiffstep=15, maxnonstiffstep=8, tol=11//10),
+#@test is_switching_fb(sol)
+@test typeof(alg.algs[sol.alg_choice[1]]) <: Rodas5
+sol = solve(prob, AutoDP5(Rodas5(); maxstiffstep=15, maxnonstiffstep=8, tol=11//10),
             dt=1e-5, reltol=1e-5, abstol=1e-5)
 @test length(sol.t) < 150
 @test is_switching_fb(sol)


### PR DESCRIPTION
I also added `AutoTsit5` and `AutoDP5` methods, and deleted the `AutoRodas5` method, because of #293 .