### PR TITLE
Lanczos algorithm for symmetric/Hermitian matrices

### DIFF
--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -174,7 +174,7 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
     else
       _A = full(A)
     end
-    exphA, phihA = phim(dt*_A, 1)
+    exphA, phihA = phi(dt*_A, 1)
   end
   NorsettEulerCache(u,uprev,similar(u),zeros(rate_prototype),exphA,phihA,Ks,KsCache)
 end
@@ -198,7 +198,7 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
     else
       _A = full(A)
     end
-    exphA, phihA = phim(dt*_A, 1)
+    exphA, phihA = phi(dt*_A, 1)
   end
   NorsettEulerConstantCache(exphA, phihA)
 end
@@ -233,7 +233,7 @@ function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   else
     _A = full(A)
   end
-  Phi = phim(dt*_A, 2)
+  Phi = phi(dt*_A, 2)
   ETD2ConstantCache(Phi[1], Phi[2], Phi[2] + Phi[3], -Phi[3])
 end
 
@@ -256,7 +256,7 @@ function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   else
     _A = full(A)
   end
-  Phi = phim(dt*_A, 2)
+  Phi = phi(dt*_A, 2)
   ETD2Cache(u,uprev,zero(u),zero(rate_prototype),zero(rate_prototype),Phi[1],Phi[2],Phi[2]+Phi[3],-Phi[3])
 end
 
@@ -280,8 +280,8 @@ function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   else
     L = full(A)
   end
-  P = phim(dt * L, 3)
-  Phalf = phim(dt/2 * L, 1)
+  P = phi(dt * L, 3)
+  Phalf = phi(dt/2 * L, 1)
   E = P[1]
   E2 = Phalf[1]
   a = dt * (P[2] - 3*P[3] + 4*P[4])
@@ -319,8 +319,8 @@ function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   else
     L = full(A)
   end
-  P = phim(dt * L, 3)
-  Phalf = phim(dt/2 * L, 1)
+  P = phi(dt * L, 3)
+  Phalf = phi(dt/2 * L, 1)
   E = P[1]
   E2 = Phalf[1]
   a = dt * (P[2] - 3*P[3] + 4*P[4])

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -245,6 +245,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol=1e-7,
     @assert size(cache) == (n,) "Dimension mismatch"
   end
   # Arnoldi iterations
+  fill!(H, zero(T))
   Ks.beta = norm(b)
   V[:, 1] = b / Ks.beta
   @inbounds for j = 1:m
@@ -287,6 +288,7 @@ function lanczos!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol=1e-7,
     @assert size(cache) == (n,) "Dimension mismatch"
   end
   # Lanczos iterations
+  fill!(H, zero(T))
   Ks.beta = norm(b)
   V[:, 1] = b / Ks.beta
   @inbounds for j = 1:m

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -21,7 +21,7 @@ function perform_step!(integrator, cache::LawsonEulerConstantCache, repeat_step=
   integrator.k[1] = lin + nl
 
   if alg.krylov
-    @muladd u = expmv(dt, f.f1, uprev + dt*nl; m=min(alg.m, size(f.f1,1)), norm=normbound)
+    @muladd u = expv(dt, f.f1, uprev + dt*nl; m=min(alg.m, size(f.f1,1)), norm=normbound)
   else
     @muladd u = cache.exphA*(uprev + dt*nl)
   end
@@ -60,7 +60,7 @@ function perform_step!(integrator, cache::LawsonEulerCache, repeat_step=false)
   @muladd @. tmp = uprev + dt*nl
   if alg.krylov
     arnoldi!(Ks,f.f1,tmp; m=min(alg.m, size(f.f1,1)), norm=normbound, cache=u)
-    expmv!(u,dt,Ks; cache=KsCache)
+    expv!(u,dt,Ks; cache=KsCache)
   else
     A_mul_B!(u,exphA,tmp)
   end
@@ -96,7 +96,7 @@ function perform_step!(integrator, cache::NorsettEulerConstantCache, repeat_step
   integrator.k[1] = lin + nl
 
   if alg.krylov
-    w = phimv(dt, f.f1, f.f1 * uprev + nl, 1; m=min(alg.m, size(f.f1,1)), norm=normbound)
+    w = phiv(dt, f.f1, f.f1 * uprev + nl, 1; m=min(alg.m, size(f.f1,1)), norm=normbound)
     u = uprev + dt * w[:,2]
   else
     u = exphA*uprev + dt*(phihA*nl)
@@ -137,7 +137,7 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
     w = KsCache[1]
     A_mul_B!(tmp, f.f1, uprev); tmp .+= nl
     arnoldi!(Ks, f.f1, tmp; m=min(alg.m, size(f.f1,1)), norm=normbound, cache=u)
-    phimv!(w, dt, Ks, 1; caches=KsCache[2:end])
+    phiv!(w, dt, Ks, 1; caches=KsCache[2:end])
     @muladd @. u = uprev + dt * @view(w[:, 2])
   else
     A_mul_B!(tmp,exphA,uprev)

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi
+using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi, getH, getV
 
 @testset "Exponential Utilities" begin
   # Scalar phi
@@ -44,6 +44,6 @@ using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi
   Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
   Ks = arnoldi(A, b; m=m) # uses lanczos!
   Ksperm = arnoldi(Aperm, b; m=m)
-  @test Ks.H[1:m, 1:m] ≈ Ksperm.H[1:m, 1:m]
-  @test Ks.V[:, 1:m] ≈ Ksperm.V[:, 1:m]
+  @test getH(Ks) ≈ getH(Ksperm)
+  @test getV(Ks) ≈ getV(Ksperm)
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -44,6 +44,6 @@ using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
   Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
   Ks = arnoldi(A, b; m=m) # uses lanczos!
   Ksperm = arnoldi(Aperm, b; m=m)
-  @test Ks[:H] ≈ Ksperm[:H]
-  @test Ks[:V] ≈ Ksperm[:V]
+  @test Ks.H[1:m, 1:m] ≈ Ksperm.H[1:m, 1:m]
+  @test Ks.V[:, 1:m] ≈ Ksperm.V[:, 1:m]
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
 
-@testset "Phi functions" begin
+@testset "Exponential Utilities" begin
   # Scalar phi
   K = 4
   z = 0.1
@@ -38,4 +38,12 @@ using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
   A = v * v' # A is Idempotent
   Ks = arnoldi(A, b)
   @test Ks.m == 2
+
+  # Arnoldi vs Lanczos
+  A = Hermitian(randn(n, n))
+  Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
+  Ks = arnoldi(A, b; m=m) # uses lanczos!
+  Ksperm = arnoldi(Aperm, b; m=m)
+  @test Ks[:H] ≈ Ksperm[:H]
+  @test Ks[:V] ≈ Ksperm[:V]
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -42,8 +42,7 @@ using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi, getH, getV
   # Arnoldi vs Lanczos
   A = Hermitian(randn(n, n))
   Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
-  Ks = arnoldi(A, b; m=m) # uses lanczos!
-  Ksperm = arnoldi(Aperm, b; m=m)
-  @test getH(Ks) ≈ getH(Ksperm)
-  @test getV(Ks) ≈ getV(Ksperm)
+  w = expv(t, A, b; m=m)
+  wperm = expv(t, Aperm, b; m=m)
+  @test w ≈ wperm
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
+using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi
 
 @testset "Exponential Utilities" begin
   # Scalar phi
@@ -16,7 +16,7 @@ using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
   for i = 1:K
     P[i+1] = (P[i] - 1/factorial(i-1)*I) / A
   end
-  @test phim(A, K) ≈ P
+  @test phi(A, K) ≈ P
 
   # Krylov
   n = 20; m = 5
@@ -24,13 +24,13 @@ using OrdinaryDiffEq: phi, phim, phimv, expmv, arnoldi
   A = randn(n, n)
   t = 1e-2
   b = randn(n)
-  @test expm(t * A) * b ≈ expmv(t, A, b; m=m)
-  P = phim(t * A, K)
+  @test expm(t * A) * b ≈ expv(t, A, b; m=m)
+  P = phi(t * A, K)
   W = zeros(n, K+1)
   for i = 1:K+1
     W[:,i] = P[i] * b
   end
-  W_approx = phimv(t, A, b, K; m=m)
+  W_approx = phiv(t, A, b, K; m=m)
   @test W ≈ W_approx
 
   # Happy-breakdown in Krylov


### PR DESCRIPTION
For symmetric/Hermitian `A`, we know that Arnoldi iteration will produce an `H` that is also real symmetric. The Lanczos algorithm improves upon Arnoldi by not calculating the zero elements of the upper part of `H`, thus saving time.

```julia
using OrdinaryDiffEq: KrylovSubspace, arnoldi!
```


```julia
n = 1000
m = 50
A = full(Hermitian(randn(n, n)))
Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
@show ishermitian(A)
@show ishermitian(Aperm);
```

    ishermitian(A) = true
    ishermitian(Aperm) = false
    


```julia
b = randn(n)
cache = similar(b)
Ks = KrylovSubspace{Float64}(n, m);
```


```julia
@time arnoldi!(Ks, A, b; m=m, cache=cache); # uses lanczos!
```

      0.043768 seconds (108 allocations: 13.016 KiB)
    


```julia
@time arnoldi!(Ks, Aperm, b; m=m, cache=cache);
```

      0.046262 seconds (2.61 k allocations: 130.094 KiB)
    
Note that the difference in time is not big: Arnoldi/Lanczos iteration is, after all, bounded in time by `A_mul_B!`. What Lanczos saves is just a bunch of dot products and `axpy!` updates.

Nevertheless, it's still valuable to have `lanczos!` around because it guarantees the results `Ks[:H]` is real symmetric, which can speed up later calculations. For example, `expm` is able to use diagonalization for Hermitian matrices:

```julia
@time expm(A);
```

      0.428920 seconds (36 allocations: 53.774 MiB, 2.35% gc time)
    


```julia
@time expm(Aperm);
```

      0.805784 seconds (103 allocations: 343.342 MiB, 14.75% gc time)
    
