### PR TITLE
Adaptation for `phiv_timestep(!)`

### DIFF
--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -569,10 +569,12 @@ function _phiv_timestep_adapt(m, tau, epsilon, m_old, tau_old, epsilon_old, q, k
     q = log(tau/tau_old) / log(epsilon/epsilon_old) - 1
   end # else keep q the same
   tau_new = tau * (gamma / omega)^(1/(q + 1))
+  tau_new = min(max(tau_new, tau/5), 2*tau, maxtau)
   if m_old < m
     kappa = (epsilon/epsilon_old)^(1/(m_old - m))
   end # else keep kappa the same
   m_new = m + ceil(Int, log(omega / gamma) / log(kappa))
+  m_new = min(max(m_new, div(3*m, 4), 1), Int(ceil(4*m / 3)))
   verbose && println("  - Proposed new m: $m_new, new tau: $tau_new")
   # Compare costs of using new m vs new tau (23)
   cost_tau = _phiv_timestep_estimate_flops(m, tau_new, n, p, NA, iop, Hnorm, maxtau)
@@ -580,9 +582,7 @@ function _phiv_timestep_adapt(m, tau, epsilon, m_old, tau_old, epsilon_old, q, k
   verbose && println("  - Cost to use new m: $cost_m flops, new tau: $cost_tau flops")
   if cost_tau < cost_m
     m_new = m
-    tau_new = min(max(tau_new, tau/5), 2*tau, maxtau)
   else
-    m_new = min(max(m_new, div(3*m, 4), 1), Int(ceil(4*m / 3)))
     tau_new = tau
   end
   return m_new, tau_new, q, kappa

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -477,10 +477,12 @@ function phiv_timestep!(u::Vector{T}, t::Real, A, B::Matrix{T}; tau::Real=0.0,
   correct::Bool=false, caches=nothing, adaptive=false, delta::Real=1.2, 
   gamma::Real=0.8, NA::Int=0, verbose=false) where {T <: Number}
   # Choose initial timestep
+  abstol = tol * norm(A, Inf)
+  verbose && println("Absolute tolerance: $abstol")
   if iszero(tau)
     Anorm = norm(A, Inf)
     b0norm = norm(@view(B[:, 1]), Inf)
-    tau = 10/Anorm * (tol * ((m+1)/e)^(m+1) * sqrt(2*pi*(m+1)) / 
+    tau = 10/Anorm * (abstol * ((m+1)/e)^(m+1) * sqrt(2*pi*(m+1)) / 
       (4*Anorm*b0norm))^(1/m)
     verbose && println("Initial time step unspecified, chosen to be $tau")
   end
@@ -499,8 +501,6 @@ function phiv_timestep!(u::Vector{T}, t::Real, A, B::Matrix{T}; tau::Real=0.0,
   end
   copy!(u, @view(B[:, 1])) # u(0) = b0
   if adaptive # initialization step for the adaptive scheme
-    abstol = tol * norm(A, Inf)
-    verbose && println("Absolute tolerance: $abstol")
     if ishermitian(A)
       iop = 2 # does not have an effect on arnoldi!, just for flops estimation
     end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -46,14 +46,15 @@ using OrdinaryDiffEq: phi, phi, phiv, phiv_timestep, expv, arnoldi, getH, getV
   wperm = expv(t, Aperm, b; m=m)
   @test w ≈ wperm
 
-  # Internal time-stepping for Krylov
-  n = 100; m = 20
+  # Internal time-stepping for Krylov (with adaptation)
+  n = 100
   K = 4
-  A = diagm(-2*ones(n)) + diagm(ones(n-1), -1) + diagm(ones(n-1), 1)
+  t = 5.0
+  tol = 1e-7
+  A = spdiagm((ones(n-1), -2*ones(n), ones(n-1)), (-1, 0, 1))
   B = randn(n, K+1)
-  t = 5.0; tau = 1.0
   Phi = phi(t * A, K)
   u_exact = sum(t^i * Phi[i+1] * B[:,i+1] for i = 0:K)
-  u = phiv_timestep(t, A, B; m=m, tau=tau) # effectively only a single step
-  @test u_exact ≈ u
+  u = phiv_timestep(t, A, B; adaptive=true, tol=tol)
+  @test norm(u - u_exact) / norm(u_exact) < tol
 end


### PR DESCRIPTION
The adaptation framework of phipm (Algorithm 3 & 4 in the paper) is unfortunately a bit messy. Took me a while to sort through the threads and incorporate the framework into `phiv_timestep(!)`. In particular, I changed the do loop of Algorithm 3 to the more manageable form in `phiv_timestep`, which also makes Algorithm 4 (the helper funtion `_phiv_timestep_adapt`) a bit simpler to interpret.

The framework is not yet complete though: the cost comparison part of Algorithm 4 only concerns full Arnoldi and Lanczos, so I need to come up with a similar estimation for IOP(p).

I also entertained myself with the idea of rewriting `phiv_timestep` into an iterator object much like `integrator` does in OrdinaryDiffEq. For the moment I think I'll just keep things as-is, but if there's future need to extend or modify the phipm algorithm, then it may be worthwhile to do so.