### PR TITLE
Change `ABDF2` coefficients to the FLC form

### DIFF
--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -5,7 +5,7 @@ mutable struct ABDF2ConstantCache{F,uToltype,dtType,rate_prototype} <: OrdinaryD
   tol::uToltype
   newton_iters::Int
   eulercache::ImplicitEulerConstantCache
-  dtₙ₊₁::dtType
+  dtₙ₋₁::dtType
   fsalfirstprev::rate_prototype
 end
 
@@ -28,21 +28,22 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   eulercache = ImplicitEulerConstantCache(uf,ηold,κ,tol,100000)
 
-  dtₙ₊₁ = one(dt)
+  dtₙ₋₁ = one(dt)
   fsalfirstprev = zero(rate_prototype)
 
-  ABDF2ConstantCache(uf, ηold, κ, tol, 10000, eulercache, dtₙ₊₁, fsalfirstprev)
+  ABDF2ConstantCache(uf, ηold, κ, tol, 10000, eulercache, dtₙ₋₁, fsalfirstprev)
 end
 
 mutable struct ABDF2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,F,dtType} <: OrdinaryDiffEqMutableCache
-  uₙ₊₂::uType
-  uₙ₊₁::uType
   uₙ::uType
+  uₙ₋₁::uType
+  uₙ₋₂::uType
   du1::rateType
   fsalfirst::rateType
   fsalfirstprev::rateType
   k::rateType
   z::uType
+  zₙ₋₁::uType
   dz::uType
   b::uType
   tmp::uType
@@ -57,7 +58,7 @@ mutable struct ABDF2Cache{uType,rateType,uNoUnitsType,J,UF,JC,uToltype,F,dtType}
   tol::uToltype
   newton_iters::Int
   eulercache::ImplicitEulerCache
-  dtₙ₊₁::dtType
+  dtₙ₋₁::dtType
 end
 
 u_cache(c::ABDF2Cache)    = (c.z,c.dz)
@@ -69,7 +70,7 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
   W = similar(J)
   zprev = similar(u,indices(u))
-  zᵧ = similar(u,indices(u)); z = similar(u,indices(u))
+  zₙ₋₁ = similar(u,indices(u)); z = similar(u,indices(u))
   dz = similar(u,indices(u))
   fsalfirst = zeros(rate_prototype)
   fsalfirstprev = zeros(rate_prototype)
@@ -97,7 +98,7 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   eulercache = ImplicitEulerCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,ηold,κ,tol,10000)
 
-  dtₙ₊₁ = one(dt)
-  ABDF2Cache(u,uprev,uprev2,du1,fsalfirst,fsalfirstprev,k,z,dz,b,tmp,atmp,J,
-              W,uf,jac_config,linsolve,ηold,κ,tol,10000,eulercache,dtₙ₊₁)
+  dtₙ₋₁ = one(dt)
+  ABDF2Cache(u,uprev,uprev2,du1,fsalfirst,fsalfirstprev,k,z,zₙ₋₁,dz,b,tmp,atmp,J,
+              W,uf,jac_config,linsolve,ηold,κ,tol,10000,eulercache,dtₙ₋₁)
 end

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -29,7 +29,7 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   eulercache = ImplicitEulerConstantCache(uf,ηold,κ,tol,100000)
 
   dtₙ₋₁ = one(dt)
-  fsalfirstprev = zero(rate_prototype)
+  fsalfirstprev = rate_prototype
 
   ABDF2ConstantCache(uf, ηold, κ, tol, 10000, eulercache, dtₙ₋₁, fsalfirstprev)
 end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -40,6 +40,7 @@ function calc_W!(integrator, cache, dtgamma, repeat_step, check_newW=false, W_tr
     is_compos = typeof(integrator.alg) <: CompositeAlgorithm
 
     # calculate W
+    new_W = true
     if has_invW(f)
       # skip calculation of inv(W) if step is repeated
       !repeat_step && W_transform ? f(Val{:invW_t}, W, uprev, p, dtgamma, t) :
@@ -72,6 +73,7 @@ function calc_W!(integrator, cache, dtgamma, repeat_step, check_newW=false, W_tr
         end
       else
         new_W = false
+        check_newW && return new_W
       end
     end
     return check_newW ? new_W : nothing

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -73,7 +73,6 @@ function calc_W!(integrator, cache, dtgamma, repeat_step, check_newW=false, W_tr
         end
       else
         new_W = false
-        check_newW && return new_W
       end
     end
     return check_newW ? new_W : nothing

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -162,10 +162,10 @@ end
   if has_invW(f)
     A_mul_B!(vec(dz),W,vec(b)) # Here W is actually invW
   else
-    cache.linsolve(vec(dz),W,vec(b),false)
+    cache.linsolve(vec(dz),W,vec(b),new_W)
   end
   ndz = integrator.opts.internalnorm(dz)
-  z += dz
+  @. z += dz
 
   η = max(cache.ηold,eps(eltype(integrator.opts.reltol)))^(0.8)
   do_newton = (η*ndz > κtol)

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -102,7 +102,9 @@ end
   cache.dtₙ₋₁ = dtₙ
   cache.ηold = η
   cache.newton_iters = iter
-  cache.fsalfirstprev = integrator.fsalfirst
+  if integrator.EEst < one(integrator.EEst)
+    cache.fsalfirstprev = integrator.fsalfirst
+  end
 
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -127,7 +129,7 @@ end
   if integrator.iter == 1 && !integrator.u_modified
     cache.dtₙ₋₁ = dtₙ
     x = perform_step!(integrator, cache.eulercache, repeat_step)
-    cache.fsalfirstprev = integrator.fsalfirst
+    cache.fsalfirstprev .= integrator.fsalfirst
     return x
   end
 
@@ -216,5 +218,7 @@ end
   cache.ηold = η
   cache.newton_iters = iter
   cache.dtₙ₋₁ = dtₙ
-  @. cache.fsalfirstprev = integrator.fsalfirst
+  if integrator.EEst < one(integrator.EEst)
+    @. cache.fsalfirstprev = integrator.fsalfirst
+  end
 end


### PR DESCRIPTION
The coefficients are provided in http://sundials.wikidot.com/bdf-method, and here are convergence plots.

Out-of-place:
```julia
julia> sim = test_convergence(dts,probArr[1],ABDF2(extrapolant = :linear));

julia> sim.𝒪est[:final]
1.9879754678888957

julia> sim.𝒪est[:l2]
1.9901519044978664

julia> sim.𝒪est[:final]
1.9879754678888957
```

![prob1](https://user-images.githubusercontent.com/17304743/38473442-018f88fe-3b45-11e8-844e-7ca797f5ceac.png)

In-place:
```julia
julia> sim = test_convergence(dts,probArr[2],ABDF2(extrapolant = :linear));

julia> sim.𝒪est[:final]
1.9879754678564714

julia> sim.𝒪est[:l2]
1.9901519044563416

julia> sim.𝒪est[:final]
1.9879754678564714
```

![prob2](https://user-images.githubusercontent.com/17304743/38473511-edb41cae-3b45-11e8-81e7-6ecefbb8b5c7.png)
