### PR TITLE
Exp4 using EPIRK

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -161,7 +161,7 @@ module OrdinaryDiffEq
 
   export GenericIIF1, GenericIIF2
 
-  export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, HochOst4, ETD2
+  export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, HochOst4, Exp4, ETD2
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -108,6 +108,7 @@ alg_order(alg::ETDRK2) = 2
 alg_order(alg::ETDRK3) = 3
 alg_order(alg::ETDRK4) = 4
 alg_order(alg::HochOst4) = 4
+alg_order(alg::Exp4) = 4
 alg_order(alg::SplitEuler) = 1
 alg_order(alg::ETD2) = 2
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -687,6 +687,11 @@ for Alg in [:LawsonEuler, :NorsettEuler, :ETDRK2, :ETDRK3, :ETDRK4, :HochOst4]
   @eval Base.@pure $Alg(;krylov=false, m=30, iop=0) = $Alg(krylov, m, iop)
 end
 ETD1 = NorsettEuler # alias
+struct Exp4 <: OrdinaryDiffEqExponentialAlgorithm
+  m::Int
+  iop::Int
+end
+Base.@pure Exp4(;m=30, iop=0)  = Exp4(m, iop)
 struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm end
 struct ETD2 <: OrdinaryDiffEqExponentialAlgorithm end
 

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -331,6 +331,37 @@ function alg_cache(alg::HochOst4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
 end
 
 ####################################
+# EPIRK method caches
+struct Exp4ConstantCache <: ExpRKConstantCache end
+alg_cache(alg::Exp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
+  uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = Exp4ConstantCache()
+
+struct Exp4Cache{uType,rateType,JType,KsType} <: ExpRKCache
+  u::uType
+  uprev::uType
+  tmp::uType
+  rtmp::rateType
+  k1::rateType
+  k2::rateType
+  k3::rateType
+  d::rateType
+  A::JType
+  KsCache::KsType
+end
+function alg_cache(alg::Exp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
+  tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  tmp = similar(u)                                              # uType caches
+  rtmp, k1, k2, k3, d = (zeros(rate_prototype) for i = 1:5)     # rateType caches
+  # Allocate Jacobian
+  n = length(u); T = eltype(u)
+  A = Matrix{T}(n, n) # TODO: sparse Jacobian support
+  # Allocate caches for phiv_timestep
+  maxiter = min(alg.m, n)
+  KsCache = _phiv_timestep_caches(u, maxiter, 1)
+  Exp4Cache(u,uprev,tmp,rtmp,k1,k2,k3,d,A,KsCache)
+end
+
+####################################
 # Multistep exponential method caches
 
 #=

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -336,29 +336,32 @@ struct Exp4ConstantCache <: ExpRKConstantCache end
 alg_cache(alg::Exp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
   uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = Exp4ConstantCache()
 
-struct Exp4Cache{uType,rateType,JType,KsType} <: ExpRKCache
+struct Exp4Cache{uType,rateType,matType,KsType} <: ExpRKCache
   u::uType
   uprev::uType
   tmp::uType
   rtmp::rateType
-  k1::rateType
-  k2::rateType
-  k3::rateType
-  d::rateType
-  A::JType
+  rtmp2::rateType
+  k7::rateType
+  K::matType
+  A::matType
+  B::matType
   KsCache::KsType
 end
 function alg_cache(alg::Exp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
   tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u)                                              # uType caches
-  rtmp, k1, k2, k3, d = (zeros(rate_prototype) for i = 1:5)     # rateType caches
-  # Allocate Jacobian
+  rtmp, rtmp2, k7 = (zeros(rate_prototype) for i = 1:3)         # rateType caches
+  # Allocate matrices
+  # TODO: units
   n = length(u); T = eltype(u)
+  K = Matrix{T}(n, 3)
   A = Matrix{T}(n, n) # TODO: sparse Jacobian support
+  B = zeros(T, n, 2)
   # Allocate caches for phiv_timestep
   maxiter = min(alg.m, n)
   KsCache = _phiv_timestep_caches(u, maxiter, 1)
-  Exp4Cache(u,uprev,tmp,rtmp,k1,k2,k3,d,A,KsCache)
+  Exp4Cache(u,uprev,tmp,rtmp,rtmp2,k7,K,A,B,KsCache)
 end
 
 ####################################

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -723,10 +723,10 @@ function _phiv_timestep_estimate_flops(m, tau, n, p, NA, iop, Hnorm, maxtau)
 end
 function _phiv_timestep_caches(u_prototype, maxiter::Int, p::Int)
   n = length(u_prototype); T = eltype(u_prototype)
-  u = similar(u_prototype)                    # stores the current state
-  W = Matrix{T}(n, p+1)                       # stores the w vectors
-  P = Matrix{T}(n, p+2)                       # stores output from phiv!
-  Ks = KrylovSubspace{T}(n, maxiter)          # stores output from arnoldi!
-  phiv_caches = construct_phiv_caches(Ks, p)  # caches used by phiv!
+  u = similar(u_prototype)                      # stores the current state
+  W = Matrix{T}(n, p+1)                         # stores the w vectors
+  P = Matrix{T}(n, p+2)                         # stores output from phiv!
+  Ks = KrylovSubspace{T}(n, maxiter)            # stores output from arnoldi!
+  phiv_caches = construct_phiv_caches(Ks, p+1)  # caches used by phiv! (need +1 for error estimation)
   return u, W, P, Ks, phiv_caches
 end

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -500,13 +500,18 @@ function expv_timestep(ts::Vector{tType}, A, b; kwargs...) where {tType <: Real}
 end
 function expv_timestep(t::tType, A, b; kwargs...) where {tType <: Real}
   u = Vector{eltype(A)}(size(A, 1))
-  expv_timestep!(reshape(u, length(u), 1), [t], A, b; kwargs...)
+  expv_timestep!(u, t, A, b; kwargs...)
 end
 """
     expv_timestep!(u,t,A,b[;kwargs]) -> u
 
 Non-allocating version of `expv_timestep`.
 """
+function expv_timestep!(u::Vector{T}, t::tType, A, b::Vector{T}; 
+  kwargs...) where {T <: Number, tType <: Real}
+  expv_timestep!(reshape(u, length(u), 1), [t], A, b; kwargs...)
+  return u
+end
 function expv_timestep!(U::Matrix{T}, ts::Vector{tType}, A, b::Vector{T}; 
   kwargs...) where {T <: Number, tType <: Real}
   B = reshape(b, length(b), 1)
@@ -546,14 +551,18 @@ function phiv_timestep(ts::Vector{tType}, A, B; kwargs...) where {tType <: Real}
 end
 function phiv_timestep(t::tType, A, B; kwargs...) where {tType <: Real}
   u = Vector{eltype(A)}(size(A, 1))
-  phiv_timestep!(reshape(u, length(u), 1), [t], A, B; kwargs...)
-  return u
+  phiv_timestep!(u, t, A, B; kwargs...)
 end
 """
     phiv_timestep!(U,ts,A,B[;kwargs]) -> U
 
 Non-allocating version of `phiv_timestep`.
 """
+function phiv_timestep!(u::Vector{T}, t::tType, A, B::Matrix{T}; 
+  kwargs...) where {T <: Number, tType <: Real}
+  phiv_timestep!(reshape(u, length(u), 1), [t], A, B; kwargs...)
+  return u
+end
 function phiv_timestep!(U::Matrix{T}, ts::Vector{tType}, A, B::Matrix{T}; tau::Real=0.0, 
   m::Int=min(10, size(A, 1)), tol::Real=1e-7, norm=Base.norm, iop::Int=0, 
   correct::Bool=false, caches=nothing, adaptive=false, delta::Real=1.2, 

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -677,3 +677,11 @@ function _phiv_timestep_estimate_flops(m, tau, n, p, NA, iop, Hnorm, maxtau)
   flops_onestep = flops_W + flops_u + flops_matvec + flops_vecvec + flops_phiv
   return flops_onestep * Int(ceil(maxtau / tau))
 end
+function _phiv_timestep_caches(u, maxiter::Int, p::Int)
+  n = length(u); T = eltype(u)
+  W = Matrix{T}(n, p+1)                       # stores the w vectors
+  P = Matrix{T}(n, p+2)                       # stores output from phiv!
+  Ks = KrylovSubspace{T}(n, maxiter)          # stores output from arnoldi!
+  phiv_caches = construct_phiv_caches(Ks, p)  # caches used by phiv!
+  return W, P, Ks, phiv_caches
+end

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -576,6 +576,36 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step=false)
   # integrator.k is automatically set due to aliasing
 end
 
+#############################################
+# EPIRK integrators
+function perform_step!(integrator, cache::Exp4ConstantCache, repeat_step=false)
+  @unpack t,dt,uprev,f,p = integrator
+  A = f.jac(uprev, p, t)
+  alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
+  f0 = integrator.fsalfirst # f(u0) is fsaled
+
+  # TODO
+
+  # Update integrator state
+  integrator.fsallast = f(u, p, t + dt)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
+  integrator.u = u
+end
+
+function perform_step!(integrator, cache::Exp4Cache, repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack tmp,rtmp,k1,k2,k3,d,A,KsCache = cache
+  f.jac(A, uprev, p, t)
+  f0 = integrator.fsalfirst # f(u0) is fsaled
+
+  # TODO
+
+  # Update integrator state
+  f(integrator.fsallast, u, p, t + dt)
+  # integrator.k is automatically set due to aliasing
+end
+
 ######################################################
 # Multistep exponential integrators
 function initialize!(integrator,cache::ETD2ConstantCache)

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -1,28 +1,52 @@
 using OrdinaryDiffEq, Base.Test, DiffEqOperators
-N = 20
-dx = 1.0; dt=0.1
-srand(0); u0 = rand(N)
-reltol = 1e-4
-L = DerivativeOperator{Float64}(2,2,dx,N,:Dirichlet0,:Dirichlet0)
-krylov_f2 = (u,p,t) -> -0.1*u
-krylov_f2! = (du,u,p,t) -> du .= -0.1*u
-prob = SplitODEProblem(L,krylov_f2,u0,(0.0,1.0))
-prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
+@testset "Classical ExpRK" begin
+    N = 20
+    dx = 1.0; dt=0.1
+    srand(0); u0 = rand(N)
+    reltol = 1e-4
+    L = DerivativeOperator{Float64}(2,2,dx,N,:Dirichlet0,:Dirichlet0)
+    krylov_f2 = (u,p,t) -> -0.1*u
+    krylov_f2! = (du,u,p,t) -> du .= -0.1*u
+    prob = SplitODEProblem(L,krylov_f2,u0,(0.0,1.0))
+    prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
 
-# Ad-hoc fix for SplitFunction miscalssified as having analytic solutions
-DiffEqBase.has_analytic(::typeof(prob.f)) = false
-DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
+    # Ad-hoc fix for SplitFunction miscalssified as having analytic solutions
+    DiffEqBase.has_analytic(::typeof(prob.f)) = false
+    DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
 
-Algs = [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4]
-for Alg in Algs
-    gc()
-    sol = solve(prob, Alg(); dt=dt, internalnorm=Base.norm)
-    sol_krylov = solve(prob, Alg(krylov=true, m=10); dt=dt, reltol=reltol, internalnorm=Base.norm)
-    @test isapprox(sol.u,sol_krylov.u; rtol=reltol)
+    Algs = [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4]
+    for Alg in Algs
+        gc()
+        sol = solve(prob, Alg(); dt=dt, internalnorm=Base.norm)
+        sol_krylov = solve(prob, Alg(krylov=true, m=10); dt=dt, reltol=reltol, internalnorm=Base.norm)
+        @test isapprox(sol.u,sol_krylov.u; rtol=reltol)
 
-    sol_ip = solve(prob_inplace, Alg(); dt=dt, internalnorm=Base.norm)
-    sol_ip_krylov = solve(prob_inplace, Alg(krylov=true, m=10); dt=dt, reltol=reltol, internalnorm=Base.norm)
-    @test isapprox(sol.u,sol_krylov.u; rtol=reltol)
+        sol_ip = solve(prob_inplace, Alg(); dt=dt, internalnorm=Base.norm)
+        sol_ip_krylov = solve(prob_inplace, Alg(krylov=true, m=10); dt=dt, reltol=reltol, internalnorm=Base.norm)
+        @test isapprox(sol.u,sol_krylov.u; rtol=reltol)
 
-    println(Alg) # prevent Travis hanging
+        println(Alg) # prevent Travis hanging
+    end
+end
+
+@testset "EPIRK" begin
+    N = 20
+    srand(0); u0 = normalize(randn(N))
+    # For the moment, use dense Jacobian
+    dd = -2 * ones(N); du = ones(N-1)
+    A = diagm(du, -1) + diagm(dd) + diagm(du, 1)
+    _f = (u,p,t) -> A*u - u.^3
+    _jac = (u,p,t) -> A - 3 * diagm(u.^2)
+    f = DiffEqFunction{false}(_f; jac=_jac)
+    prob = ODEProblem(f, u0, (0.0, 1.0))
+
+    dt = 0.1; tol=1e-5
+    Algs = [Exp4]
+    for Alg in Algs
+        gc()
+        sol = solve(prob, Alg(); dt=dt, internalnorm=Base.norm, reltol=tol)
+        sol_ref = solve(prob, Tsit5(); reltol=tol)
+        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+        println(Alg) # prevent Travis hanging
+    end
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -54,10 +54,13 @@ using OrdinaryDiffEq: phi, phi, phiv, phiv_timestep, expv, expv_timestep, arnold
   tol = 1e-7
   A = spdiagm((ones(n-1), -2*ones(n), ones(n-1)), (-1, 0, 1))
   B = randn(n, K+1)
+  Phi_half = phi(t/2 * A, K)
   Phi = phi(t * A, K)
+  uhalf_exact = sum((t/2)^i * Phi_half[i+1] * B[:,i+1] for i = 0:K)
   u_exact = sum(t^i * Phi[i+1] * B[:,i+1] for i = 0:K)
-  u = phiv_timestep(t, A, B; adaptive=true, tol=tol)
-  @test norm(u - u_exact) / norm(u_exact) < tol
+  U = phiv_timestep([t/2, t], A, B; adaptive=true, tol=tol)
+  @test norm(U[:,1] - uhalf_exact) / norm(uhalf_exact) < tol
+  @test norm(U[:,2] - u_exact) / norm(u_exact) < tol
   # p = 0 special case (expv_timestep)
   u_exact = Phi[1] * B[:, 1]
   u = expv_timestep(t, A, B[:, 1]; adaptive=true, tol=tol)


### PR DESCRIPTION
Mostly reviewing literature today. To fully utilize the EPIRK framework I need to modify `phiv_timestep` to be able to output intermediate results instead of just a single one, which I plan on tackling this week.

Nevertheless, the basic framework of an EPIRK integrator should be pretty much similar to the classical ones and I can even reuse some of the existing infrastructure. The only thing missing from `Exp4` now is code responsible for the actual propagation of the integrator using `phiv_timestep(!)`.