### PR TITLE
Hochbruck-Ostermann Method

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -160,7 +160,7 @@ module OrdinaryDiffEq
 
   export GenericIIF1, GenericIIF2
 
-  export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, ETD2
+  export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, HochOst4, ETD2
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -106,9 +106,10 @@ alg_order(alg::LawsonEuler) = 1
 alg_order(alg::NorsettEuler) = 1
 alg_order(alg::ETDRK2) = 2
 alg_order(alg::ETDRK3) = 3
+alg_order(alg::ETDRK4) = 4
+alg_order(alg::HochOst4) = 4
 alg_order(alg::SplitEuler) = 1
 alg_order(alg::ETD2) = 2
-alg_order(alg::ETDRK4) = 4
 
 alg_order(alg::SymplecticEuler) = 1
 alg_order(alg::VelocityVerlet) = 2

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -668,7 +668,7 @@ struct GenericIIF2{F} <: OrdinaryDiffEqExponentialAlgorithm
 end
 Base.@pure GenericIIF2(;nlsolve=NLSOLVEJL_SETUP()) = GenericIIF2{typeof(nlsolve)}(nlsolve)
 
-for Alg in [:LawsonEuler, :NorsettEuler, :ETDRK2, :ETDRK3, :ETDRK4]
+for Alg in [:LawsonEuler, :NorsettEuler, :ETDRK2, :ETDRK3, :ETDRK4, :HochOst4]
   @eval struct $Alg <: OrdinaryDiffEqExponentialAlgorithm
     krylov::Bool
     m::Int

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -416,10 +416,10 @@ function alg_cache(alg::HochOst4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     m = min(alg.m, length(u))
     T = eltype(u)
     Ks = KrylovSubspace{T}(n, m)
-    w1_half = Matrix{T}(n, 4); w2_half = Matrix{T}(n, 4)
-    w1 = Matrix{T}(n, 4); w2 = Matrix{T}(n, 4); w3 = Matrix{T}(n, 4); w4 = Matrix{T}(n, 4)
+    w1_half = Matrix{T}(n, 4); w2_half = Matrix{T}(n, 4); w3_half = Matrix{T}(n, 4); w4_half = Matrix{T}(n, 4)
+    w1 = Matrix{T}(n, 4); w2 = Matrix{T}(n, 4); w3 = Matrix{T}(n, 4); w4 = Matrix{T}(n, 4); w5 = Matrix{T}(n, 4)
     phiv_caches = (Vector{T}(m), Matrix{T}(m, m), Matrix{T}(m + 3, m + 3), Matrix{T}(m, 4))
-    KsCache = (w1_half, w2_half, w1, w2, w3, w4, phiv_caches)
+    KsCache = (w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5, phiv_caches)
   else
     Ks = KsCache = nothing
     A = f.f1

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -23,6 +23,8 @@ sim  = test_convergence(dts,prob,ETDRK3())
 @test abs(sim.𝒪est[:l2]-3) < 0.2
 sim  = test_convergence(dts,prob,ETDRK4(),dense_errors=true)
 @test abs(sim.𝒪est[:l2]-4) < 0.2
+sim  = test_convergence(dts,prob,HochOst4())
+@test abs(sim.𝒪est[:l2]-4) < 0.2
 sim  = test_convergence(dts,prob,ETD2())
 @test abs(sim.𝒪est[:l2]-2) < 0.2
 
@@ -60,6 +62,9 @@ sim  = test_convergence(dts,prob,ETDRK3())
 sim  = test_convergence(dts,prob,ETDRK4(),dense_errors=true)
 @test abs(sim.𝒪est[:l2]-4) < 0.1
 @test abs(sim.𝒪est[:L2]-4) < 0.1
+
+sim  = test_convergence(dts,prob,HochOst4())
+@test abs(sim.𝒪est[:l2]-4) < 0.1
 
 sim  = test_convergence(dts,prob,ETD2())
 @test abs(sim.𝒪est[:l2]-2) < 0.1

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -13,7 +13,7 @@ prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
 DiffEqBase.has_analytic(::typeof(prob.f)) = false
 DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
 
-Algs = [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4]
+Algs = [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4]
 for Alg in Algs
     gc()
     sol = solve(prob, Alg(); dt=dt, internalnorm=Base.norm)


### PR DESCRIPTION
The aim of this PR is to add a few more ExpRK integrators from #394 as well as optimize/organize the existing implementations.

The Hochbruck-Ostermann method is a 5-stage, 4th order ExpRK method (the name is coined by EXPINT). This is so far the only fourth order method proposed that is stiffly accurate, and as such it's an important one to include.