### PR TITLE
Update ExpRK to use `calc_J!` and new DiffEqOperators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 0.7-beta2
 DiffEqBase 3.8.0
-DiffEqOperators
 Parameters 0.5.0
 ForwardDiff 0.7.0
 GenericSVD 0.0.2

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -17,8 +17,6 @@ module OrdinaryDiffEq
   # Internal utils
   import DiffEqBase: ODE_DEFAULT_NORM, ODE_DEFAULT_ISOUTOFDOMAIN, ODE_DEFAULT_PROG_MESSAGE, ODE_DEFAULT_UNSTABLE_CHECK
 
-  using DiffEqOperators: DiffEqArrayOperator
-
   import RecursiveArrayTools: chain, recursivecopy!
 
   using Parameters, GenericSVD, ForwardDiff, RecursiveArrayTools,

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -152,7 +152,7 @@ for (Alg, Cache) in [(:LawsonEuler, :LawsonEulerConstantCache),
       ops = nothing # no caching
     else
       isa(f, SplitFunction) || throw(ArgumentError("Caching can only be used with SplitFunction"))
-      A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+      A = size(f.f1) == () ? convert(Number, f.f1) : convert(AbstractMatrix, f.f1)
       ops = expRK_operators(alg, dt, A)
     end
     return $Cache(ops)
@@ -183,7 +183,7 @@ function alg_cache_expRK(alg::OrdinaryDiffEqExponentialAlgorithm, u, f, dt, plis
   else
     KsCache = nothing
     # Precompute the operators
-    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    A = size(f.f1) == () ? convert(Number, f.f1) : convert(AbstractMatrix, f.f1)
     ops = expRK_operators(alg, dt, A)
   end
   return Jcache, ops, KsCache
@@ -216,7 +216,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     KsCache = (Ks, expv_cache)
   else
     KsCache = nothing
-    A = isa(f.f1, DiffEqArrayOperator) ? f.f1.A * f.f1.α.coeff : full(f.f1)
+    A = size(f.f1) == () ? convert(Number, f.f1) : convert(AbstractMatrix, f.f1)
     exphA = expRK_operators(alg, dt, A)
   end
   LawsonEulerCache(u,uprev,tmp,rtmp,G,Jcache,exphA,KsCache)
@@ -571,13 +571,8 @@ struct ETD2ConstantCache{expType} <: OrdinaryDiffEqConstantCache
 end
 
 function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  A = f.f1
-  if isa(A, DiffEqArrayOperator)
-    _A = A.A * A.α.coeff # .* does not return Diagonal for A.A Diagonal
-  else
-    _A = full(A)
-  end
-  Phi = phi(dt*_A, 2)
+  A = size(f.f1) == () ? convert(Number, f.f1) : convert(AbstractMatrix, f.f1)
+  Phi = phi(dt*A, 2)
   ETD2ConstantCache(Phi[1], Phi[2], Phi[2] + Phi[3], -Phi[3])
 end
 
@@ -594,13 +589,8 @@ struct ETD2Cache{uType,rateType,expType} <: OrdinaryDiffEqMutableCache
 end
 
 function alg_cache(alg::ETD2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  A = f.f1
-  if isa(A, DiffEqArrayOperator)
-    _A = A.A * A.α.coeff # .* does not return Diagonal for A.A Diagonal
-  else
-    _A = full(A)
-  end
-  Phi = phi(dt*_A, 2)
+  A = size(f.f1) == () ? convert(Number, f.f1) : convert(AbstractMatrix, f.f1)
+  Phi = phi(dt*A, 2)
   ETD2Cache(u,uprev,zero(u),zero(rate_prototype),zero(rate_prototype),Phi[1],Phi[2],Phi[2]+Phi[3],-Phi[3])
 end
 

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -19,17 +19,27 @@ function calc_tderivative!(integrator, cache, dtd1, repeat_step)
   end
 end
 
-function calc_J!(integrator, cache, is_compos)
-    @unpack t,dt,uprev,u,f,p = integrator
-    @unpack du1,uf,J,jac_config = cache
-    if DiffEqBase.has_jac(f)
-      f.jac(J, uprev, p, t)
-    else
-      uf.t = t
-      uf.p = p
-      jacobian!(J, uf, uprev, du1, integrator, jac_config)
-    end
-    is_compos && (integrator.eigen_est = opnorm(J, Inf))
+"""
+    calc_J!(integrator,cache,is_compos)
+
+Interface for updating the jacobian field `J` in a mutable cache.
+
+If `integrator.f` has a custom jacobian update function, then it will be
+called for the update. Otherwise, either ForwardDiff or finite difference
+will be used depending on the `jac_config` of the cache.
+"""
+function calc_J!(integrator, cache::OrdinaryDiffEqMutableCache, is_compos)
+  @unpack t,dt,uprev,u,f,p = integrator
+  J = cache.J
+  if DiffEqBase.has_jac(f)
+    f.jac(J, uprev, p, t)
+  else
+    @unpack du1,uf,jac_config = cache
+    uf.t = t
+    uf.p = p
+    jacobian!(J, uf, uprev, du1, integrator, jac_config)
+  end
+  is_compos && (integrator.eigen_est = opnorm(J, Inf))
 end
 
 function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, W_transform=false)

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -627,10 +627,11 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
       iop = 2 # does not have an effect on arnoldi!, just for flops estimation
     end
     if iszero(NA)
-      if isa(A, SparseMatrixCSC)
-        NA = nnz(A)
+      _A = convert(AbstractMatrix, A)
+      if isa(_A, SparseMatrixCSC)
+        NA = nnz(_A)
       else
-        NA = count(!iszero, A) # not constant operation, should be best avoided
+        NA = count(!iszero, _A) # not constant operation, should be best avoided
       end
     end
   end

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -1,5 +1,7 @@
 using OrdinaryDiffEq, Test, DiffEqDevTools, DiffEqOperators, Random
-const μ = 1.01
+
+@testset "Out-of-place" begin
+μ = 1.01
 linnonlin_f2 = (u,p,t) -> μ * u
 linnonlin_f1 = DiffEqScalar(μ)
 fun = SplitFunction(linnonlin_f1, linnonlin_f2; analytic=(u0,p,t)->u0.*exp.(2μ*t))
@@ -26,8 +28,11 @@ sim  = test_convergence(dts,prob,HochOst4())
 @test abs(sim.𝒪est[:l2]-4) < 0.2
 sim  = test_convergence(dts,prob,ETD2())
 @test abs(sim.𝒪est[:l2]-2) < 0.2
+end
 
+@testset "Inplace" begin
 println("Inplace")
+μ = 1.01
 u0 = rand(2)
 A = [2.0 -1.0; -1.0 2.0]
 linnonlin_f1 = DiffEqArrayOperator(A)
@@ -63,3 +68,4 @@ sim  = test_convergence(dts,prob,HochOst4())
 
 sim  = test_convergence(dts,prob,ETD2())
 @test abs(sim.𝒪est[:l2]-2) < 0.1
+end

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -1,7 +1,7 @@
 using OrdinaryDiffEq, Test, DiffEqDevTools, DiffEqOperators, Random
 const μ = 1.01
 linnonlin_f2 = (u,p,t) -> μ * u
-linnonlin_f1 = DiffEqArrayOperator(μ)
+linnonlin_f1 = DiffEqScalar(μ)
 fun = SplitFunction(linnonlin_f1, linnonlin_f2; analytic=(u0,p,t)->u0.*exp.(2μ*t))
 prob = SplitODEProblem(fun,1/2,(0.0,1.0))
 

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -1,30 +1,26 @@
 using OrdinaryDiffEq, Test, DiffEqOperators, Random, LinearAlgebra
-
-function _construct_test_prob(N)
-  srand(0); u0 = normalize(randn(N))
-  dd = -2 * ones(N); du = ones(N-1)
-  A = diagm(-1 => du, 0 => dd, 1 => du)
-  _f = (u,p,t) -> A*u - u.^3
-  _f_ip = (du,u,p,t) -> (mul!(du, A, u); du .-= u.^3)
-  _jac = (u,p,t) -> A - 3 * diagm(0 => u.^2)
-  _jac_ip = (J,u,p,t) -> begin
-    copyto!(J, A)
-    @inbounds for i = 1:N
-      J[i, i] -= 3 * u[i]^2
-    end
+let N = 20
+srand(0); u0 = normalize(randn(N))
+dd = -2 * ones(N); du = ones(N-1)
+A = diagm(-1 => du, 0 => dd, 1 => du)
+_f = (u,p,t) -> A*u - u.^3
+_f_ip = (du,u,p,t) -> (mul!(du, A, u); du .-= u.^3)
+_jac = (u,p,t) -> A - 3 * diagm(0 => u.^2)
+_jac_ip = (J,u,p,t) -> begin
+  copyto!(J, A)
+  @inbounds for i = 1:N
+    J[i, i] -= 3 * u[i]^2
   end
-  # f = ODEFunction(_f; jac=_jac)
-  # f_ip = ODEFunction(_f_ip; jac=_jac_ip, jac_prototype=zeros(N,N))
-  jac_prototype = DiffEqArrayOperator(zeros(N,N); update_func=_jac_ip)
-  f = ODEFunction(_f; jac_prototype=jac_prototype)
-  f_ip = ODEFunction(_f_ip; jac_prototype=jac_prototype)
-  prob = ODEProblem(f, u0, (0.0, 1.0))
-  prob_ip = ODEProblem(f_ip, u0, (0.0, 1.0))
-  return prob, prob_ip
 end
+# f = ODEFunction(_f; jac=_jac)
+# f_ip = ODEFunction(_f_ip; jac=_jac_ip, jac_prototype=zeros(N,N))
+jac_prototype = DiffEqArrayOperator(zeros(N,N); update_func=_jac_ip)
+f = ODEFunction(_f; jac_prototype=jac_prototype)
+f_ip = ODEFunction(_f_ip; jac_prototype=jac_prototype)
+prob = ODEProblem(f, u0, (0.0, 1.0))
+prob_ip = ODEProblem(f_ip, u0, (0.0, 1.0))
 
 @testset "Classical ExpRK - Low Order" begin
-  prob, prob_ip = _construct_test_prob(20)
   dt = 0.01; tol=1e-3
   Algs = [LawsonEuler,NorsettEuler,ETDRK2]
   for Alg in Algs
@@ -41,7 +37,6 @@ end
 end
 
 @testset "Classical ExpRK - High Order" begin
-  prob, prob_ip = _construct_test_prob(20)
   dt = 0.05; tol=1e-5
   Algs = [ETDRK3,ETDRK4,HochOst4]
   for Alg in Algs
@@ -58,7 +53,6 @@ end
 end
 
 @testset "EPIRK" begin
-  prob, prob_ip = _construct_test_prob(20)
   dt = 0.05; tol=1e-5
   Algs = [Exp4, EPIRK4s3A, EPIRK4s3B, EXPRB53s3, EPIRK5P1, EPIRK5P2]
   for Alg in Algs
@@ -80,4 +74,5 @@ end
   sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
   @test_broken isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
   println(EPIRK5s3) # prevent Travis hanging
+end
 end

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -1,80 +1,83 @@
 using OrdinaryDiffEq, Test, DiffEqOperators, Random, LinearAlgebra
 
 function _construct_test_prob(N)
-    srand(0); u0 = normalize(randn(N))
-    dd = -2 * ones(N); du = ones(N-1)
-    A = diagm(-1 => du, 0 => dd, 1 => du)
-    _f = (u,p,t) -> A*u - u.^3
-    _f_ip = (du,u,p,t) -> (mul!(du, A, u); du .-= u.^3)
-    _jac = (u,p,t) -> A - 3 * diagm(0 => u.^2)
-    _jac_ip = (J,u,p,t) -> begin
-        copyto!(J, A)
-        @inbounds for i = 1:N
-            J[i, i] -= 3 * u[i]^2
-        end
+  srand(0); u0 = normalize(randn(N))
+  dd = -2 * ones(N); du = ones(N-1)
+  A = diagm(-1 => du, 0 => dd, 1 => du)
+  _f = (u,p,t) -> A*u - u.^3
+  _f_ip = (du,u,p,t) -> (mul!(du, A, u); du .-= u.^3)
+  _jac = (u,p,t) -> A - 3 * diagm(0 => u.^2)
+  _jac_ip = (J,u,p,t) -> begin
+    copyto!(J, A)
+    @inbounds for i = 1:N
+      J[i, i] -= 3 * u[i]^2
     end
-    f = ODEFunction(_f; jac=_jac)
-    f_ip = ODEFunction(_f_ip; jac=_jac_ip, jac_prototype=zeros(N,N))
-    prob = ODEProblem(f, u0, (0.0, 1.0))
-    prob_ip = ODEProblem(f_ip, u0, (0.0, 1.0))
-    return prob, prob_ip
+  end
+  # f = ODEFunction(_f; jac=_jac)
+  # f_ip = ODEFunction(_f_ip; jac=_jac_ip, jac_prototype=zeros(N,N))
+  jac_prototype = DiffEqArrayOperator(zeros(N,N); update_func=_jac_ip)
+  f = ODEFunction(_f; jac_prototype=jac_prototype)
+  f_ip = ODEFunction(_f_ip; jac_prototype=jac_prototype)
+  prob = ODEProblem(f, u0, (0.0, 1.0))
+  prob_ip = ODEProblem(f_ip, u0, (0.0, 1.0))
+  return prob, prob_ip
 end
 
 @testset "Classical ExpRK - Low Order" begin
-    prob, prob_ip = _construct_test_prob(20)
-    dt = 0.01; tol=1e-3
-    Algs = [LawsonEuler,NorsettEuler,ETDRK2]
-    for Alg in Algs
-        sol = solve(prob, Alg(krylov=true, m=20); dt=dt, reltol=tol)
-        sol_ref = solve(prob, Tsit5(); reltol=tol)
-        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+  prob, prob_ip = _construct_test_prob(20)
+  dt = 0.01; tol=1e-3
+  Algs = [LawsonEuler,NorsettEuler,ETDRK2]
+  for Alg in Algs
+    sol = solve(prob, Alg(krylov=true, m=20); dt=dt, reltol=tol)
+    sol_ref = solve(prob, Tsit5(); reltol=tol)
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
 
-        sol = solve(prob_ip, Alg(krylov=true, m=20); dt=dt, reltol=tol)
-        sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
-        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+    sol = solve(prob_ip, Alg(krylov=true, m=20); dt=dt, reltol=tol)
+    sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
 
-        println(Alg) # prevent Travis hanging
-    end
+    println(Alg) # prevent Travis hanging
+  end
 end
 
 @testset "Classical ExpRK - High Order" begin
-    prob, prob_ip = _construct_test_prob(20)
-    dt = 0.05; tol=1e-5
-    Algs = [ETDRK3,ETDRK4,HochOst4]
-    for Alg in Algs
-        sol = solve(prob, Alg(krylov=true, m=20); dt=dt, reltol=tol)
-        sol_ref = solve(prob, Tsit5(); reltol=tol)
-        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+  prob, prob_ip = _construct_test_prob(20)
+  dt = 0.05; tol=1e-5
+  Algs = [ETDRK3,ETDRK4,HochOst4]
+  for Alg in Algs
+    sol = solve(prob, Alg(krylov=true, m=20); dt=dt, reltol=tol)
+    sol_ref = solve(prob, Tsit5(); reltol=tol)
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
 
-        sol = solve(prob_ip, Alg(krylov=true, m=20); dt=dt, reltol=tol)
-        sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
-        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+    sol = solve(prob_ip, Alg(krylov=true, m=20); dt=dt, reltol=tol)
+    sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
 
-        println(Alg) # prevent Travis hanging
-    end
+    println(Alg) # prevent Travis hanging
+  end
 end
 
 @testset "EPIRK" begin
-    prob, prob_ip = _construct_test_prob(20)
-    dt = 0.05; tol=1e-5
-    Algs = [Exp4, EPIRK4s3A, EPIRK4s3B, EXPRB53s3, EPIRK5P1, EPIRK5P2]
-    for Alg in Algs
-        sol = solve(prob, Alg(); dt=dt, reltol=tol)
-        sol_ref = solve(prob, Tsit5(); reltol=tol)
-        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
-
-        sol = solve(prob_ip, Alg(); dt=dt, reltol=tol)
-        sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
-        @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
-        println(Alg) # prevent Travis hanging
-    end
-
-    sol = solve(prob, EPIRK5s3(); dt=dt, reltol=tol)
+  prob, prob_ip = _construct_test_prob(20)
+  dt = 0.05; tol=1e-5
+  Algs = [Exp4, EPIRK4s3A, EPIRK4s3B, EXPRB53s3, EPIRK5P1, EPIRK5P2]
+  for Alg in Algs
+    sol = solve(prob, Alg(); dt=dt, reltol=tol)
     sol_ref = solve(prob, Tsit5(); reltol=tol)
-    @test_broken isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
 
-    sol = solve(prob_ip, EPIRK5s3(); dt=dt, reltol=tol)
+    sol = solve(prob_ip, Alg(); dt=dt, reltol=tol)
     sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
-    @test_broken isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
-    println(EPIRK5s3) # prevent Travis hanging
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+    println(Alg) # prevent Travis hanging
+  end
+
+  sol = solve(prob, EPIRK5s3(); dt=dt, reltol=tol)
+  sol_ref = solve(prob, Tsit5(); reltol=tol)
+  @test_broken isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+
+  sol = solve(prob_ip, EPIRK5s3(); dt=dt, reltol=tol)
+  sol_ref = solve(prob_ip, Tsit5(); reltol=tol)
+  @test_broken isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+  println(EPIRK5s3) # prevent Travis hanging
 end

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -41,7 +41,7 @@ end
         end
     end
     f = ODEFunction(_f; jac=_jac)
-    f_ip = ODEFunction(_f_ip; jac=_jac_ip)
+    f_ip = ODEFunction(_f_ip; jac=_jac_ip, jac_prototype=zeros(N,N))
     prob = ODEProblem(f, u0, (0.0, 1.0))
     prob_ip = ODEProblem(f_ip, u0, (0.0, 1.0))
 


### PR DESCRIPTION
The main goal of this PR is to update the ExpRK integrators to use the `calc_J!` instead of directly calling `f.jac`. This would allow general sparse and/or lazy types to be used as the jacobian, as indicated here https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/416.

A secondary goal is to apply the newest changes to DiffEqOperators to the ExpRK integrators. This goes hand in hand with the primary goal as both are related to lazy operator support. One thing in particular I'd like to do is to drop DiffEqOperators in the requirement list, which should make the separation of functionality clearer. This is made possible due to the various new interfaces introduced in the DiffEqOperators update, in particular `convert(Number, a)` and `convert(AbstractArray, A)`.