### PR TITLE
Fix type of coefficients of some methods

### DIFF
--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -126,81 +126,61 @@ end
 alg_cache(alg::RK4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = RK4ConstantCache()
 
 
-struct CarpenterKennedy2N54Cache{uType,rateType} <: OrdinaryDiffEqMutableCache
+struct CarpenterKennedy2N54Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
   tmp::uType
   fsalfirst::rateType
-  A2::Float64
-  A3::Float64
-  A4::Float64
-  A5::Float64
-  B1::Float64
-  B2::Float64
-  B3::Float64
-  B4::Float64
-  B5::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
-  c5::Float64
+  tab::TabType
 end
 
 u_cache(c::CarpenterKennedy2N54Cache) = ()
 du_cache(c::CarpenterKennedy2N54Cache) = (c.k,c.fsalfirst)
 
-struct CarpenterKennedy2N54ConstantCache <: OrdinaryDiffEqConstantCache
-  A2::Float64
-  A3::Float64
-  A4::Float64
-  A5::Float64
-  B1::Float64
-  B2::Float64
-  B3::Float64
-  B4::Float64
-  B5::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
-  c5::Float64
+struct CarpenterKennedy2N54ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  A2::T
+  A3::T
+  A4::T
+  A5::T
+  B1::T
+  B2::T
+  B3::T
+  B4::T
+  B5::T
+  c2::T2
+  c3::T2
+  c4::T2
+  c5::T2
+
+  function CarpenterKennedy2N54ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    A2 = T(-567301805773/1357537059087)
+    A3 = T(-2404267990393/2016746695238)
+    A4 = T(-3550918686646/2091501179385)
+    A5 = T(-1275806237668/842570457699)
+    B1 = T(1432997174477/9575080441755)
+    B2 = T(5161836677717/13612068292357)
+    B3 = T(1720146321549/2090206949498)
+    B4 = T(3134564353537/4481467310338)
+    B5 = T(2277821191437/14882151754819)
+    c2 = T2(1432997174477/9575080441755)
+    c3 = T2(2526269341429/6820363962896)
+    c4 = T2(2006345519317/3224310063776)
+    c5 = T2(2802321613138/2924317926251)
+    new{T,T2}(A2, A3, A4, A5, B1, B2, B3, B4, B5, c2, c3, c4, c5)
+  end
 end
 
 function alg_cache(alg::CarpenterKennedy2N54,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u)
   k = zero(rate_prototype)
   fsalfirst = zero(rate_prototype)
-  A2 = -567301805773/1357537059087
-  A3 = -2404267990393/2016746695238
-  A4 = -3550918686646/2091501179385
-  A5 = -1275806237668/842570457699
-  B1 = 1432997174477/9575080441755
-  B2 = 5161836677717/13612068292357
-  B3 = 1720146321549/2090206949498
-  B4 = 3134564353537/4481467310338
-  B5 = 2277821191437/14882151754819
-  c2 = 1432997174477/9575080441755
-  c3 = 2526269341429/6820363962896
-  c4 = 2006345519317/3224310063776
-  c5 = 2802321613138/2924317926251
-  CarpenterKennedy2N54Cache(u,uprev,k,tmp,fsalfirst,A2,A3,A4,A5,B1,B2,B3,B4,B5,c2,c3,c4,c5)
+  tab = CarpenterKennedy2N54ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  CarpenterKennedy2N54Cache(u,uprev,k,tmp,fsalfirst,tab)
 end
 
 function alg_cache(alg::CarpenterKennedy2N54,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  A2 = -567301805773/1357537059087
-  A3 = -2404267990393/2016746695238
-  A4 = -3550918686646/2091501179385
-  A5 = -1275806237668/842570457699
-  B1 = 1432997174477/9575080441755
-  B2 = 5161836677717/13612068292357
-  B3 = 1720146321549/2090206949498
-  B4 = 3134564353537/4481467310338
-  B5 = 2277821191437/14882151754819
-  c2 = 1432997174477/9575080441755
-  c3 = 2526269341429/6820363962896
-  c4 = 2006345519317/3224310063776
-  c5 = 2802321613138/2924317926251
-  CarpenterKennedy2N54ConstantCache(A2,A3,A4,A5,B1,B2,B3,B4,B5,c2,c3,c4,c5)
+  CarpenterKennedy2N54ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
 end
 
 

--- a/src/caches/ssprk_caches.jl
+++ b/src/caches/ssprk_caches.jl
@@ -182,7 +182,7 @@ function alg_cache(alg::SSPRK63,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
 end
 
 
-struct SSPRK73Cache{uType,rateType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMutableCache
+struct SSPRK73Cache{uType,rateType,StageLimiter,StepLimiter,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
@@ -191,52 +191,58 @@ struct SSPRK73Cache{uType,rateType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMu
   fsalfirst::rateType
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
-  α40::Float64
-  α43::Float64
-  α50::Float64
-  α51::Float64
-  α54::Float64
-  α73::Float64
-  α76::Float64
-  β10::Float64
-  β21::Float64
-  β32::Float64
-  β43::Float64
-  β54::Float64
-  β65::Float64
-  β76::Float64
-  c1::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
-  c5::Float64
-  c6::Float64
+  tab::TabType
 end
 
 u_cache(c::SSPRK73Cache) = (c.tmp,c.u₁)
 du_cache(c::SSPRK73Cache) = (c.k,c.fsalfirst)
 
-struct SSPRK73ConstantCache <: OrdinaryDiffEqConstantCache
-  α40::Float64
-  α43::Float64
-  α50::Float64
-  α51::Float64
-  α54::Float64
-  α73::Float64
-  α76::Float64
-  β10::Float64
-  β21::Float64
-  β32::Float64
-  β43::Float64
-  β54::Float64
-  β65::Float64
-  β76::Float64
-  c1::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
-  c5::Float64
-  c6::Float64
+struct SSPRK73ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  α40::T
+  α43::T
+  α50::T
+  α51::T
+  α54::T
+  α73::T
+  α76::T
+  β10::T
+  β21::T
+  β32::T
+  β43::T
+  β54::T
+  β65::T
+  β76::T
+  c1::T2
+  c2::T2
+  c3::T2
+  c4::T2
+  c5::T2
+  c6::T2
+
+  function SSPRK73ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    α40 = T(0.184962588071072)
+    α43 = T(0.815037411928928)
+    α50 = T(0.180718656570380)
+    α51 = T(0.314831034403793)
+    α54 = T(0.504450309025826)
+    α73 = T(0.120199000000000)
+    α76 = T(0.879801000000000)
+    β10 = T(0.233213863663009)
+    β21 = T(0.233213863663009)
+    β32 = T(0.233213863663009)
+    β43 = T(0.190078023865845)
+    β54 = T(0.117644805593912)
+    β65 = T(0.233213863663009)
+    β76 = T(0.205181790464579)
+    c1 = T2(0.233213863663009)
+    c2 = T2(0.466427727326018)
+    c3 = T2(0.699641590989027)
+    c4 = T2(0.760312095463379)
+    c5 = T2(0.574607439040817)
+    c6 = T2(0.807821302703826)
+
+    new{T,T2}(α40, α43, α50, α51, α54, α73, α76, β10, β21, β32, β43, β54, β65, β76, c1, c2, c3, c4, c5, c6)
+  end
 end
 
 function alg_cache(alg::SSPRK73,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
@@ -244,52 +250,12 @@ function alg_cache(alg::SSPRK73,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   u₁ = similar(u)
   k = zero(rate_prototype)
   fsalfirst = zero(rate_prototype)
-  α40 = 0.184962588071072
-  α43 = 0.815037411928928
-  α50 = 0.180718656570380
-  α51 = 0.314831034403793
-  α54 = 0.504450309025826
-  α73 = 0.120199000000000
-  α76 = 0.879801000000000
-  β10 = 0.233213863663009
-  β21 = 0.233213863663009
-  β32 = 0.233213863663009
-  β43 = 0.190078023865845
-  β54 = 0.117644805593912
-  β65 = 0.233213863663009
-  β76 = 0.205181790464579
-  c1 = 0.233213863663009
-  c2 = 0.466427727326018
-  c3 = 0.699641590989027
-  c4 = 0.760312095463379
-  c5 = 0.574607439040817
-  c6 = 0.807821302703826
-  SSPRK73Cache(u,uprev,k,tmp,u₁,fsalfirst,alg.stage_limiter!,alg.step_limiter!,
-                α40,α43,α50,α51,α54,α73,α76,β10,β21,β32,β43,β54,β65,β76,c1,c2,c3,c4,c5,c6)
+  tab = SSPRK73ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  SSPRK73Cache(u,uprev,k,tmp,u₁,fsalfirst,alg.stage_limiter!,alg.step_limiter!,tab)
 end
 
 function alg_cache(alg::SSPRK73,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  α40 = 0.184962588071072
-  α43 = 0.815037411928928
-  α50 = 0.180718656570380
-  α51 = 0.314831034403793
-  α54 = 0.504450309025826
-  α73 = 0.120199000000000
-  α76 = 0.879801000000000
-  β10 = 0.233213863663009
-  β21 = 0.233213863663009
-  β32 = 0.233213863663009
-  β43 = 0.190078023865845
-  β54 = 0.117644805593912
-  β65 = 0.233213863663009
-  β76 = 0.205181790464579
-  c1 = 0.233213863663009
-  c2 = 0.466427727326018
-  c3 = 0.699641590989027
-  c4 = 0.760312095463379
-  c5 = 0.574607439040817
-  c6 = 0.807821302703826
-  SSPRK73ConstantCache(α40,α43,α50,α51,α54,α73,α76,β10,β21,β32,β43,β54,β65,β76,c1,c2,c3,c4,c5,c6)
+  SSPRK73ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
 

--- a/src/caches/ssprk_caches.jl
+++ b/src/caches/ssprk_caches.jl
@@ -113,7 +113,7 @@ function alg_cache(alg::SSPRK53,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
 end
 
 
-struct SSPRK63Cache{uType,rateType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMutableCache
+struct SSPRK63Cache{uType,rateType,StageLimiter,StepLimiter,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
@@ -122,44 +122,50 @@ struct SSPRK63Cache{uType,rateType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMu
   fsalfirst::rateType
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
-  α40::Float64
-  α41::Float64
-  α43::Float64
-  α62::Float64
-  α65::Float64
-  β10::Float64
-  β21::Float64
-  β32::Float64
-  β43::Float64
-  β54::Float64
-  β65::Float64
-  c1::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
-  c5::Float64
+  tab::TabType
 end
 
 u_cache(c::SSPRK63Cache) = (c.tmp,c.u₂)
 du_cache(c::SSPRK63Cache) = (c.k,c.fsalfirst)
 
-struct SSPRK63ConstantCache <: OrdinaryDiffEqConstantCache
-  α40::Float64
-  α41::Float64
-  α43::Float64
-  α62::Float64
-  α65::Float64
-  β10::Float64
-  β21::Float64
-  β32::Float64
-  β43::Float64
-  β54::Float64
-  β65::Float64
-  c1::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
-  c5::Float64
+struct SSPRK63ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  α40::T
+  α41::T
+  α43::T
+  α62::T
+  α65::T
+  β10::T
+  β21::T
+  β32::T
+  β43::T
+  β54::T
+  β65::T
+  c1::T2
+  c2::T2
+  c3::T2
+  c4::T2
+  c5::T2
+
+  function SSPRK63ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    α40 = T(0.476769811285196)
+    α41 = T(0.098511733286064)
+    α43 = T(0.424718455428740)
+    α62 = T(0.155221702560091)
+    α65 = T(0.844778297439909)
+    β10 = T(0.284220721334261)
+    β21 = T(0.284220721334261)
+    β32 = T(0.284220721334261)
+    β43 = T(0.120713785765930)
+    β54 = T(0.284220721334261)
+    β65 = T(0.240103497065900)
+    c1 = T2(0.284220721334261)
+    c2 = T2(0.568441442668522)
+    c3 = T2(0.852662164002783)
+    c4 = T2(0.510854218958172)
+    c5 = T2(0.795074940292433)
+
+    new{T,T2}(α40, α41, α43, α62, α65, β10, β21, β32, β43, β54, β65, c1, c2, c3, c4, c5)
+  end
 end
 
 function alg_cache(alg::SSPRK63,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
@@ -167,44 +173,12 @@ function alg_cache(alg::SSPRK63,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   u₂ = similar(u)
   k = zero(rate_prototype)
   fsalfirst = zero(rate_prototype)
-  α40 = 0.476769811285196
-  α41 = 0.098511733286064
-  α43 = 0.424718455428740
-  α62 = 0.155221702560091
-  α65 = 0.844778297439909
-  β10 = 0.284220721334261
-  β21 = 0.284220721334261
-  β32 = 0.284220721334261
-  β43 = 0.120713785765930
-  β54 = 0.284220721334261
-  β65 = 0.240103497065900
-  c1 = 0.284220721334261
-  c2 = 0.568441442668522
-  c3 = 0.852662164002783
-  c4 = 0.510854218958172
-  c5 = 0.795074940292433
-  SSPRK63Cache(u,uprev,k,tmp,u₂,fsalfirst,alg.stage_limiter!,alg.step_limiter!,
-                α40,α41,α43,α62,α65,β10,β21,β32,β43,β54,β65,c1,c2,c3,c4,c5)
+  tab = SSPRK63ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  SSPRK63Cache(u,uprev,k,tmp,u₂,fsalfirst,alg.stage_limiter!,alg.step_limiter!,tab)
 end
 
 function alg_cache(alg::SSPRK63,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  α40 = 0.476769811285196
-  α41 = 0.098511733286064
-  α43 = 0.424718455428740
-  α62 = 0.155221702560091
-  α65 = 0.844778297439909
-  β10 = 0.284220721334261
-  β21 = 0.284220721334261
-  β32 = 0.284220721334261
-  β43 = 0.120713785765930
-  β54 = 0.284220721334261
-  β65 = 0.240103497065900
-  c1 = 0.284220721334261
-  c2 = 0.568441442668522
-  c3 = 0.852662164002783
-  c4 = 0.510854218958172
-  c5 = 0.795074940292433
-  SSPRK63ConstantCache(α40,α41,α43,α62,α65,β10,β21,β32,β43,β54,β65,c1,c2,c3,c4,c5)
+  SSPRK63ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
 

--- a/src/caches/ssprk_caches.jl
+++ b/src/caches/ssprk_caches.jl
@@ -48,7 +48,7 @@ end
 alg_cache(alg::SSPRK33,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = SSPRK33ConstantCache()
 
 
-struct SSPRK53Cache{uType,rateType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMutableCache
+struct SSPRK53Cache{uType,rateType,StageLimiter,StepLimiter,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
@@ -56,84 +56,60 @@ struct SSPRK53Cache{uType,rateType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMu
   fsalfirst::rateType
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
-  α30::Float64
-  α32::Float64
-  α40::Float64
-  α43::Float64
-  α52::Float64
-  α54::Float64
-  β10::Float64
-  β21::Float64
-  β32::Float64
-  β43::Float64
-  β54::Float64
-  c1::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
+  tab::TabType
 end
 
 u_cache(c::SSPRK53Cache) = (c.tmp,)
 du_cache(c::SSPRK53Cache) = (c.k,c.fsalfirst)
 
-struct SSPRK53ConstantCache <: OrdinaryDiffEqConstantCache
-  α30::Float64
-  α32::Float64
-  α40::Float64
-  α43::Float64
-  α52::Float64
-  α54::Float64
-  β10::Float64
-  β21::Float64
-  β32::Float64
-  β43::Float64
-  β54::Float64
-  c1::Float64
-  c2::Float64
-  c3::Float64
-  c4::Float64
+struct SSPRK53ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  α30::T
+  α32::T
+  α40::T
+  α43::T
+  α52::T
+  α54::T
+  β10::T
+  β21::T
+  β32::T
+  β43::T
+  β54::T
+  c1::T2
+  c2::T2
+  c3::T2
+  c4::T2
+
+  function SSPRK53ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    α30 = T(0.355909775063327)
+    α32 = T(0.644090224936674)
+    α40 = T(0.367933791638137)
+    α43 = T(0.632066208361863)
+    α52 = T(0.237593836598569)
+    α54 = T(0.762406163401431)
+    β10 = T(0.377268915331368)
+    β21 = T(0.377268915331368)
+    β32 = T(0.242995220537396)
+    β43 = T(0.238458932846290)
+    β54 = T(0.287632146308408)
+    c1 = T2(0.377268915331368)
+    c2 = T2(0.754537830662736)
+    c3 = T2(0.728985661612188)
+    c4 = T2(0.699226135931670)
+
+    new{T,T2}(α30, α32, α40, α43, α52, α54, β10, β21, β32, β43, β54, c1, c2, c3, c4)
+  end
 end
 
 function alg_cache(alg::SSPRK53,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u)
   k = zero(rate_prototype)
   fsalfirst = zero(rate_prototype)
-  α30 = 0.355909775063327
-  α32 = 0.644090224936674
-  α40 = 0.367933791638137
-  α43 = 0.632066208361863
-  α52 = 0.237593836598569
-  α54 = 0.762406163401431
-  β10 = 0.377268915331368
-  β21 = 0.377268915331368
-  β32 = 0.242995220537396
-  β43 = 0.238458932846290
-  β54 = 0.287632146308408
-  c1 = 0.377268915331368
-  c2 = 0.754537830662736
-  c3 = 0.728985661612188
-  c4 = 0.699226135931670
-  SSPRK53Cache(u,uprev,k,tmp,fsalfirst,alg.stage_limiter!,alg.step_limiter!,
-                α30,α32,α40,α43,α52,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4)
+  tab = SSPRK53ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  SSPRK53Cache(u,uprev,k,tmp,fsalfirst,alg.stage_limiter!,alg.step_limiter!,tab)
 end
 
 function alg_cache(alg::SSPRK53,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  α30 = 0.355909775063327
-  α32 = 0.644090224936674
-  α40 = 0.367933791638137
-  α43 = 0.632066208361863
-  α52 = 0.237593836598569
-  α54 = 0.762406163401431
-  β10 = 0.377268915331368
-  β21 = 0.377268915331368
-  β32 = 0.242995220537396
-  β43 = 0.238458932846290
-  β54 = 0.287632146308408
-  c1 = 0.377268915331368
-  c2 = 0.754537830662736
-  c3 = 0.728985661612188
-  c4 = 0.699226135931670
-  SSPRK53ConstantCache(α30,α32,α40,α43,α52,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4)
+  SSPRK53ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
 

--- a/src/perform_step/fixed_timestep_perform_step.jl
+++ b/src/perform_step/fixed_timestep_perform_step.jl
@@ -368,7 +368,8 @@ end
 
 @muladd function perform_step!(integrator,cache::CarpenterKennedy2N54Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,fsalfirst,tmp,A2,A3,A4,A5,B1,B2,B3,B4,B5,c2,c3,c4,c5 = cache
+  @unpack k,fsalfirst,tmp = cache
+  @unpack A2,A3,A4,A5,B1,B2,B3,B4,B5,c2,c3,c4,c5 = cache.tab
 
   # u1
   @. tmp = dt*fsalfirst

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -696,7 +696,8 @@ end
 
 @muladd function perform_step!(integrator,cache::SSPRK54Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,k₃,u₂,u₃,tmp,fsalfirst,stage_limiter!,step_limiter!,β10,α20,α21,β21,α30,α32,β32,α40,α43,β43,α52,α53,β53,α54,β54,c1,c2,c3,c4 = cache
+  @unpack k,k₃,u₂,u₃,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
+  @unpack β10,α20,α21,β21,α30,α32,β32,α40,α43,β43,α52,α53,β53,α54,β54,c1,c2,c3,c4 = cache.tab
 
   # u₁
   @. u₂ = uprev + β10 * dt * integrator.fsalfirst

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -227,7 +227,8 @@ end
 
 @muladd function perform_step!(integrator,cache::SSPRK63Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,tmp,u₂,fsalfirst,stage_limiter!,step_limiter!,α40,α41,α43,α62,α65,β10,β21,β32,β43,β54,β65,c1,c2,c3,c4,c5 = cache
+  @unpack k,tmp,u₂,fsalfirst,stage_limiter!,step_limiter! = cache
+  @unpack α40,α41,α43,α62,α65,β10,β21,β32,β43,β54,β65,c1,c2,c3,c4,c5 = cache.tab
 
   # u1 -> stored as u
   @. u = uprev + β10 * dt * integrator.fsalfirst

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -400,7 +400,8 @@ end
 
 @muladd function perform_step!(integrator,cache::SSPRK83Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,tmp,u₂,u₃,fsalfirst,stage_limiter!,step_limiter!,α50,α51,α54,α61,α65,α72,α73,α76,β10,β21,β32,β43,β54,β65,β76,β87,c1,c2,c3,c4,c5,c6,c7 = cache
+  @unpack k,tmp,u₂,u₃,fsalfirst,stage_limiter!,step_limiter! = cache
+  @unpack α50,α51,α54,α61,α65,α72,α73,α76,β10,β21,β32,β43,β54,β65,β76,β87,c1,c2,c3,c4,c5,c6,c7 = cache.tab
 
   # u1 -> save as u
   @. u = uprev + β10 * dt * integrator.fsalfirst

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -310,7 +310,8 @@ end
 
 @muladd function perform_step!(integrator,cache::SSPRK73Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,tmp,u₁,fsalfirst,stage_limiter!,step_limiter!,α40,α43,α50,α51,α54,α73,α76,β10,β21,β32,β43,β54,β65,β76,c1,c2,c3,c4,c5,c6 = cache
+  @unpack k,tmp,u₁,fsalfirst,stage_limiter!,step_limiter! = cache
+  @unpack α40,α43,α50,α51,α54,α73,α76,β10,β21,β32,β43,β54,β65,β76,c1,c2,c3,c4,c5,c6 = cache.tab
 
   # u1
   @. u₁ = uprev + β10 * dt * integrator.fsalfirst

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -151,7 +151,8 @@ end
 
 @muladd function perform_step!(integrator,cache::SSPRK53Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack k,tmp,fsalfirst,stage_limiter!,step_limiter!,α30,α32,α40,α43,α52,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache
+  @unpack k,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
+  @unpack α30,α32,α40,α43,α52,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache.tab
 
   # u1
   @. tmp = uprev + β10 * dt * fsalfirst

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -65,9 +65,9 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 @test all(sol.u .>= 0)
 # test SSP property of dense output
 sol = solve(test_problem_ssp, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50))
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
 sol = solve(test_problem_ssp_inplace, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50))
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
 
 
 alg = SSPRK33()
@@ -90,9 +90,9 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 @test all(sol.u .>= 0)
 # test SSP property of dense output
 sol = solve(test_problem_ssp, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50))
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
 sol = solve(test_problem_ssp_inplace, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50))
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
 
 
 alg = SSPRK53()
@@ -186,9 +186,9 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 @test all(sol.u .>= 0)
 # test SSP property of dense output
 sol = solve(test_problem_ssp, alg, dt=8/5, adaptive=false)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50))
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
 sol = solve(test_problem_ssp_inplace, alg, dt=8/5, adaptive=false)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50))
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
 
 
 alg = SSPRK932()


### PR DESCRIPTION
Without these fixes, these methods can currently not be used with `CLArray`s.