### PR TITLE
Packaged cache type for `expv` and `phiv`

### DIFF
--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -175,10 +175,11 @@ function alg_cache_expRK(alg::OrdinaryDiffEqExponentialAlgorithm, u, f, dt, plis
   if alg.krylov
     ops = nothing # no caching
     # Build up caches used by Krylov phiv
-    Ks = KrylovSubspace{T}(n, min(alg.m, n))
-    phiv_caches = construct_phiv_caches(Ks, maximum(plist))
+    m = min(alg.m, n)
+    Ks = KrylovSubspace{T}(n, m)
+    phiv_cache = PhivCache{T}(m, maximum(plist))
     ws = [Matrix{T}(n, plist[i] + 1) for i = 1:length(plist)]
-    KsCache = (Ks, phiv_caches, ws) # should use named tuple in v0.6
+    KsCache = (Ks, phiv_cache, ws) # should use named tuple in v0.6
   else
     KsCache = nothing
     # Precompute the operators
@@ -211,7 +212,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     exphA = nothing # no caching
     m = min(alg.m, n)
     Ks = KrylovSubspace{T}(n, m)
-    expv_cache = Matrix{T}(m, m)
+    expv_cache = ExpvCache{T}(m)
     KsCache = (Ks, expv_cache)
   else
     KsCache = nothing

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -387,6 +387,28 @@ function expv!(w::Vector{T}, t::Number, Ks::KrylovSubspace{B, T};
   scale!(beta, A_mul_B!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e
 end
 
+# Cache type for phiv
+mutable struct PhivCache{T}
+  mem::Vector{T}
+  function PhivCache{T}(maxiter::Int, p::Int) where {T}
+    numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter*(p + 1)
+    new{T}(Vector{T}(numelems))
+  end
+end
+function Base.resize!(C::PhivCache{T}, maxiter::Int, p::Int) where {T}
+  numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter*(p + 1)
+  C.mem = Vector{T}(numelems)
+  return C
+end
+function get_caches(C::PhivCache, m::Int, p::Int)
+  numelems = m + m^2 + (m + p)^2 + m*(p + 1)
+  numelems^2 > length(C.mem) && resize!(C, m, p) # resize the cache if needed
+  e = @view(C.mem[1:m]); offset = m
+  Hcopy = reshape(@view(C.mem[offset + 1:offset + m^2]), m, m); offset += m^2
+  C1 = reshape(@view(C.mem[offset + 1:offset + (m+p)^2]), m+p, m+p); offset += (m+p)^2
+  C2 = reshape(@view(C.mem[offset + 1:offset + m*(p+1)]), m, p+1)
+  return e, Hcopy, C1, C2
+end
 """
     phiv(t,A,b,k;correct,kwargs) -> [phi_0(tA)b phi_1(tA)b ... phi_k(tA)b][, errest]
 
@@ -413,37 +435,33 @@ the φ-functions in exponential integrators. arXiv preprint arXiv:0907.4631.
 Formula (10).
 """
 function phiv(t, A, b, k; m=min(30, size(A, 1)), tol=1e-7, norm=Base.norm, iop=0, 
-  caches=nothing, correct=false, errest=false)
+  cache=nothing, correct=false, errest=false)
   Ks = arnoldi(A, b; m=m, tol=tol, norm=norm, iop=iop)
   w = Matrix{eltype(b)}(length(b), k+1)
-  phiv!(w, t, Ks, k; caches=caches, correct=correct, errest=errest)
+  phiv!(w, t, Ks, k; cache=cache, correct=correct, errest=errest)
 end
-function phiv(t, Ks::KrylovSubspace{B, T}, k; caches=nothing, correct=false, 
+function phiv(t, Ks::KrylovSubspace{B, T}, k; cache=nothing, correct=false, 
   errest=false) where {B, T}
   n = size(getV(Ks), 1)
   w = Matrix{T}(n, k+1)
-  phiv!(w, t, Ks, k; caches=caches, correct=correct, errest=errest)
+  phiv!(w, t, Ks, k; cache=cache, correct=correct, errest=errest)
 end
 """
-    phiv!(w,t,Ks,k[;caches,correct,errest]) -> w[,errest]
+    phiv!(w,t,Ks,k[;cache,correct,errest]) -> w[,errest]
 
 Non-allocating version of 'phiv' that uses precomputed Krylov subspace `Ks`.
 """
 function phiv!(w::Matrix{T}, t::Number, Ks::KrylovSubspace{B, T}, k::Integer; 
-  caches=nothing, correct=false, errest=false) where {B, T <: Number}
+  cache=nothing, correct=false, errest=false) where {B, T <: Number}
   m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
   @assert size(w, 1) == size(V, 1) "Dimension mismatch"
   @assert size(w, 2) == k + 1 "Dimension mismatch"
-  if caches == nothing
-    caches = construct_phiv_caches(Ks, k)
+  if cache == nothing
+    cache = PhivCache{T}(m, k)
+  elseif !isa(cache, PhivCache)
+    throw(ArgumentError("Cache must be a PhivCache"))
   end
-  e, Hcopy, C1, C2 = caches
-  # The caches may have a bigger size to handle different values of m.
-  # Here we only need a portion of them.
-  e = @view(e[1:m])
-  Hcopy = @view(Hcopy[1:m, 1:m])
-  C1 = @view(C1[1:m + k, 1:m + k])
-  C2 = @view(C2[1:m, 1:k + 1])
+  e, Hcopy, C1, C2 = get_caches(cache, m, k)
   scale!(t, copy!(Hcopy, @view(H[1:m, :])))
   fill!(e, zero(T)); e[1] = one(T) # e is the [1,0,...,0] basis vector
   phiv_dense!(C2, Hcopy, e, k; cache=C1) # C2 = [ϕ0(H)e ϕ1(H)e ... ϕk(H)e]
@@ -463,15 +481,6 @@ function phiv!(w::Matrix{T}, t::Number, Ks::KrylovSubspace{B, T}, k::Integer;
   else
     return w
   end
-end
-# Helper method to allocate caches for phiv
-function construct_phiv_caches(Ks::KrylovSubspace{B, T}, p::Int) where {B, T}
-  m = Ks.maxiter
-  e = Vector{T}(m)
-  Hcopy = Matrix{T}(m, m)
-  C1 = Matrix{T}(m + p, m + p)
-  C2 = Matrix{T}(m, p + 1)
-  return e, Hcopy, C1, C2
 end
 
 ###########################################
@@ -601,9 +610,9 @@ function phiv_timestep!(U::Matrix{T}, ts::Vector{tType}, A, B::Matrix{T}; tau::R
     W = Matrix{T}(n, p+1)         # stores the w vectors
     P = Matrix{T}(n, p+2)         # stores output from phiv!
     Ks = KrylovSubspace{T}(n, m)  # stores output from arnoldi!
-    phiv_caches = nothing         # caches used by phiv!
+    phiv_cache = nothing         # cache used by phiv!
   else
-    u, W, P, Ks, phiv_caches = caches
+    u, W, P, Ks, phiv_cache = caches
     @assert length(u) == n && size(W) == (n, p+1) && size(P) == (n, p+2) "Dimension mismatch"
   end
   copy!(u, @view(B[:, 1])) # u(0) = b0
@@ -640,7 +649,7 @@ function phiv_timestep!(U::Matrix{T}, ts::Vector{tType}, A, B::Matrix{T}; tau::R
     end
     # Part 2: compute ϕp(tau*A)wp using Krylov, possibly with adaptation
     arnoldi!(Ks, A, @view(W[:, end]); tol=tol, m=m, norm=norm, iop=iop, cache=u)
-    _, epsilon = phiv!(P, tau, Ks, p + 1; caches=phiv_caches, correct=correct, errest=true)
+    _, epsilon = phiv!(P, tau, Ks, p + 1; cache=phiv_cache, correct=correct, errest=true)
     verbose && println("t = $t, m = $m, tau = $tau, error estimate = $epsilon")
     if adaptive
       omega = (tend / tau) * (epsilon / abstol)
@@ -654,7 +663,7 @@ function phiv_timestep!(U::Matrix{T}, ts::Vector{tType}, A, B::Matrix{T}; tau::R
         tau, tau_old = tau_new, tau
         # Compute ϕp(tau*A)wp using the new parameters
         arnoldi!(Ks, A, @view(W[:, end]); tol=tol, m=m, norm=norm, iop=iop, cache=u)
-        _, epsilon_new = phiv!(P, tau, Ks, p + 1; caches=phiv_caches, correct=correct, errest=true)
+        _, epsilon_new = phiv!(P, tau, Ks, p + 1; cache=phiv_cache, correct=correct, errest=true)
         epsilon, epsilon_old = epsilon_new, epsilon
         omega = (tend / tau) * (epsilon / abstol)
         verbose && println("  * m = $m, tau = $tau, error estimate = $epsilon")
@@ -672,7 +681,7 @@ function phiv_timestep!(U::Matrix{T}, ts::Vector{tType}, A, B::Matrix{T}; tau::R
     while snapshot <= length(ts) && t + tau >= ts[snapshot]
       tau_snapshot = ts[snapshot] - t
       u_snapshot = @view(U[:, snapshot])
-      phiv!(P, tau_snapshot, Ks, p + 1; caches=phiv_caches, correct=correct)
+      phiv!(P, tau_snapshot, Ks, p + 1; cache=phiv_cache, correct=correct)
       scale!(tau_snapshot^p, copy!(u_snapshot, @view(P[:, end - 1])))
       @inbounds for l = 1:p-1 # compute cl = tau^l/l!
         coeffs[l+1] = coeffs[l] * tau_snapshot / l
@@ -740,6 +749,6 @@ function _phiv_timestep_caches(u_prototype, maxiter::Int, p::Int)
   W = Matrix{T}(n, p+1)                         # stores the w vectors
   P = Matrix{T}(n, p+2)                         # stores output from phiv!
   Ks = KrylovSubspace{T}(n, maxiter)            # stores output from arnoldi!
-  phiv_caches = construct_phiv_caches(Ks, p+1)  # caches used by phiv! (need +1 for error estimation)
-  return u, W, P, Ks, phiv_caches
+  phiv_cache = PhivCache{T}(maxiter, p+1)       # cache used by phiv! (need +1 for error estimation)
+  return u, W, P, Ks, phiv_cache
 end

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -329,7 +329,7 @@ mutable struct ExpvCache{T}
   ExpvCache{T}(maxiter::Int) where {T} = new{T}(Vector{T}(maxiter^2))
 end
 function Base.resize!(C::ExpvCache{T}, maxiter::Int) where {T}
-  C.mem = Vector{T}(maxiter^2)
+  C.mem = Vector{T}(maxiter^2 * 2)
   return C
 end
 function get_cache(C::ExpvCache, m::Int)
@@ -397,7 +397,7 @@ mutable struct PhivCache{T}
 end
 function Base.resize!(C::PhivCache{T}, maxiter::Int, p::Int) where {T}
   numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter*(p + 1)
-  C.mem = Vector{T}(numelems)
+  C.mem = Vector{T}(numelems * 2)
   return C
 end
 function get_caches(C::PhivCache, m::Int, p::Int)

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -107,10 +107,10 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov
-    Ks, phiv_caches, ws = KsCache; w = ws[1]
+    Ks, phiv_cache, ws = KsCache; w = ws[1]
     arnoldi!(Ks, A, integrator.fsalfirst; m=min(alg.m, size(A,1)), norm=integrator.opts.internalnorm, 
       cache=u, iop=alg.iop)
-    phiv!(w, dt, Ks, 1; caches=phiv_caches)
+    phiv!(w, dt, Ks, 1; cache=phiv_cache)
     @muladd @. u = uprev + dt * @view(w[:, 2])
   else
     A_mul_B!(rtmp, cache.phihA, integrator.fsalfirst)
@@ -159,17 +159,17 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step=false)
 
   if alg.krylov
     F1 = integrator.fsalfirst
-    Ks, phiv_caches, ws = KsCache
+    Ks, phiv_cache, ws = KsCache
     w1, w2 = ws
     # Krylov for F1
     arnoldi!(Ks, A, F1; m=min(alg.m, size(A,1)), norm=integrator.opts.internalnorm, cache=tmp, iop=alg.iop)
-    phiv!(w1, dt, Ks, 2; caches=phiv_caches)
+    phiv!(w1, dt, Ks, 2; cache=phiv_cache)
     # Krylov for F2
     @muladd @. tmp = uprev + dt * @view(w1[:, 2])
     _compute_nl!(F2, f, tmp, p, t + dt, A, rtmp)
     F2 .+= A_mul_B!(rtmp, A, uprev)
     arnoldi!(Ks, A, F2; m=min(alg.m, size(A,1)), norm=integrator.opts.internalnorm, cache=tmp, iop=alg.iop)
-    phiv!(w2, dt, Ks, 2; caches=phiv_caches)
+    phiv!(w2, dt, Ks, 2; cache=phiv_cache)
     # Update u
     u .= uprev
     Base.axpy!( dt, @view(w1[:, 2]), u)
@@ -251,24 +251,24 @@ function perform_step!(integrator, cache::ETDRK3Cache, repeat_step=false)
   A_mul_B!(Au, A, uprev)
   halfdt = dt/2
   if alg.krylov
-    Ks, phiv_caches, ws = KsCache
+    Ks, phiv_cache, ws = KsCache
     w1_half, w1, w2, w3 = ws
     # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop), (:cache, tmp)]
     # Krylov for F1 (first column)
     arnoldi!(Ks, A, F1; kwargs...)
-    phiv!(w1_half, halfdt, Ks, 1; caches=phiv_caches)
-    phiv!(w1, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w1_half, halfdt, Ks, 1; cache=phiv_cache)
+    phiv!(w1, dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + halfdt * w1_half[:, 2] # tmp is U2
     _compute_nl!(F2, f, tmp, p, t + halfdt, A, rtmp); F2 .+= Au
     # Krylov for F2 (second column)
     arnoldi!(Ks, A, F2; kwargs...)
-    phiv!(w2, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w2, dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + dt * (2*w2[:, 2] - w1[:, 2]) # tmp is U3
     _compute_nl!(F3, f, tmp, p, t + dt, A, rtmp); F3 .+= Au
     # Krylov for F3 (third column)
     arnoldi!(Ks, A, F3; kwargs...)
-    phiv!(w3, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w3, dt, Ks, 3; cache=phiv_cache)
     # Update u
     @views @. rtmp = 4w1[:,4] - 3w1[:,3] + w1[:,2] - 8w2[:,4] + 4w2[:,3] + 4w3[:,4] - w3[:,3]
     @muladd @. u = uprev + dt * rtmp
@@ -364,36 +364,36 @@ function perform_step!(integrator, cache::ETDRK4Cache, repeat_step=false)
   A_mul_B!(Au, A, uprev)
   halfdt = dt/2
   if alg.krylov
-    Ks, phiv_caches, ws = KsCache
+    Ks, phiv_cache, ws = KsCache
     w1_half, w2_half, w1, w2, w3, w4 = ws
     # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop), (:cache, tmp)]
     # Krylov for F1 (first column)
     arnoldi!(Ks, A, F1; kwargs...)
-    phiv!(w1_half, halfdt, Ks, 1; caches=phiv_caches)
-    phiv!(w1, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w1_half, halfdt, Ks, 1; cache=phiv_cache)
+    phiv!(w1, dt, Ks, 3; cache=phiv_cache)
     U2 = u # temporarily use u to store U2 (used in the extra Krylov step)
     @muladd @. @views U2 = uprev + halfdt * w1_half[:, 2]
     _compute_nl!(F2, f, U2, p, t + halfdt, A, rtmp); F2 .+= Au
     # Krylov for F2 (second column)
     arnoldi!(Ks, A, F2; kwargs...)
-    phiv!(w2_half, halfdt, Ks, 1; caches=phiv_caches)
-    phiv!(w2, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w2_half, halfdt, Ks, 1; cache=phiv_cache)
+    phiv!(w2, dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + halfdt * w2_half[:, 2] # tmp is U3
     _compute_nl!(F3, f, tmp, p, t + halfdt, A, rtmp); F3 .+= Au
     # Krylov for F3 (third column)
     arnoldi!(Ks, A, F3; kwargs...)
-    phiv!(w3, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w3, dt, Ks, 3; cache=phiv_cache)
     # Extra Krylov for computing F4
     # Compute rtmp = 2F3 - F1 - Au + A*U2
     A_mul_B!(rtmp, A, U2); @. rtmp += 2F3 - F1 - Au
     arnoldi!(Ks, A, rtmp; kwargs...)
-    phiv!(w1_half, halfdt, Ks, 1; caches=phiv_caches) # original w1_half is no longer needed
+    phiv!(w1_half, halfdt, Ks, 1; cache=phiv_cache) # original w1_half is no longer needed
     @muladd @. @views tmp = U2 + halfdt * w1_half[:, 2] # tmp is U4
     _compute_nl!(F4, f, tmp, p, t + dt, A, rtmp); F4 .+= Au
     # Krylov for F4 (fourth column)
     arnoldi!(Ks, A, F4; kwargs...)
-    phiv!(w4, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w4, dt, Ks, 3; cache=phiv_cache)
     # update u
     @views @. rtmp = w1[:,2] - 3w1[:,3] + 4w1[:,4] + 2w2[:,3] - 4w2[:,4] + 
                      2w3[:,3] - 4w3[:,4] + 4w4[:,4] - w4[:,3]
@@ -504,32 +504,32 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step=false)
   A_mul_B!(Au, A, uprev)
   halfdt = dt/2
   if alg.krylov
-    Ks, phiv_caches, ws = KsCache
+    Ks, phiv_cache, ws = KsCache
     w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5 = ws
     # TODO: change to named tuple in v0.7
     kwargs = [(:m, min(alg.m, size(A,1))), (:norm, integrator.opts.internalnorm), (:iop, alg.iop), (:cache, tmp)]
     # Krylov on F1 (first column)
     arnoldi!(Ks, A, F1; kwargs...)
-    phiv!(w1_half, halfdt, Ks, 3; caches=phiv_caches)
-    phiv!(w1,          dt, Ks, 3; caches=phiv_caches)
+    phiv!(w1_half, halfdt, Ks, 3; cache=phiv_cache)
+    phiv!(w1,          dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + halfdt * w1_half[:, 2] # tmp is U2
     _compute_nl!(F2, f, tmp, p, t + halfdt, A, rtmp); F2 .+= Au
     # Krylov on F2 (second column)
     arnoldi!(Ks, A, F2; kwargs...)
-    phiv!(w2_half, halfdt, Ks, 3; caches=phiv_caches)
-    phiv!(w2,          dt, Ks, 3; caches=phiv_caches)
+    phiv!(w2_half, halfdt, Ks, 3; cache=phiv_cache)
+    phiv!(w2,          dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + dt * (0.5w1_half[:,2] - w1_half[:,3] + w2_half[:,3]) # tmp is U3
     _compute_nl!(F3, f, tmp, p, t + halfdt, A, rtmp); F3 .+= Au
     # Krylov on F3 (third column)
     arnoldi!(Ks, A, F3; kwargs...)
-    phiv!(w3_half, halfdt, Ks, 3; caches=phiv_caches)
-    phiv!(w3,          dt, Ks, 3; caches=phiv_caches)
+    phiv!(w3_half, halfdt, Ks, 3; cache=phiv_cache)
+    phiv!(w3,          dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + dt * (w1[:,2] - 2w1[:,3] + w2[:,3] + w3[:,3]) # tmp is U4
     _compute_nl!(F4, f, tmp, p, t + dt, A, rtmp); F4 .+= Au
     # Krylov on F4 (fourth column)
     arnoldi!(Ks, A, F4; kwargs...)
-    phiv!(w4_half, halfdt, Ks, 3; caches=phiv_caches)
-    phiv!(w4,          dt, Ks, 3; caches=phiv_caches)
+    phiv!(w4_half, halfdt, Ks, 3; cache=phiv_cache)
+    phiv!(w4,          dt, Ks, 3; cache=phiv_cache)
     @muladd @. @views tmp = uprev + dt * (
       0.5w1_half[:,2] - 0.75w1_half[:,3] + 0.5w1_half[:,4] + w1[:,4] - 0.25w1[:,3] + 
       0.5w2_half[:,3] - w2[:,4] + 0.25w2[:,3] - 0.5w2_half[:,4] + 
@@ -538,7 +538,7 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step=false)
     _compute_nl!(F5, f, tmp, p, t + dt, A, rtmp); F5 .+= Au
     # Krylov on F5 (fifth column)
     arnoldi!(Ks, A, F5; kwargs...)
-    phiv!(w5, dt, Ks, 3; caches=phiv_caches)
+    phiv!(w5, dt, Ks, 3; cache=phiv_cache)
     # update u
     @muladd @. @views rtmp = w1[:,2] - 3w1[:,3] + 4w1[:,4] - w4[:,3] + 4w4[:,4] + 4w5[:,3] - 8w5[:,4]
     @muladd @. u = uprev + dt * rtmp


### PR DESCRIPTION
One problem I found while writing `Exp4` is the resizing issue of caches used by `phiv(!)`. Since we're using adaptation for the EPIRK methods the Krylov space size `m` changes, but this is not reflected in the caches. In fact, previously we can only set a maximum size and hope that the adaptation does not produce an `m` that is bigger than the limit.

We need to dynamically resize the caches as adaptation proceeds. However one complication is that Julia does not support `resize!` on multidimensional arrays. Therefore the only choice left is to implement our own dynamic cache object.

To demonstrate how `PhivCache` is use:

```julia
using OrdinaryDiffEq: phiv, PhivCache
```


```julia
n = 20; m = 5; p = 3
srand(0)
A = randn(n, n)
t = 1e-2
b = randn(n);
```


```julia
cache = PhivCache{Float64}(m, p)
length(cache.mem)
```




    114




```julia
w = phiv(t, A, b, p; m=m, cache=cache)
```




    20×4 Array{Float64,2}:
      1.84056     1.81877      0.905763     0.301319  
      ...
     -0.054289   -0.00951268   0.00271059   0.00214844




```julia
# Use a bigger m with the same cache
w = phiv(t, A, b, p; m=2*m, cache=cache)
```




    20×4 Array{Float64,2}:
      1.84056     1.81877      0.905763     0.301319  
      ...
     -0.054289   -0.00951268   0.00271059   0.00214844




```julia
# cache is resized under the hood
length(cache.mem)
```




    638

Note that we're not actually calling `reshape` as Julia does not allow resizing vectors whose data is reference by other objects (e.g. through `reshape`). Instead if resizing is needed, a completely new memory chunk is allocated. While this may cause extra time for garbage collection, this should be a rare operation.

Incidentally, because we're using linear memory for `PhivCache` and returning reshaped arrays of the memory chunk instead of views into a larger array, this also solves the contiguity issue of #366.