### PR TITLE
Happy-breakdown detection and `t` parameter for `phimv`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -14,4 +14,3 @@ Compat 0.18.0
 Reexport
 MuladdMacro 0.0.2
 StaticArrays
-Expokit

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -22,8 +22,6 @@ module OrdinaryDiffEq
   using Parameters, GenericSVD, ForwardDiff, RecursiveArrayTools,
         NLsolve, Juno, Roots, DataStructures, DiffEqDiffTools
 
-  using Expokit: expmv, expmv!, phimv, phimv!
-
   import Base: linspace
 
   import ForwardDiff.Dual

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -92,18 +92,25 @@ function recursivecopy!(dest::ExpRKFsal, src::ExpRKFsal)
   recursivecopy!(dest.nl, src.nl)
 end
 
-struct LawsonEulerCache{uType,rateType,expType} <: OrdinaryDiffEqMutableCache
+struct LawsonEulerCache{uType,rateType,expType,KsType,KsCacheType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   tmp::uType
   rtmp::rateType
   exphA::expType
+  Ks::KsType
+  KsCache::KsCacheType
 end
 
 function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   if alg.krylov
     exphA = nothing # no caching
+    m = min(alg.m, length(u))
+    Ks = KrylovSubspace{eltype(u)}(length(u), m)
+    KsCache = Matrix{eltype(u)}(m, m)
   else
+    Ks = nothing
+    KsCache = nothing
     A = f.f1
     if isa(A, DiffEqArrayOperator)
       _A = A.A * A.α.coeff
@@ -112,7 +119,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     end
     exphA = expm(dt*_A)
   end
-  LawsonEulerCache(u,uprev,similar(u),zeros(rate_prototype),exphA)
+  LawsonEulerCache(u,uprev,similar(u),zeros(rate_prototype),exphA,Ks,KsCache)
 end
 
 u_cache(c::LawsonEulerCache) = ()

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -273,17 +273,17 @@ A Krylov subspace is constructed using `arnoldi` and `expm!` is called
 on the Heisenberg matrix. Consult `arnoldi` for the values of the keyword 
 arguments.
 """
-function _expmv(t, A, b; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, cache=nothing)
+function expmv(t, A, b; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, cache=nothing)
   Ks = arnoldi(A, b; m=m, tol=tol, norm=norm)
   w = similar(b)
-  _expmv!(w, t, Ks; cache=cache)
+  expmv!(w, t, Ks; cache=cache)
 end
 """
     expmv!(w,t,Ks[;cache]) -> w
 
 Non-allocating version of `expmv` that uses precomputed Krylov subspace `Ks`.
 """
-function _expmv!(w::Vector{T}, t::Number, Ks::KrylovSubspace{B, T}; 
+function expmv!(w::Vector{T}, t::Number, Ks::KrylovSubspace{B, T}; 
   cache=nothing) where {B, T <: Number}
   m, beta, V, H = Ks.m, Ks.beta, Ks[:V], Ks[:H]
   @assert length(w) == size(V, 1) "Dimension mismatch"
@@ -314,18 +314,18 @@ A Krylov subspace is constructed using `arnoldi` and `phimv_dense` is called
 on the Heisenberg matrix. Consult `arnoldi` for the values of the keyword 
 arguments.
 """
-function _phimv(t, A, b, k; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, 
+function phimv(t, A, b, k; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, 
   caches=nothing)
   Ks = arnoldi(A, b; m=m, tol=tol, norm=norm)
   w = Matrix{eltype(b)}(length(b), k+1)
-  _phimv!(w, t, Ks, k; caches=caches)
+  phimv!(w, t, Ks, k; caches=caches)
 end
 """
     phimv!(w,t,Ks,k[;caches]) -> w
 
 Non-allocating version of 'phimv' that uses precomputed Krylov subspace `Ks`.
 """
-function _phimv!(w::Matrix{T}, t::Number, Ks::KrylovSubspace{B, T}, k::Integer; 
+function phimv!(w::Matrix{T}, t::Number, Ks::KrylovSubspace{B, T}, k::Integer; 
   caches=nothing) where {B, T <: Number}
   m, beta, V, H = Ks.m, Ks.beta, Ks[:V], Ks[:H]
   @assert size(w, 1) == size(V, 1) "Dimension mismatch"

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -162,7 +162,7 @@ mutable struct KrylovSubspace{B, T}
   V::Matrix{T}  # orthonormal bases
   H::Matrix{T}  # Gram-Schmidt coefficients
   KrylovSubspace{T}(n::Integer, maxiter::Integer=30) where {T} = new{real(T), T}(
-    0, zero(real(T)), Matrix{T}(n, maxiter), Matrix{T}(maxiter, maxiter))
+    0, zero(real(T)), Matrix{T}(n, maxiter), zeros(T, maxiter, maxiter))
 end
 maxiter(Ks::KrylovSubspace) = size(Ks.V, 2)
 function Base.getindex(Ks::KrylovSubspace, which::Symbol)
@@ -178,7 +178,7 @@ function Base.resize!(Ks::KrylovSubspace{B,T}, maxiter::Integer) where {B,T}
   prevsize = maxiter(Ks)
   if prevsize <= maxiter
     V = Matrix{T}(size(Ks.V, 1), maxiter)
-    H = Matrix{T}(maxiter, maxiter)
+    H = zeros(T, maxiter, maxiter)
     V[:, 1:prevsize] = Ks.V
     H[1:prevsize, 1:prevsize] = Ks.H
   else

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -200,7 +200,7 @@ function Base.show(io::IO, Ks::KrylovSubspace)
 end
 
 """
-    arnoldi(A,b,m) -> Ks
+    arnoldi(A,b[;m,tol,norm,cache]) -> Ks
 
 Performs `m` anoldi iterations to obtain the Krylov subspace K_m(A,b).
 
@@ -212,24 +212,27 @@ v_1=b,\\quad Av_j = \\sum_{i=1}^{j+1}h_{ij}v_i\\quad(j = 1,2,\\ldots,m)
 ```
 
 Refer to `KrylovSubspace` for more information regarding the output.
+
+Happy-breakdown occurs whenver `norm(v_j) < tol * norm(A, Inf)`, in this case 
+the dimension of `Ks` is smaller than `m`.
 """
-function arnoldi(A, b, m; cache=nothing)
+function arnoldi(A, b; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, 
+  cache=nothing)
   Ks = KrylovSubspace{eltype(b)}(length(b), m)
-  arnoldi!(Ks, A, b, m; cache=cache)
+  arnoldi!(Ks, A, b; m=m, tol=tol, norm=norm, cache=cache)
 end
 """
-    arnoldi!(Ks,A,b,m) -> Ks
+    arnoldi!(Ks,A,b[;tol,m,norm,cache]) -> Ks
 
 Non-allocating version of `arnoldi`.
 """
-function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}, 
-  m::Integer; cache=nothing) where {B, T <: Number}
-  # Set dimension of the Krylov subspace
+function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol=1e-7, 
+  m=min(maxiter(Ks), size(A, 1)), norm=Base.norm, cache=nothing) where {B, T <: Number}
   if m > maxiter(Ks)
     resize!(Ks, m)
   end
-  Ks.m = m
-  V, H = Ks[:V], Ks[:H]
+  V, H = Ks.V, Ks.H
+  vtol = tol * norm(A, Inf)
   # Safe checks
   n = size(V, 1)
   @assert length(b) == size(A,1) == size(A,2) == n "Dimension mismatch"
@@ -241,7 +244,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T},
   # Arnoldi iterations
   Ks.beta = norm(b)
   V[:, 1] = b / Ks.beta
-  @inbounds for j = 1:m-1
+  @inbounds for j = 1:m
     A_mul_B!(cache, A, @view(V[:, j]))
     @inbounds for i = 1:j
       alpha = dot(@view(V[:, i]), cache)
@@ -249,23 +252,20 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T},
       Base.axpy!(-alpha, @view(V[:, i]), cache)
     end
     beta = norm(cache)
+    if beta < vtol || j == m
+      # happy-breakdown or maximum iteration is reached
+      Ks.m = j
+      return Ks
+    end
     H[j+1, j] = beta
     @inbounds for i = 1:n
       V[i, j+1] = cache[i] / beta
     end
   end
-  # Last iteration (j = m)
-  A_mul_B!(cache, A, @view(V[:, m-1]))
-  @inbounds for i = 1:m
-    alpha = dot(@view(V[:, i]), cache)
-    H[i, m] = alpha
-    Base.axpy!(-alpha, @view(V[:, i]), cache)
-  end
-  return Ks
 end
 
 """
-    phimv(A,b,k,m) -> [phi_0(A)*b phi_1(A)*b ... phi_k(A)*b]
+    phimv(A,b,k; kwargs) -> [phi_0(A)*b phi_1(A)*b ... phi_k(A)*b]
 
 Compute the matrix-phi-vector products using Krylov.
 
@@ -275,11 +275,13 @@ The phi functions are defined as
 \\varphi_0(z) = \\exp(z),\\quad \\varphi_k(z+1) = \\frac{\\varphi_k(z) - 1}{z} 
 ```
 
-A size-`m` Krylov subspace is constructed using `arnoldi` and `phimv_dense` is 
-called on the Heisenberg matrix.
+A Krylov subspace is constructed using `arnoldi` and `phimv_dense` is called 
+on the Heisenberg matrix. Consult `arnoldi` for the values of the keyword 
+arguments.
 """
-function _phimv(A, b, k, m; caches=nothing)
-  Ks = arnoldi(A, b, m)
+function _phimv(A, b, k; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, 
+  caches=nothing)
+  Ks = arnoldi(A, b; m=m, tol=tol, norm=norm)
   w = Matrix{eltype(b)}(length(b), k+1)
   _phimv!(w, Ks, k; caches=caches)
 end
@@ -299,7 +301,11 @@ function _phimv!(w::Matrix{T}, Ks::KrylovSubspace{B, T}, k::Integer;
     C2 = Matrix{T}(m, k + 1)
   else
     e, C1, C2 = caches
-    @assert size(e) == (m,) && size(C1) == (m+k,m+k) && size(C2) == (m,k+1) "Dimension mismatch"
+    # The caches may have a bigger size to handle different values of m.
+    # Here we only need a portion of them.
+    e = @view(e[1:m])
+    C1 = @view(C1[1:m + k, 1:m + k])
+    C2 = @view(C2[1:m, 1:k + 1])
   end
   fill!(e, zero(T)); e[1] = one(T) # e is the [1,0,...,0] basis vector
   phimv_dense!(C2, H, e, k; cache=C1) # C2 = [ϕ0(H)e ϕ1(H)e ... ϕk(H)e]

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -21,7 +21,7 @@ function perform_step!(integrator, cache::LawsonEulerConstantCache, repeat_step=
   integrator.k[1] = lin + nl
 
   if alg.krylov
-    @muladd u = expmv(dt, f.f1, uprev + dt*nl; tol=integrator.opts.reltol, m=min(alg.m, size(f.f1,1)), norm=normbound)
+    @muladd u = _expmv(dt, f.f1, uprev + dt*nl; m=min(alg.m, size(f.f1,1)), norm=normbound)
   else
     @muladd u = cache.exphA*(uprev + dt*nl)
   end
@@ -53,13 +53,14 @@ end
 function perform_step!(integrator, cache::LawsonEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack lin,nl = integrator.fsalfirst
-  @unpack tmp,exphA = cache
+  @unpack tmp,exphA,Ks,KsCache = cache
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
   @. integrator.k[1] = lin + nl
 
   @muladd @. tmp = uprev + dt*nl
   if alg.krylov
-    expmv!(u,dt,f.f1,tmp; tol=integrator.opts.reltol, m=min(alg.m, size(f.f1,1)), norm=normbound)
+    arnoldi!(Ks,f.f1,tmp; m=min(alg.m, size(f.f1,1)), norm=normbound, cache=u)
+    _expmv!(u,dt,Ks; cache=KsCache)
   else
     A_mul_B!(u,exphA,tmp)
   end

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -96,7 +96,8 @@ function perform_step!(integrator, cache::NorsettEulerConstantCache, repeat_step
   integrator.k[1] = lin + nl
 
   if alg.krylov
-    u = phimv(dt,f.f1,nl,uprev; tol=integrator.opts.reltol, m=min(alg.m, size(f.f1,1)), norm=normbound)
+    w = _phimv(dt, f.f1, f.f1 * uprev + nl, 1; m=min(alg.m, size(f.f1,1)), norm=normbound)
+    u = uprev + dt * w[:,2]
   else
     u = exphA*uprev + dt*(phihA*nl)
   end
@@ -128,12 +129,16 @@ end
 function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack lin,nl = integrator.fsalfirst
-  @unpack tmp,rtmp,exphA,phihA = cache
+  @unpack tmp,rtmp,exphA,phihA,Ks,KsCache = cache
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
   @. integrator.k[1] = lin + nl
 
   if alg.krylov
-    phimv!(u,dt,f.f1,nl,uprev; tol=integrator.opts.reltol, m=min(alg.m, size(f.f1,1)), norm=normbound)
+    w = KsCache[1]
+    A_mul_B!(tmp, f.f1, uprev); tmp .+= nl
+    arnoldi!(Ks, f.f1, tmp; m=min(alg.m, size(f.f1,1)), norm=normbound, cache=u)
+    _phimv!(w, dt, Ks, 1; caches=KsCache[2:end])
+    @muladd @. u = uprev + dt * @view(w[:, 2])
   else
     A_mul_B!(tmp,exphA,uprev)
     A_mul_B!(rtmp,phihA,nl)

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -21,7 +21,7 @@ function perform_step!(integrator, cache::LawsonEulerConstantCache, repeat_step=
   integrator.k[1] = lin + nl
 
   if alg.krylov
-    @muladd u = _expmv(dt, f.f1, uprev + dt*nl; m=min(alg.m, size(f.f1,1)), norm=normbound)
+    @muladd u = expmv(dt, f.f1, uprev + dt*nl; m=min(alg.m, size(f.f1,1)), norm=normbound)
   else
     @muladd u = cache.exphA*(uprev + dt*nl)
   end
@@ -60,7 +60,7 @@ function perform_step!(integrator, cache::LawsonEulerCache, repeat_step=false)
   @muladd @. tmp = uprev + dt*nl
   if alg.krylov
     arnoldi!(Ks,f.f1,tmp; m=min(alg.m, size(f.f1,1)), norm=normbound, cache=u)
-    _expmv!(u,dt,Ks; cache=KsCache)
+    expmv!(u,dt,Ks; cache=KsCache)
   else
     A_mul_B!(u,exphA,tmp)
   end
@@ -96,7 +96,7 @@ function perform_step!(integrator, cache::NorsettEulerConstantCache, repeat_step
   integrator.k[1] = lin + nl
 
   if alg.krylov
-    w = _phimv(dt, f.f1, f.f1 * uprev + nl, 1; m=min(alg.m, size(f.f1,1)), norm=normbound)
+    w = phimv(dt, f.f1, f.f1 * uprev + nl, 1; m=min(alg.m, size(f.f1,1)), norm=normbound)
     u = uprev + dt * w[:,2]
   else
     u = exphA*uprev + dt*(phihA*nl)
@@ -137,7 +137,7 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
     w = KsCache[1]
     A_mul_B!(tmp, f.f1, uprev); tmp .+= nl
     arnoldi!(Ks, f.f1, tmp; m=min(alg.m, size(f.f1,1)), norm=normbound, cache=u)
-    _phimv!(w, dt, Ks, 1; caches=KsCache[2:end])
+    phimv!(w, dt, Ks, 1; caches=KsCache[2:end])
     @muladd @. u = uprev + dt * @view(w[:, 2])
   else
     A_mul_B!(tmp,exphA,uprev)

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -18,7 +18,6 @@ DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
 Algs = [LawsonEuler,NorsettEuler]
 for Alg in Algs
     gc()
-    @show Alg
     sol = solve(prob, Alg(); dt=dt)
     sol_krylov = solve(prob, Alg(krylov=true); dt=dt, reltol=reltol)
     @test isapprox(sol.u,sol_krylov.u; rtol=reltol)

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -22,7 +22,7 @@ for Alg in Algs
     sol_krylov = solve(prob, Alg(krylov=true); dt=dt, reltol=reltol)
     @test isapprox(sol.u,sol_krylov.u; rtol=reltol)
 
-    sol_ip = solve(prob_inplace, Alg(); dt=0.01)
+    sol_ip = solve(prob_inplace, Alg(); dt=dt)
     sol_ip_krylov = solve(prob_inplace, Alg(krylov=true); dt=dt, reltol=reltol)
     @test isapprox(sol_ip.u,sol_ip_krylov.u; rtol=reltol)
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -28,6 +28,6 @@ using OrdinaryDiffEq: phi, phim, _phimv
   for i = 1:K+1
     W[:,i] = P[i] * b
   end
-  W_approx = _phimv(A, b, K, m)
+  W_approx = _phimv(A, b, K; m=m)
   @test W ≈ W_approx  
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq: phi, phim, _phimv, _expmv, arnoldi
+using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
 
 @testset "Phi functions" begin
   # Scalar phi
@@ -24,13 +24,13 @@ using OrdinaryDiffEq: phi, phim, _phimv, _expmv, arnoldi
   A = randn(n, n)
   t = 1e-2
   b = randn(n)
-  @test expm(t * A) * b ≈ _expmv(t, A, b; m=m)
+  @test expm(t * A) * b ≈ expmv(t, A, b; m=m)
   P = phim(t * A, K)
   W = zeros(n, K+1)
   for i = 1:K+1
     W[:,i] = P[i] * b
   end
-  W_approx = _phimv(t, A, b, K; m=m)
+  W_approx = phimv(t, A, b, K; m=m)
   @test W ≈ W_approx
 
   # Happy-breakdown in Krylov

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq: phi, phim, _phimv
+using OrdinaryDiffEq: phi, phim, _phimv, arnoldi
 
 @testset "Phi functions" begin
   # Scalar phi
@@ -29,5 +29,11 @@ using OrdinaryDiffEq: phi, phim, _phimv
     W[:,i] = P[i] * b
   end
   W_approx = _phimv(A, b, K; m=m)
-  @test W ≈ W_approx  
+  @test W ≈ W_approx
+
+  # Happy-breakdown in Krylov
+  v = normalize(randn(n))
+  A = v * v' # A is Idempotent
+  Ks = arnoldi(A, b)
+  @test Ks.m == 2
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq: phi, phim, _phimv, arnoldi
+using OrdinaryDiffEq: phi, phim, _phimv, _expmv, arnoldi
 
 @testset "Phi functions" begin
   # Scalar phi
@@ -24,6 +24,7 @@ using OrdinaryDiffEq: phi, phim, _phimv, arnoldi
   A = randn(n, n)
   t = 1e-2
   b = randn(n)
+  @test expm(t * A) * b ≈ _expmv(t, A, b; m=m)
   P = phim(t * A, K)
   W = zeros(n, K+1)
   for i = 1:K+1

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -21,14 +21,15 @@ using OrdinaryDiffEq: phi, phim, _phimv, arnoldi
   # Krylov
   n = 20; m = 5
   srand(0)
-  A = 1e-2 * randn(n, n)
+  A = randn(n, n)
+  t = 1e-2
   b = randn(n)
-  P = phim(A, K)
+  P = phim(t * A, K)
   W = zeros(n, K+1)
   for i = 1:K+1
     W[:,i] = P[i] * b
   end
-  W_approx = _phimv(A, b, K; m=m)
+  W_approx = _phimv(t, A, b, K; m=m)
   @test W ≈ W_approx
 
   # Happy-breakdown in Krylov


### PR DESCRIPTION
With the addition of happy-breakdown detection and the time parameter, `phimv` now has all functionality supported by Expokit. Ours is actually more powerful in that the code for Arnoldi iterations and function evaluation is separated, so we can reuse the arnoldi results for different `t` easily.

One thing I got wrong though in #361 is how happy-breakdown should be interpreted. It doesn't really have anything to do with the integrator's error control, but rather is an indication of how singular `A` is. In particular, if the minimal polynomial of `A` only has degree $d < n$, then happy-breakdown will occur at the $d$th iteration. In other words, whether happy-breakdown occurs is intrinsic to the problem/discretization method, and doesn't concern the integrator.

What this leaves us is the number of arnoldi iterations `m`, which does have a direct impact on the integrator's accuracy. I think there is some estimation formula available, but I need to consult the literatures on this.