### PR TITLE
More ExpRK v0.7 fixes

### DIFF
--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -34,7 +34,7 @@ end
 function alg_cache(alg::GenericIIF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u,axes(u)); rtmp1 = zero(rate_prototype)
   dual_cache = DiffCache(u,Val{determine_chunksize(u,get_chunksize(alg.nlsolve))})
-  A = f.f1
+  A = f.f1.f
   expA = exp(A*dt)
   rhs = RHS_IIF(f,tmp,t,t,uEltypeNoUnits(1//1),dual_cache,p)
   k = similar(rate_prototype); fsalfirst = similar(rate_prototype)
@@ -76,7 +76,7 @@ end
 function alg_cache(alg::GenericIIF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u,axes(u)); rtmp1 = zero(rate_prototype)
   dual_cache = DiffCache(u,Val{determine_chunksize(u,get_chunksize(alg.nlsolve))})
-  A = f.f1
+  A = f.f1.f
   expA = exp(A*dt)
   k = similar(rate_prototype); fsalfirst = similar(rate_prototype)
   rhs = RHS_IIF(f,tmp,t,t,uEltypeNoUnits(1//2),dual_cache,p)
@@ -152,7 +152,7 @@ for (Alg, Cache) in [(:LawsonEuler, :LawsonEulerConstantCache),
       ops = nothing # no caching
     else
       isa(f, SplitFunction) || throw(ArgumentError("Caching can only be used with SplitFunction"))
-      A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+      A = isa(f.f1.f, DiffEqArrayOperator) ? f.f1.f.A * f.f1.f.α.coeff : full(f.f1.f)
       ops = expRK_operators(alg, dt, A)
     end
     return $Cache(ops)
@@ -183,7 +183,7 @@ function alg_cache_expRK(alg::OrdinaryDiffEqExponentialAlgorithm, u, f, dt, plis
   else
     KsCache = nothing
     # Precompute the operators
-    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    A = isa(f.f1.f, DiffEqArrayOperator) ? f.f1.f.A * f.f1.f.α.coeff : full(f.f1.f)
     ops = expRK_operators(alg, dt, A)
   end
   return Jcache, ops, KsCache
@@ -216,7 +216,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     KsCache = (Ks, expv_cache)
   else
     KsCache = nothing
-    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    A = isa(f.f1.f, DiffEqArrayOperator) ? f.f1.f.A * f.f1.f.α.coeff : full(f.f1.f)
     exphA = expRK_operators(alg, dt, A)
   end
   LawsonEulerCache(u,uprev,tmp,rtmp,G,Jcache,exphA,KsCache)
@@ -571,7 +571,7 @@ struct ETD2ConstantCache{expType} <: OrdinaryDiffEqConstantCache
 end
 
 function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  A = f.f1
+  A = f.f1.f
   if isa(A, DiffEqArrayOperator)
     _A = A.A * A.α.coeff # .* does not return Diagonal for A.A Diagonal
   else
@@ -594,7 +594,7 @@ struct ETD2Cache{uType,rateType,expType} <: OrdinaryDiffEqMutableCache
 end
 
 function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  A = f.f1
+  A = f.f1.f
   if isa(A, DiffEqArrayOperator)
     _A = A.A * A.α.coeff # .* does not return Diagonal for A.A Diagonal
   else

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -40,7 +40,7 @@ end
 # Classical ExpRK integrators
 function perform_step!(integrator, cache::LawsonEulerConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   nl = _compute_nl(f, uprev, p, t, A)
@@ -62,14 +62,14 @@ end
 function perform_step!(integrator, cache::LawsonEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack tmp,rtmp,G,Jcache,exphA,KsCache = cache
-  A = isa(f, SplitFunction) ? f.f1 : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   _compute_nl!(G, f, uprev, p, t, A, rtmp)
   @muladd @. tmp = uprev + dt*G
   if alg.krylov
     Ks, expv_cache = KsCache
-    arnoldi!(Ks, f.f1, tmp; m=min(alg.m, size(f.f1,1)), opnorm=integrator.opts.internalopnorm,
+    arnoldi!(Ks, f.f1.f, tmp; m=min(alg.m, size(f.f1.f,1)), opnorm=integrator.opts.internalopnorm,
       cache=u, iop=alg.iop)
     expv!(u,dt,Ks; cache=expv_cache)
   else
@@ -83,7 +83,7 @@ end
 
 function perform_step!(integrator, cache::NorsettEulerConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov
@@ -105,7 +105,7 @@ end
 function perform_step!(integrator, cache::NorsettEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack rtmp,Jcache,KsCache = cache
-  A = isa(f, SplitFunction) ? f.f1 : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov
@@ -126,7 +126,7 @@ end
 
 function perform_step!(integrator, cache::ETDRK2ConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov
@@ -156,7 +156,7 @@ end
 function perform_step!(integrator, cache::ETDRK2Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack tmp,rtmp,F2,Jcache,KsCache = cache
-  A = isa(f, SplitFunction) ? f.f1 : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   if alg.krylov
@@ -200,7 +200,7 @@ end
 
 function perform_step!(integrator, cache::ETDRK3ConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   Au = A * uprev
@@ -245,7 +245,7 @@ end
 function perform_step!(integrator, cache::ETDRK3Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack tmp,rtmp,Au,F2,F3,Jcache,KsCache = cache
-  A = isa(f, SplitFunction) ? f.f1 : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   F1 = integrator.fsalfirst
@@ -298,7 +298,7 @@ end
 
 function perform_step!(integrator, cache::ETDRK4ConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   Au = A * uprev
@@ -356,7 +356,7 @@ end
 function perform_step!(integrator, cache::ETDRK4Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack tmp,rtmp,Au,F2,F3,F4,Jcache,KsCache = cache
-  A = isa(f, SplitFunction) ? f.f1 : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   F1 = integrator.fsalfirst
@@ -426,7 +426,7 @@ end
 
 function perform_step!(integrator, cache::HochOst4ConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  A = isa(f, SplitFunction) ? f.f1 : f.jac(uprev, p, t) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : f.jac(uprev, p, t) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   Au = A * uprev
@@ -494,7 +494,7 @@ end
 function perform_step!(integrator, cache::HochOst4Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack tmp,rtmp,rtmp2,Au,F2,F3,F4,F5,Jcache,KsCache = cache
-  A = isa(f, SplitFunction) ? f.f1 : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
+  A = isa(f, SplitFunction) ? f.f1.f : (f.jac(Jcache, uprev, p, t); Jcache) # get linear operator
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   F1 = integrator.fsalfirst

--- a/src/perform_step/iif_perform_step.jl
+++ b/src/perform_step/iif_perform_step.jl
@@ -14,7 +14,7 @@ end
 function initialize!(integrator,cache::Union{GenericIIF1ConstantCache,GenericIIF2ConstantCache})
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  A = integrator.f.f1
+  A = integrator.f.f1.f
   cache.uhold[1] = integrator.f.f2(integrator.uprev,integrator.p,integrator.t)
   integrator.fsalfirst = integrator.f.f1(integrator.uprev,integrator.p,integrator.t) .+ cache.uhold[1]
 
@@ -30,7 +30,7 @@ function perform_step!(integrator,cache::Union{GenericIIF1ConstantCache,GenericI
   alg = typeof(integrator.alg) <: CompositeAlgorithm ? integrator.alg.algs[integrator.cache.current] : integrator.alg
 
   # If adaptive, this should be computed after and cached
-  A = integrator.f.f1
+  A = integrator.f.f1.f
   if typeof(cache) <: GenericIIF1ConstantCache
     rhs.tmp = exp(A*dt)*(uprev)
   elseif typeof(cache) <: GenericIIF2ConstantCache
@@ -73,7 +73,7 @@ function initialize!(integrator,cache::Union{GenericIIF1Cache,GenericIIF2Cache})
   integrator.fsallast = cache.k
   integrator.kshortsize = 2
   resize!(integrator.k, integrator.kshortsize)
-  A = integrator.f.f1
+  A = integrator.f.f1.f
   integrator.f.f2(cache.rtmp1,integrator.uprev,integrator.p,integrator.t)
   mul!(cache.k,A,integrator.uprev)
   @. integrator.fsalfirst = cache.k + cache.rtmp1
@@ -104,6 +104,6 @@ function perform_step!(integrator,cache::Union{GenericIIF1Cache,GenericIIF2Cache
 
   copyto!(u,nlres)
   integrator.f.f2(rtmp1,nlres,integrator.p,t+dt)
-  A = f.f1
+  A = f.f1.f
   integrator.fsallast .= A*u .+ rtmp1
 end

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -2,12 +2,13 @@ using OrdinaryDiffEq, Test, DiffEqDevTools, DiffEqOperators, Random
 const μ = 1.01
 linnonlin_f2 = (u,p,t) -> μ * u
 linnonlin_f1 = DiffEqArrayOperator(μ)
-prob = SplitODEProblem(linnonlin_f1,linnonlin_f2,1/2,(0.0,1.0),func_cache=1/2)
-(::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t) = u0.*exp.(2μ*t)
+linnonlin_f = SplitFunction(linnonlin_f1, linnonlin_f2;
+                            analytic=(u0,p,t) -> u0.*exp.(2μ*t))
+prob = SplitODEProblem(linnonlin_f,1/2,(0.0,1.0))
 
 println("Out-of-place")
 srand(100)
-dts = 1./2.^(7:-1:4) #14->7 good plot
+dts = 1 ./ 2 .^ (7:-1:4) #14->7 good plot
 sim  = test_convergence(dts,prob,GenericIIF1())
 @test abs(sim.𝒪est[:l2]-1) < 0.2
 sim  = test_convergence(dts,prob,GenericIIF2())
@@ -32,13 +33,11 @@ u0 = rand(2)
 A = [2.0 -1.0; -1.0 2.0]
 linnonlin_f1 = DiffEqArrayOperator(A)
 linnonlin_f2 = (du,u,p,t) -> du .= μ .* u
-prob = SplitODEProblem(linnonlin_f1,linnonlin_f2,u0,(0.0,1.0))
-function (::typeof(prob.f))(::Type{Val{:analytic}},u0,p,t)
- tmp = (A+μ*I)*t
- exp(tmp)*u0
-end
+linnonlin_f = SplitFunction(linnonlin_f1,linnonlin_f2;
+                            analytic=(u0,p,t) -> exp((A+μ*I)*t) * u0)
+prob = SplitODEProblem(linnonlin_f,u0,(0.0,1.0))
 
-dts = 1./2.^(8:-1:4) #14->7 good plot
+dts = 1 ./ 2 .^ (8:-1:4) #14->7 good plot
 sim  = test_convergence(dts,prob,GenericIIF1())
 @test abs(sim.𝒪est[:l2]-1) < 0.2
 

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Test, DiffEqOperators, Random
+using OrdinaryDiffEq, Test, DiffEqOperators, Random, LinearAlgebra
 @testset "Classical ExpRK" begin
     N = 20
     dt=0.1
@@ -10,10 +10,6 @@ using OrdinaryDiffEq, Test, DiffEqOperators, Random
     krylov_f2! = (du,u,p,t) -> du .= -0.1*u
     prob = SplitODEProblem(L,krylov_f2,u0,(0.0,1.0))
     prob_inplace = SplitODEProblem(L,krylov_f2!,u0,(0.0,1.0))
-
-    # Ad-hoc fix for SplitFunction miscalssified as having analytic solutions
-    DiffEqBase.has_analytic(::typeof(prob.f)) = false
-    DiffEqBase.has_analytic(::typeof(prob_inplace.f)) = false
 
     Algs = [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4]
     for Alg in Algs


### PR DESCRIPTION
This should fix ExpRK and its test scripts with regards to the `SplitFunction` change. Because `f.f1` is now wrapped in an `ODEFunction`, I need to change all instances of `f.f1` to `f.f1.f`. Which is a bit ugly to be honest, but as an ad-hoc fix this should now make all tests regarding the ExpRK methods pass.

For linear_nonlinear_convergence_tests.jl there're still a ton of depwarns, but they are either in DiffEqOperators or DiffEqDevTools.