### PR TITLE
Optimizing the classical ExpRK integrators

### DIFF
--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -225,8 +225,9 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
     m = min(alg.m, length(u))
     T = eltype(u)
     Ks = KrylovSubspace{T}(n, m)
-    KsCache = (Matrix{T}(n, 2), Vector{T}(m), Matrix{T}(m, m), Matrix{T}(m + 1, m + 1), 
-      Matrix{T}(m, 2))
+    w = Matrix{T}(n, 2)
+    phiv_caches = construct_phiv_caches(Ks, 1)
+    KsCache = (w, phiv_caches)
   else
     Ks = nothing
     KsCache = nothing
@@ -271,7 +272,7 @@ function alg_cache(alg::ETDRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     Ks = KrylovSubspace{T}(n, m)
     w1 = Matrix{T}(n, 3)
     w2 = Matrix{T}(n, 3)
-    phiv_caches = (Vector{T}(m), Matrix{T}(m, m), Matrix{T}(m + 2, m + 2), Matrix{T}(m, 3))
+    phiv_caches = construct_phiv_caches(Ks, 2)
     KsCache = (w1, w2, phiv_caches)
   else
     Ks = nothing
@@ -315,7 +316,7 @@ function alg_cache(alg::ETDRK3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     T = eltype(u)
     Ks = KrylovSubspace{T}(n, m)
     w1_half = Matrix{T}(n, 2); w1 = Matrix{T}(n, 4); w2 = Matrix{T}(n, 4); w3 = Matrix{T}(n, 4)
-    phiv_caches = (Vector{T}(m), Matrix{T}(m, m), Matrix{T}(m + 3, m + 3), Matrix{T}(m, 4))
+    phiv_caches = construct_phiv_caches(Ks, 3)
     KsCache = (w1_half, w1, w2, w3, phiv_caches)
   else
     Ks = nothing
@@ -365,7 +366,7 @@ function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     Ks = KrylovSubspace{T}(n, m)
     w1_half = Matrix{T}(n, 2); w2_half = Matrix{T}(n, 2)
     w1 = Matrix{T}(n, 4); w2 = Matrix{T}(n, 4); w3 = Matrix{T}(n, 4); w4 = Matrix{T}(n, 4)
-    phiv_caches = (Vector{T}(m), Matrix{T}(m, m), Matrix{T}(m + 3, m + 3), Matrix{T}(m, 4))
+    phiv_caches = construct_phiv_caches(Ks, 3)
     KsCache = (w1_half, w2_half, w1, w2, w3, w4, phiv_caches)
   else
     Ks = KsCache = nothing
@@ -418,7 +419,7 @@ function alg_cache(alg::HochOst4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     Ks = KrylovSubspace{T}(n, m)
     w1_half = Matrix{T}(n, 4); w2_half = Matrix{T}(n, 4); w3_half = Matrix{T}(n, 4); w4_half = Matrix{T}(n, 4)
     w1 = Matrix{T}(n, 4); w2 = Matrix{T}(n, 4); w3 = Matrix{T}(n, 4); w4 = Matrix{T}(n, 4); w5 = Matrix{T}(n, 4)
-    phiv_caches = (Vector{T}(m), Matrix{T}(m, m), Matrix{T}(m + 3, m + 3), Matrix{T}(m, 4))
+    phiv_caches = construct_phiv_caches(Ks, 3)
     KsCache = (w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5, phiv_caches)
   else
     Ks = KsCache = nothing

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -186,13 +186,8 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
   else
     Ks = nothing
     KsCache = nothing
-    A = f.f1
-    if isa(A, DiffEqArrayOperator)
-      _A = A.A * A.α.coeff
-    else
-      _A = full(A)
-    end
-    exphA = expRK_operators(alg, dt, _A)
+    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    exphA = expRK_operators(alg, dt, A)
   end
   LawsonEulerCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),Jcache,exphA,Ks,KsCache)
 end
@@ -231,13 +226,8 @@ function alg_cache(alg::NorsettEuler,u,rate_prototype,uEltypeNoUnits,uBottomElty
   else
     Ks = nothing
     KsCache = nothing
-    A = f.f1
-    if isa(A, DiffEqArrayOperator)
-      _A = A.A * A.α.coeff
-    else
-      _A = full(A)
-    end
-    phihA = expRK_operators(alg, dt, _A)
+    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    phihA = expRK_operators(alg, dt, A)
   end
   NorsettEulerCache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),Jcache,phihA,Ks,KsCache)
 end
@@ -278,12 +268,8 @@ function alg_cache(alg::ETDRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     Ks = nothing
     KsCache = nothing
     A = f.f1
-    if isa(A, DiffEqArrayOperator)
-      _A = A.A * A.α.coeff
-    else
-      _A = full(A)
-    end
-    ops = expRK_operators(alg, dt, _A)
+    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    ops = expRK_operators(alg, dt, A)
   end
   ETDRK2Cache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),Jcache,ops,Ks,KsCache)
 end
@@ -322,12 +308,8 @@ function alg_cache(alg::ETDRK3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     Ks = nothing
     KsCache = nothing
     A = f.f1
-    if isa(A, DiffEqArrayOperator)
-      _A = A.A * A.α.coeff
-    else
-      _A = full(A)
-    end
-    ops = expRK_operators(alg, dt, _A)
+    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    ops = expRK_operators(alg, dt, A)
   end
   ETDRK3Cache(u,uprev,similar(u),zeros(rate_prototype),zeros(rate_prototype),
     zeros(rate_prototype),zeros(rate_prototype),Jcache,ops,Ks,KsCache)
@@ -370,13 +352,8 @@ function alg_cache(alg::ETDRK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     KsCache = (w1_half, w2_half, w1, w2, w3, w4, phiv_caches)
   else
     Ks = KsCache = nothing
-    A = f.f1
-    if isa(A, DiffEqArrayOperator)
-      L = A.A .* A.α.coeff # has special handling if A.A is Diagonal
-    else
-      L = full(A)
-    end
-    ops = expRK_operators(alg, dt, L)
+    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    ops = expRK_operators(alg, dt, A)
   end
   ETDRK4Cache(u,uprev,tmp,rtmp,Au,F2,F3,F4,Jcache,ops,Ks,KsCache)
 end
@@ -423,13 +400,8 @@ function alg_cache(alg::HochOst4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     KsCache = (w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5, phiv_caches)
   else
     Ks = KsCache = nothing
-    A = f.f1
-    if isa(A, DiffEqArrayOperator)
-      L = A.A .* A.α.coeff # has special handling if A.A is Diagonal
-    else
-      L = full(A)
-    end
-    ops = expRK_operators(alg, dt, L)
+    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    ops = expRK_operators(alg, dt, A)
   end
   HochOst4Cache(u,uprev,tmp,rtmp,rtmp2,Au,F2,F3,F4,F5,Jcache,ops,Ks,KsCache)
 end

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -297,7 +297,7 @@ function lanczos!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol=1e-7,
   # Lanczos iterations
   fill!(H, zero(T))
   Ks.beta = norm(b)
-  V[:, 1] = b / Ks.beta
+  @. V[:, 1] = b / Ks.beta
   @inbounds for j = 1:m
     vj = @view(V[:, j])
     A_mul_B!(cache, A, vj)

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -252,7 +252,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol::Real=1
   # Arnoldi iterations (with IOP)
   fill!(H, zero(T))
   Ks.beta = norm(b)
-  V[:, 1] = b / Ks.beta
+  @. V[:, 1] = b / Ks.beta
   @inbounds for j = 1:m
     A_mul_B!(cache, A, @view(V[:, j]))
     @inbounds for i = max(1, j - iop + 1):j
@@ -263,7 +263,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol::Real=1
     beta = norm(cache)
     H[j+1, j] = beta
     @inbounds for i = 1:n
-      V[i, j+1] = cache[i] / beta
+      @. V[i, j+1] = cache[i] / beta
     end
     if beta < vtol # happy-breakdown
       Ks.m = j

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -107,12 +107,7 @@ end
 function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack rtmp,Jcache,Ks,KsCache = cache
-  if isa(f, SplitFunction)
-    A = f.f1
-  else
-    f.jac(Jcache, uprev, p, t)
-    A = Jcache
-  end
+  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -212,6 +212,7 @@ function perform_step!(integrator, cache::ETDRK3ConstantCache, repeat_step=false
   Au = A * uprev
   F1 = integrator.fsalfirst
   if alg.krylov
+    # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop)]
     # Krylov on F1 (first column)
     Ks = arnoldi(A, F1; kwargs...)
@@ -259,6 +260,7 @@ function perform_step!(integrator, cache::ETDRK3Cache, repeat_step=false)
   halfdt = dt/2
   if alg.krylov
     w1_half, w1, w2, w3, phiv_caches = KsCache
+    # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop), (:cache, tmp)]
     # Krylov for F1 (first column)
     arnoldi!(Ks, A, F1; kwargs...)
@@ -310,6 +312,7 @@ function perform_step!(integrator, cache::ETDRK4ConstantCache, repeat_step=false
   F1 = integrator.fsalfirst
   halfdt = dt/2
   if alg.krylov
+    # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop)]
     # Krylov on F1 (first column)
     Ks = arnoldi(A, F1; kwargs...)
@@ -369,6 +372,7 @@ function perform_step!(integrator, cache::ETDRK4Cache, repeat_step=false)
   halfdt = dt/2
   if alg.krylov
     w1_half, w2_half, w1, w2, w3, w4, phiv_caches = KsCache
+    # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop), (:cache, tmp)]
     # Krylov for F1 (first column)
     arnoldi!(Ks, A, F1; kwargs...)
@@ -437,6 +441,7 @@ function perform_step!(integrator, cache::HochOst4ConstantCache, repeat_step=fal
   F1 = integrator.fsalfirst
   halfdt = dt/2
   if alg.krylov
+    # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop)]
     # Krylov on F1 (first column)
     Ks = arnoldi(A, F1; kwargs...)
@@ -506,6 +511,7 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step=false)
   halfdt = dt/2
   if alg.krylov
     w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5, phiv_caches = KsCache
+    # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop), (:cache, tmp)]
     # Krylov on F1 (first column)
     arnoldi!(Ks, A, F1; kwargs...)

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -111,10 +111,10 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov
-    w = KsCache[1]
+    w, phiv_caches = KsCache
     arnoldi!(Ks, A, integrator.fsalfirst; m=min(alg.m, size(A,1)), norm=integrator.opts.internalnorm, 
       cache=u, iop=alg.iop)
-    phiv!(w, dt, Ks, 1; caches=KsCache[2:end])
+    phiv!(w, dt, Ks, 1; caches=phiv_caches)
     @muladd @. u = uprev + dt * @view(w[:, 2])
   else
     A_mul_B!(rtmp, cache.phihA, integrator.fsalfirst)

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -30,7 +30,8 @@ using OrdinaryDiffEq: phi, phi, phiv, phiv_timestep, expv, expv_timestep, arnold
   for i = 1:K+1
     W[:,i] = P[i] * b
   end
-  W_approx = phiv(t, A, b, K; m=m)
+  Ks = arnoldi(A, b; m=m)
+  W_approx = phiv(t, Ks, K)
   @test W ≈ W_approx
 
   # Happy-breakdown in Krylov


### PR DESCRIPTION
The first update adds a version of `phiv` that uses a pre-constructed Krylov subspace, which should make the out-of-place versions of the ExpRK methods a bit faster due to fewer `arnoldi` calls. The difference between the out-of-place and in-place versions now should only be the extra allocation of caches, but I need to check this using profiling.