### PR TITLE
Lazy W bugfix

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -282,7 +282,7 @@ function calc_W!(integrator, cache::OrdinaryDiffEqConstantCache, dtgamma, repeat
   if !W_transform
     if DiffEqBase.has_jac(f)
       J = f.jac(uprev, p, t)
-      if !isa(f, DiffEqBase.AbstractDiffEqLinearOperator)
+      if !isa(J, DiffEqBase.AbstractDiffEqLinearOperator)
         J = DiffEqArrayOperator(J)
       end
       W = WOperator(mass_matrix, dtgamma, J; transform=false)
@@ -297,7 +297,7 @@ function calc_W!(integrator, cache::OrdinaryDiffEqConstantCache, dtgamma, repeat
   else
     if DiffEqBase.has_jac(f)
       J = f.jac(uprev, p, t)
-      if !isa(f, DiffEqBase.AbstractDiffEqLinearOperator)
+      if !isa(J, DiffEqBase.AbstractDiffEqLinearOperator)
         J = DiffEqArrayOperator(J)
       end
       W = WOperator(mass_matrix, dtgamma, J; transform=true)


### PR DESCRIPTION
Discovered this typo while working on StochasticDiffEq. This isn't technically a bug so it wasn't caught in the test suite, but this would result in the jacobian being unnecessarily wrapped in `DiffEqArrayOperator` if it is already a diffeq operator.