### PR TITLE
WIP: Lazy W operator support

### DIFF
--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEq: phi, phi, phiv, phiv_timestep, expv, expv_timestep, arnoldi, getH, getV
-using LinearAlgebra, SparseArrays, Random, Test
+using LinearAlgebra, SparseArrays, Random, Test, DiffEqOperators
 
 @testset "Exponential Utilities" begin
   # Scalar phi
@@ -66,4 +66,17 @@ using LinearAlgebra, SparseArrays, Random, Test
   u_exact = Phi[1] * B[:, 1]
   u = expv_timestep(t, A, B[:, 1]; adaptive=true, tol=tol)
   @test norm(u - u_exact) / norm(u_exact) < tol
+end
+
+@testset "Derivative Utilities" begin
+  @testset "WOperator" begin
+    srand(0); y = zeros(2); b = rand(2)
+    mm = I; _J = rand(2,2)
+    W = OrdinaryDiffEq.WOperator(mm, 1.0, DiffEqArrayOperator(_J))
+    OrdinaryDiffEq.set_gamma!(W, 2.0)
+    _W = mm - 2.0 * _J
+    @test convert(AbstractMatrix,W) ≈ _W
+    @test W * b ≈ _W * b
+    mul!(y, W, b); @test y ≈ _W * b
+  end
 end


### PR DESCRIPTION
Implements the lazy W operators as suggested in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/416#issuecomment-406323306.

I decided to write `WOperator` in OrdinaryDiffEq.jl so that DiffEqOperators is not required for OrdinaryDiffEq. The fact that the interface for `AbstractDiffEqLinearOperator` in DiffEqBase helps a lot.

(By the way, it occurs to me that a lot of methods in common_defaults.jl for DiffEqOperators should, in fact, be written in DiffEqBase instead. I should do a separate PR for this in the future).

Currently the lazy part of `WOperator` is already in place and what remains is to modify `alg_cache` and `calc_W!` to use it. (Also I need to migrate `mass_matrix` to `*DEFunction` in DiffEqBase). The suggestions here https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/416#issuecomment-406330098 is also worth looking into.

I also intend to add more tests for the methods in `derivative_utils.jl` to `utility_tests.jl`, starting with `calc_J!` and `calc_W!`.