### PR TITLE
Mass matrix hotfix

### DIFF
--- a/src/dense/stiff_addsteps.jl
+++ b/src/dense/stiff_addsteps.jl
@@ -27,7 +27,7 @@ end
 
     # Assignments
     sizeu  = size(u)
-    #mass_matrix = integrator.sol.prob.mass_matrix
+    #mass_matrix = integrator.f.mass_matrix
     γ = dt*d
     dto2 = dt/2
     dto6 = dt/6
@@ -166,7 +166,7 @@ end
     # Assignments
     sizeu  = size(u)
     uidx = eachindex(uprev)
-    #mass_matrix = integrator.sol.prob.mass_matrix
+    #mass_matrix = integrator.f.mass_matrix
     mass_matrix = I
     atmp = du # does not work with units - additional unitless array required!
 

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -58,7 +58,7 @@ function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_
   @inbounds begin
     @unpack t,dt,uprev,u,f,p = integrator
     @unpack J,W,jac_config = cache
-    mass_matrix = integrator.sol.prob.mass_matrix
+    mass_matrix = integrator.f.mass_matrix
     is_compos = typeof(integrator.alg) <: CompositeAlgorithm
     alg = unwrap_alg(integrator, true)
 

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -60,10 +60,10 @@
   still works for matrix-free definitions of the mass matrix.
   =#
 
-  if prob.mass_matrix != I
+  if prob.f.mass_matrix != I
     ftmp = similar(f₀)
     try
-      integrator.alg.linsolve(ftmp, copy(prob.mass_matrix), f₀, true)
+      integrator.alg.linsolve(ftmp, copy(prob.f.mass_matrix), f₀, true)
       f₀ .= ftmp
     catch
       return _tType(1//10^(6))
@@ -97,8 +97,8 @@
   f₁ = similar(f₀)
   f(f₁,u₁,p,t+dt₀_tdir)
 
-  if prob.mass_matrix != I
-    integrator.alg.linsolve(ftmp, prob.mass_matrix, f₁, false)
+  if prob.f.mass_matrix != I
+    integrator.alg.linsolve(ftmp, prob.f.mass_matrix, f₁, false)
     f₁ .= ftmp
   end
 

--- a/src/nlsolve_utils.jl
+++ b/src/nlsolve_utils.jl
@@ -91,7 +91,7 @@ function diffeq_nlsolve!(integrator,
                          ::Type{Val{:newton}})
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,tmp,W,κ,tol,c,γ = nlcache
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1
@@ -146,7 +146,7 @@ function diffeq_nlsolve!(integrator,
                          ::Type{Val{:newton}})
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,dz,tmp,b,W,κ,tol,k,new_W,c,γ = nlcache
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1
@@ -245,7 +245,7 @@ function diffeq_nlsolve!(integrator,
                          ::Type{Val{:functional}})
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,tmp,κ,tol,c,γ = nlcache
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1
@@ -301,7 +301,7 @@ function diffeq_nlsolve!(integrator,
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,dz,tmp,κ,tol,b,k,c,γ = nlcache
   z₊ = b
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -64,7 +64,7 @@ end
 @muladd function perform_step!(integrator, cache::LinearImplicitEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u = integrator
   @unpack W,k,tmp,atmp = cache
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
 
   L = integrator.f
   update_coefficients!(L,u,p,t+dt)
@@ -129,7 +129,7 @@ end
 function perform_step!(integrator, cache::MidpointSplittingCache, repeat_step=false)
   @unpack t,dt,uprev,u = integrator
   @unpack W,k,tmp = cache
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
 
   L = integrator.f
   update_coefficients!(L,u,p,t+dt/2)

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -28,7 +28,7 @@ end
 
   # Assignments
   sizeu  = size(u)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
 
   # Precalculations
   γ = dt*d
@@ -98,7 +98,7 @@ end
 
   # Assignments
   sizeu  = size(u)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
 
   # Precalculations
   γ = dt*d
@@ -322,7 +322,7 @@ end
   @unpack a21,a31,a32,C21,C31,C32,b1,b2,b3,btilde1,btilde2,btilde3,gamma,c2,c3,d1,d2,d3 = cache.tab
 
   # Assignments
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   sizeu  = size(u)
   utilde = du
   atmp = du # does not work with units - additional unitless array required!
@@ -461,7 +461,7 @@ end
   # Assignments
   uidx = eachindex(integrator.uprev)
   sizeu  = size(u)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   utilde = du
   atmp = du # does not work with units - additional unitless array required!
 
@@ -629,7 +629,7 @@ end
   # Assignments
   sizeu  = size(u)
   uidx = eachindex(integrator.uprev)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   utilde = du
   atmp = du # does not work with units - additional unitless array required!
 
@@ -831,7 +831,7 @@ end
   # Assignments
   sizeu  = size(u)
   uidx = eachindex(integrator.uprev)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   atmp = du # does not work with units - additional unitless array required!
 
   # Precalculations
@@ -1107,7 +1107,7 @@ end
   # Assignments
   sizeu  = size(u)
   uidx = eachindex(integrator.uprev)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   atmp = du # does not work with units - additional unitless array required!
 
   # Precalculations

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -84,7 +84,7 @@ end
 @muladd function perform_step!(integrator, cache::ImplicitEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack uf,du1,dz,z,k,b,J,W,jac_config,tmp,atmp,κ,tol = cache
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   new_W = calc_W!(integrator, cache, dt, repeat_step)
 
@@ -160,7 +160,7 @@ end
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack uf,du1,dz,z,k,b,J,W,jac_config,tmp,κ,tol = cache
   alg = unwrap_alg(integrator, true)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
   γ = 1//2
   new_W = calc_W!(integrator, cache, γ*dt, repeat_step)
 
@@ -252,7 +252,7 @@ end
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack uf,du1,dz,z,k,b,J,W,jac_config,tmp,atmp,κ,tol = cache
   alg = unwrap_alg(integrator, true)
-  mass_matrix = integrator.sol.prob.mass_matrix
+  mass_matrix = integrator.f.mass_matrix
 
   # precalculations
   γ = 1//2

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,13 +58,13 @@ function DiffEqBase.__init(
   allow_extrapolation = alg_extrapolates(alg),
   initialize_integrator=true,kwargs...) where {algType<:OrdinaryDiffEqAlgorithm,recompile_flag}
 
-  if typeof(prob.f)<:DynamicalODEFunction && typeof(prob.mass_matrix)<:Tuple
-    if any(mm != I for mm in prob.mass_matrix)
+  if typeof(prob.f)<:DynamicalODEFunction && typeof(prob.f.mass_matrix)<:Tuple
+    if any(mm != I for mm in prob.f.mass_matrix)
       error("This solver is not able to use mass matrices.")
     end
   elseif !(typeof(prob)<:DiscreteProblem) &&
          !(typeof(alg) <:MassMatrixAlgorithms) &&
-         prob.mass_matrix != I
+         prob.f.mass_matrix != I
     error("This solver is not able to use mass matrices.")
   end
 

--- a/test/mass_matrix_tests.jl
+++ b/test/mass_matrix_tests.jl
@@ -14,8 +14,8 @@ using OrdinaryDiffEq, Test, LinearAlgebra, Statistics
   mm_g(du,u,p,t) = @. du = u + t
   mm_analytic(u0,p,t) = @. 2u0*exp(t) - t - 1
   prob2 = ODEProblem(ODEFunction(mm_g,analytic=mm_analytic),ones(3),(0.0,1.0))
-  prob = ODEProblem(ODEFunction(mm_f,analytic=mm_analytic),ones(3),
-                                   (0.0,1.0),mass_matrix=mm_A)
+  prob = ODEProblem(ODEFunction(mm_f,analytic=mm_analytic,mass_matrix=mm_A),ones(3),
+                                   (0.0,1.0))
 
   ######################################### Test each method for exactness
 
@@ -102,7 +102,7 @@ sol2 = solve(prob2, TRBDF2(),adaptive=false,dt=1/10)
   M = fill(0., 2,2)
   M[1,1] = 1.
 
-  m_ode_prob = ODEProblem(f!, u0, tspan, mass_matrix=M)
+  m_ode_prob = ODEProblem(ODEFunction(f!;mass_matrix=M), u0, tspan)
   @test_nowarn sol = solve(m_ode_prob, Rosenbrock23())
 
   M = [0.637947  0.637947
@@ -117,6 +117,6 @@ sol2 = solve(prob2, TRBDF2(),adaptive=false,dt=1/10)
   end
   u0 = fill(0., 2)
 
-  m_ode_prob = ODEProblem(f2!, u0, tspan, mass_matrix=M)
+  m_ode_prob = ODEProblem(ODEFunction(f2!;mass_matrix=M), u0, tspan)
   @test_nowarn sol = solve(m_ode_prob, Rosenbrock23())
 end


### PR DESCRIPTION
Address changes in JuliaDiffEq/DiffEqBase.jl#126. Note that some tests require https://github.com/JuliaDiffEq/DiffEqProblemLibrary.jl/pull/31.

The mass matrix test passes, but I think it'll be safer to wait for the whole test suite before merging.