### PR TITLE
Fix some depwarns

### DIFF
--- a/src/caches/basic_caches.jl
+++ b/src/caches/basic_caches.jl
@@ -79,7 +79,7 @@ end
 function ExplicitRKConstantCache(tableau,rate_prototype)
   @unpack A,c,α,αEEst,stages = tableau
   A = A' # Transpose A to column major looping
-  kk = Array{typeof(rate_prototype)}(stages) # Not ks since that's for integrator.opts.dense
+  kk = Array{typeof(rate_prototype)}(undef, stages) # Not ks since that's for integrator.opts.dense
   ExplicitRKConstantCache(A,c,α,αEEst,stages,kk)
 end
 

--- a/src/exponential_utils.jl
+++ b/src/exponential_utils.jl
@@ -265,7 +265,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T}, A, b::AbstractVector{T}; tol::Real=1
     beta = norm(cache)
     H[j+1, j] = beta
     @inbounds for i = 1:n
-      @. V[i, j+1] = cache[i] / beta
+      V[i, j+1] = cache[i] / beta
     end
     if beta < vtol # happy-breakdown
       Ks.m = j


### PR DESCRIPTION
This PR fixes
```julia
┌ Warning: `Array{T}(m::Int) where T` is deprecated, use `Array{T}(undef, m)` instead.
│   caller = macro expansion at Parameters.jl:755 [inlined]
```
and
```julia
┌ Warning: the behavior of `A[I...] .= X` with scalar indices willchange in the future. Use `A[I...
] = X` instead.
│   caller = ip:0x0
└ @ Core :-1
Test Summary:         | Pass  Total
Exponential Utilities |    9      9
```