### PR TITLE
v0.7 upgrade for exponential integrators

### DIFF
--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -276,7 +276,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol::Real=1
   return Ks
 end
 """
-    lanczos!(Ks,A,b[;tol,m,norm,cache]) -> Ks
+    lanczos!(Ks,A,b[;tol,m,opnorm,cache]) -> Ks
 
 A variation of `arnoldi!` that uses the Lanczos algorithm for Hermitian matrices.
 """
@@ -597,7 +597,7 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
   verbose && println("Absolute tolerance: $abstol")
   if iszero(tau)
     Anorm = opnorm(A, Inf)
-    b0norm = norm(@view(B[:, 1]), Inf)
+    b0norm = maximum(abs.(@view(B[:, 1])))
     tau = 10/Anorm * (abstol * ((m+1)/e)^(m+1) * sqrt(2*pi*(m+1)) /
       (4*Anorm*b0norm))^(1/m)
     verbose && println("Initial time step unspecified, chosen to be $tau")

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -676,7 +676,7 @@ function perform_step!(integrator, cache::EPIRK4s3AConstantCache, repeat_step=fa
   R3 = f(U3, p, t + 2dt/3) - f0 - A*K[:, 2] # remainder of U3
 
   # Update u (horizontally)
-  B = zero(eltype(f0), length(f0), 5)
+  B = zeros(eltype(f0), length(f0), 5)
   B[:, 2] = f0
   B[:, 4] = (32R2 - 13.5R3) / dt^2
   B[:, 5] = (-144R2 + 81R3) / dt^3
@@ -740,7 +740,7 @@ function perform_step!(integrator, cache::EPIRK4s3BConstantCache, repeat_step=fa
   R3 = f(U3, p, t + 3dt/4) - f0 - A*K[:, 2] # remainder of U3
 
   # Update u (horizontally)
-  B = zero(eltype(f0), length(f0), 5)
+  B = zeros(eltype(f0), length(f0), 5)
   B[:, 2] = f0
   B[:, 4] = (54R2 - 16R3) / dt^2
   B[:, 5] = (-324R2 + 144R3) / dt^3

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -44,10 +44,10 @@ end
             J[i, i] -= 3 * u[i]^2
         end
     end
-    f = ODEFunction{false}(_f; jac=_jac)
-    f_ip = ODEFunction{true}(_f_ip; jac=_jac_ip)
+    f = ODEFunction(_f; jac=_jac)
+    f_ip = ODEFunction(_f_ip; jac=_jac_ip)
     prob = ODEProblem(f, u0, (0.0, 1.0))
-    prob_ip = ODEProblem{true}(f_ip, u0, (0.0, 1.0))
+    prob_ip = ODEProblem(f_ip, u0, (0.0, 1.0))
 
     dt = 0.05; tol=1e-5
     Algs = [Exp4, EPIRK4s3A, EPIRK4s3B, EXPRB53s3, EPIRK5P1, EPIRK5P2]


### PR DESCRIPTION
The aim is to get tests related to the exponential integrators (utility_tests.jl, linear_nonlinear_convergence_tests.jl and linear_nonlinear_krylov_tests.jl) to pass and then fix all depwarns. 

For the error fixes, I have temporarily disabled the choice of custom opnorm for the integrators (i.e. no longer uses `integrators.opts.internalnorm` but instead just `LinearAlgebra.opnorm`). In the future this can be added back by expanding `internalnorm` to a tuple of `(norm, opnorm)`, as suggested by @YingboMa.

The convergence tests currently still doesn't pass, because it still uses the old trait-based method to specify the analytic solution. I probably need to follow up on the update progress on DiffEqDevTools to get this to work properly.