### PR TITLE
Default `jac_prototype` in ExpRK caches

### DIFF
--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -219,7 +219,7 @@ function alg_cache_expRK(alg::ExponentialAlgorithm,u,uEltypeNoUnits,uprev,f,t,dt
   # Allocate cache for the Jacobian
   if isa(f, SplitFunction)
     J = nothing
-  elseif DiffEqBase.has_jac(f)
+  elseif DiffEqBase.has_jac(f) && f.jac_prototype != nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), n, n)
@@ -274,7 +274,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
   # Allocate cache for the Jacobian
   if isa(f, SplitFunction)
     J = nothing
-  elseif DiffEqBase.has_jac(f)
+  elseif DiffEqBase.has_jac(f) && f.jac_prototype != nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), n, n)
@@ -484,10 +484,13 @@ function alg_cache(alg::Exp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices
@@ -524,10 +527,13 @@ function alg_cache(alg::EPIRK4s3A,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices
@@ -563,10 +569,13 @@ function alg_cache(alg::EPIRK4s3B,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices
@@ -602,10 +611,13 @@ function alg_cache(alg::EPIRK5s3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices
@@ -640,10 +652,13 @@ function alg_cache(alg::EXPRB53s3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices
@@ -679,10 +694,13 @@ function alg_cache(alg::EPIRK5P1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices
@@ -719,10 +737,13 @@ function alg_cache(alg::EPIRK5P2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   if DiffEqBase.has_jac(f)
     uf = nothing
     jac_config = nothing
-    J = deepcopy(f.jac_prototype)
   else
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
+  end
+  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    J = deepcopy(f.jac_prototype)
+  else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
   end
   # Allocate matrices

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -2,9 +2,9 @@ using LinearAlgebra: axpy!
 
 # Helper function to compute the G_nj factors for the classical ExpRK methods
 @inline _compute_nl(f::SplitFunction, u, p, t, A) = f.f2(u, p, t)
-@inline _compute_nl(f::ODEFunction, u, p, t, A) = f(u, p, t) - A * u
+@inline _compute_nl(f, u, p, t, A) = f(u, p, t) - A * u
 @inline _compute_nl!(G, f::SplitFunction, u, p, t, A, Au_cache) = f.f2(G, u, p, t)
-@inline function _compute_nl!(G, f::ODEFunction, u, p, t, A, Au_cache)
+@inline function _compute_nl!(G, f, u, p, t, A, Au_cache)
   f(G, u, p, t)
   mul!(Au_cache, A, u)
   G .-= Au_cache

--- a/test/linear_nonlinear_krylov_tests.jl
+++ b/test/linear_nonlinear_krylov_tests.jl
@@ -118,3 +118,16 @@ end
     @test sol(1.0) ≈ exp_fun2.analytic(u0,nothing,1.0)
   end
 end
+
+@testset "ExpRK with default jacobian" begin
+  N = 10
+  Random.seed!(0); u0 = normalize(randn(N))
+  dd = -2 * ones(N); du = ones(N-1)
+  A = diagm(-1 => du, 0 => dd, 1 => du)
+  f = (du,u,p,t) -> mul!(du,A,u)
+  jac = (J,u,p,t) -> (J .= A; nothing)
+  exp_fun = ODEFunction(f; jac=jac, analytic=(u,p,t) -> exp(t*A)*u)
+  prob = ODEProblem(exp_fun, u0, (0.0,1.0))
+  sol = solve(prob, LawsonEuler(krylov=true, m=N); dt=0.1)
+  @test sol(1.0) ≈ exp_fun.analytic(u0,nothing,1.0)
+end


### PR DESCRIPTION
Fixes an issue where the Jacobian is not default initialized to a dense matrix if `has_jac(f) == true` but `f.jac_prototype == nothing` and added a regression test. Similar fixes have been applied to implicit methods before but ExpRK was left out.