### PR TITLE
Krylov Phiv internal time stepping

### DIFF
--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi, getH, getV
+using OrdinaryDiffEq: phi, phi, phiv, phiv_timestep, expv, arnoldi, getH, getV
 
 @testset "Exponential Utilities" begin
   # Scalar phi
@@ -45,4 +45,15 @@ using OrdinaryDiffEq: phi, phi, phiv, expv, arnoldi, getH, getV
   w = expv(t, A, b; m=m)
   wperm = expv(t, Aperm, b; m=m)
   @test w ≈ wperm
+
+  # Internal time-stepping for Krylov
+  n = 100; m = 20
+  K = 4
+  A = diagm(-2*ones(n)) + diagm(ones(n-1), -1) + diagm(ones(n-1), 1)
+  B = randn(n, K+1)
+  t = 5.0; tau = 1.0
+  Phi = phi(t * A, K)
+  u_exact = sum(t^i * Phi[i+1] * B[:,i+1] for i = 0:K)
+  u = phiv_timestep(t, A, B; m=m, tau=tau) # effectively only a single step
+  @test u_exact ≈ u
 end


### PR DESCRIPTION
The internal time stepping method of phipm aims to calculate linear combinations of phi-vector products of the form

$$ u = \varphi_0(tA)b_0 + t\varphi_1(tA)b_1 + \cdots + t^p\varphi_p(tA)b_p $$

The interface for the `phiv_timestep` function is far from its finalized version and some parts of the code can still be optimized, but the logic for the time stepping algorithm is complete.

Currently it still uses fixed time step `tau` (except for the last one) and Krylov subspace dimension `m`. But since we already have the error estimate of `phiv` from last week adding adaptation would just be a few lines at the end of each iteration.

Quick sanity checks:

```julia
using OrdinaryDiffEq: phi, phiv_timestep
```


```julia
srand(0)
n = 100
m = 20
p = 4
tol = 1e-7
t = 5.0
A = diagm(-2*ones(n)) + diagm(ones(n-1), -1) + diagm(ones(n-1), 1)
B = randn(n, p+1);
```


```julia
Anorm = norm(A, Inf)
b0norm = norm(B[:,1], Inf)
tau = 10/Anorm * (tol * ((m+1)/e)^(m+1) * sqrt(2*pi*(m+1)) / (4*Anorm*b0norm))^(1/m)
println("Default time step = $tau")
```

    Default time step = 8.832121898706621
    


```julia
Phi = phi(t * A,p)
u_exact = sum(t^i * Phi[i+1] * B[:,i+1] for i = 0:p)
u1 = phiv_timestep(t, A, B; m=m) # effectively only a single step
u2 = phiv_timestep(t, A, B; m=m, tau=1.0); # force multiple steps
```


```julia
err1 = norm(u1 - u_exact) / norm(u_exact)
```




    2.676157436850627e-11




```julia
err2 = norm(u2 - u_exact) / norm(u_exact)
```




    6.637202188498197e-16
