### PR TITLE
setup callbacks to use previous zero crossing data

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -43,43 +43,15 @@ end
     previous_condition = callback.condition(@view(integrator.uprev[callback.idxs]),integrator.tprev,integrator)
   end
 
-  if integrator.event_last_time && abs(previous_condition) < callback.abstol
+  if integrator.event_last_time!=0 && abs(previous_condition) < callback.abstol
 
     # abs(previous_condition) < callback.abstol is for multiple events: only
     # condition this on the correct event
 
-    # If there was a previous event, utilize the derivative at the start to
-    # chose the previous sign. If the derivative is positive at tprev, then
-    # we treat the value as positive, and derivative is negative then we
-    # treat the value as negative, reguardless of the postiivity/negativity
-    # of the true value due to it being =0 sans floating point issues.
+    # If previous upcrossing, then prev_sign is positive since infinitesimally
+    # after the event it will be positive, and this stops repeat zeros
 
-    if callback.interp_points==0
-      ode_addsteps!(integrator)
-    end
-
-    if typeof(integrator.cache) <: OrdinaryDiffEqMutableCache
-      if typeof(callback.idxs) <: Nothing
-        tmp = integrator.cache.tmp
-      else !(typeof(callback.idxs) <: Number)
-        tmp = @view integrator.cache.tmp[callback.idxs]
-      end
-    end
-
-    if typeof(integrator.cache) <: OrdinaryDiffEqMutableCache && !(typeof(callback.idxs) <: Number)
-      ode_interpolant!(tmp,100eps(typeof(integrator.tprev)),
-                       integrator,callback.idxs,Val{0})
-    else
-
-      tmp = ode_interpolant(100eps(typeof(integrator.tprev)),
-                            integrator,callback.idxs,Val{0})
-    end
-
-    tmp_condition = callback.condition(tmp,integrator.tprev +
-                                       100eps(typeof(integrator.tprev)),
-                                       integrator)
-
-    prev_sign = sign((tmp_condition-previous_condition)/integrator.dt)
+    prev_sign = integrator.event_last_time
   else
     prev_sign = sign(previous_condition)
   end

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -342,10 +342,10 @@ function handle_callbacks!(integrator)
     time,upcrossing,event_occurred,idx,counter =
               find_first_continuous_callback(integrator,continuous_callbacks...)
     if event_occurred
-      integrator.event_last_time = true
+      integrator.event_last_time = upcrossing ? 1 : -1
       continuous_modified,saved_in_cb = apply_callback!(integrator,continuous_callbacks[idx],time,upcrossing)
     else
-      integrator.event_last_time = false
+      integrator.event_last_time = 0
     end
   end
   if !integrator.force_stepfail && !(typeof(discrete_callbacks)<:Tuple{})

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -105,7 +105,7 @@ mutable struct ODEIntegrator{algType<:OrdinaryDiffEqAlgorithm,uType,tType,pType,
   force_stepfail::Bool
   last_stepfail::Bool
   just_hit_tstop::Bool
-  event_last_time::Bool
+  event_last_time::Int
   accept_step::Bool
   isout::Bool
   reeval_fsal::Bool

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -292,7 +292,7 @@ function DiffEqBase.__init(
   accept_step = false
   force_stepfail = false
   last_stepfail = false
-  event_last_time = false
+  event_last_time = 0
   dtchangeable = isdtchangeable(alg)
   q11 = tTypeNoUnits(1)
   success_iter = 0


### PR DESCRIPTION
This sounded like a good idea, however the issue is that the previous zero crossing is not indicative of post-event behavior. Even on an example like the bouncing ball you note that a downcrossing will "become an upcrossing" after the event, and so treating it as going negative is bad since you get an event catching loop, while treating it as positive is also bad because then the Poincure trivial callback (i.e. just saving at zero crossings) will keep downcrossing and enter an event catching loop. The solution has to use derivative information after the event, so it needs to check the condition post event like how it's done on master, so this idea is bunk but saved for future reference