### PR TITLE
use isapprox in tests instead of norm(.) < .; closes #387

### DIFF
--- a/test/complex_tests.jl
+++ b/test/complex_tests.jl
@@ -20,12 +20,12 @@ implicit_noautodiff = [ImplicitEuler(autodiff=false),Trapezoid(autodiff=false),K
     ψ0 = [1.0+0.0im; 0.0]
     prob = ODEProblem(f,ψ0,(-T,T))
     sol = solve(prob,alg)
-    @test abs(norm(sol(T)) - 1.0) < 1e-2
+    @test norm(sol(T)) ≈ 1 atol=1e-2
   end
   ψ0 = @SArray [1.0+0.0im; 0.0]
   prob = ODEProblem(fun,ψ0,(-T,T))
   sol = solve(prob,alg)
-  @test abs(norm(sol(T)) - 1.0) < 1e-2
+  @test norm(sol(T)) ≈ 1 atol=1e-2
 end
 
 @testset "Complex Tests on Implicit Autodiff Methods" for alg in implicit_autodiff
@@ -34,12 +34,12 @@ end
       ψ0 = [1.0+0.0im; 0.0]
       prob = ODEProblem(f,ψ0,(-T,T))
       sol = solve(prob,alg)
-      @test abs(norm(sol(T)) - 1.0) < 1e-2
+      @test norm(sol(T)) ≈ 1 atol=1e-2
     end
     ψ0 = @SArray [1.0+0.0im; 0.0]
     prob = ODEProblem(fun,ψ0,(-T,T))
     sol = solve(prob,alg)
-    @test abs(norm(sol(T)) - 1.0) < 1e-2
+    @test norm(sol(T)) ≈ 1 atol=1e-2
   end
 end
 
@@ -47,7 +47,7 @@ end
     ψ0 = [1.0+0.0im; 0.0]
     prob = ODEProblem(fun_inplace,ψ0,(-T,T))
     sol = solve(prob,alg)
-    @test abs(norm(sol(T)) - 1.0) < 1e-2
+    @test norm(sol(T)) ≈ 1 atol=1e-2
 end
 
 @testset "Complex Tests on Implicit Finite Diff Out-of-place Methods" begin
@@ -55,7 +55,7 @@ end
     ψ0 = [1.0+0.0im; 0.0]
     prob = ODEProblem(fun,ψ0,(-T,T))
     sol = solve(prob,alg)
-    @test abs(norm(sol(T)) - 1.0) < 1e-2
+    @test norm(sol(T)) ≈ 1 atol=1e-2
   end
 end
 
@@ -65,7 +65,7 @@ end
       ψ0 = @SArray [1.0+0.0im; 0.0]
       prob = ODEProblem(fun,ψ0,(-T,T))
       sol = solve(prob,alg)
-      @test abs(norm(sol(T)) - 1.0) < 1e-2
+      @test norm(sol(T)) ≈ 1 atol=1e-2
     end
   end
 end

--- a/test/linear_method_tests.jl
+++ b/test/linear_method_tests.jl
@@ -14,7 +14,7 @@ sol = solve(prob,LinearImplicitEuler())
 
 dts = 1./2.^(8:-1:4) #14->7 good plot
 sim  = test_convergence(dts,prob,LinearImplicitEuler())
-@test abs(sim.𝒪est[:l2]-1) < 0.2
+@test sim.𝒪est[:l2] ≈ 1 atol=0.2
 
 # using Plots; pyplot(); plot(sim)
 
@@ -76,4 +76,4 @@ x0,v0,ti = rand(3)
 prob = ODEProblem(H, [x0, v0, 1, ti], (ti, 5.))
 dts = 1./2.^(10:-1:1)
 sim  = test_convergence(dts,prob,MidpointSplitting())
-@test abs(sim.𝒪est[:l2]-2) < 0.2
+@test sim.𝒪est[:l2] ≈ 2 atol=0.2

--- a/test/linear_nonlinear_convergence_tests.jl
+++ b/test/linear_nonlinear_convergence_tests.jl
@@ -14,9 +14,9 @@ using OrdinaryDiffEq: alg_order
   for Alg in [GenericIIF1,GenericIIF2,LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4,Exprb32,Exprb43,ETD2,KenCarp3]
     sim  = test_convergence(dts,prob,Alg())
     if Alg in [Exprb32, Exprb43]
-      @test_broken abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.2
+      @test_broken sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.2
     else
-      @test abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.2
+      @test sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.2
     end
   end
   # Dense test
@@ -38,14 +38,14 @@ end
   for Alg in [GenericIIF1,GenericIIF2,LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4,Exprb32,Exprb43,ETD2,KenCarp3]
     sim  = test_convergence(dts,prob,Alg())
     if Alg in [Exprb32, Exprb43]
-      @test_broken abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.1
+      @test_broken sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.1
     else
-      @test abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.1
+      @test sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.1
     end
   end
   sim  = test_convergence(dts,prob,ETDRK4(),dense_errors=true)
-  @test abs(sim.𝒪est[:l2]-4) < 0.1
-  @test abs(sim.𝒪est[:L2]-4) < 0.1
+  @test sim.𝒪est[:l2] ≈  4 atol=0.1
+  @test sim.𝒪est[:L2] ≈ 4 atol=0.1
 end
 
 @testset "EPIRK Out-of-place" begin
@@ -65,9 +65,9 @@ end
   for Alg in Algs
     sim = analyticless_test_convergence(dts, prob, Alg(adaptive_krylov=false), test_setup)
     if Alg == EPIRK5s3
-      @test_broken abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.1
+      @test_broken sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.1
     else
-      @test abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.1
+      @test sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.1
     end
   end
 end
@@ -90,9 +90,9 @@ end
   for Alg in Algs
     sim = analyticless_test_convergence(dts, prob, Alg(adaptive_krylov=false), test_setup)
     if Alg == EPIRK5s3
-      @test_broken abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.1
+      @test_broken sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.1
     else
-      @test abs(sim.𝒪est[:l2] - alg_order(Alg())) < 0.1
+      @test sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.1
     end
   end
 end
@@ -113,11 +113,11 @@ end
   # Convergence simulation
   dts = 1 ./2 .^(7:-1:4)
   sim = analyticless_test_convergence(dts, prob, HochOst4(krylov=true), test_setup)
-  @test abs(sim.𝒪est[:l2] - 4) < 0.1
+  @test sim.𝒪est[:l2] ≈ 4 atol=0.1
   sim = analyticless_test_convergence(dts, prob_ip, HochOst4(krylov=true), test_setup)
-  @test abs(sim.𝒪est[:l2] - 4) < 0.1
+  @test sim.𝒪est[:l2] ≈ 4 atol=0.1
   sim = analyticless_test_convergence(dts, prob, EPIRK5P1(adaptive_krylov=false), test_setup)
-  @test abs(sim.𝒪est[:l2] - 5) < 0.1
+  @test sim.𝒪est[:l2] ≈ 5 atol=0.1
   sim = analyticless_test_convergence(dts, prob_ip, EPIRK5P1(adaptive_krylov=false), test_setup)
-  @test abs(sim.𝒪est[:l2] - 5) < 0.1
+  @test sim.𝒪est[:l2] ≈ 5 atol=0.1
 end

--- a/test/ode/nordsieck_tests.jl
+++ b/test/ode/nordsieck_tests.jl
@@ -9,9 +9,9 @@ dts = 1 .//(2 .^(10:-1:5))
 @testset "Nordsieck Convergence Tests" begin
   for i in eachindex(probArr)
     sim = test_convergence(dts,probArr[i],AN5())
-    @test abs(sim.𝒪est[:final]-5) < testTol
-    @test abs(sim.𝒪est[:l2]-5) < testTol
-    @test abs(sim.𝒪est[:l∞]-5) < testTol
+    @test sim.𝒪est[:final] ≈ 5 atol=testTol
+    @test sim.𝒪est[:l2] ≈ 5 atol=testTol
+    @test sim.𝒪est[:l∞] ≈ 5 atol=testTol
   end
 end
 
@@ -23,7 +23,7 @@ probArr = [prob_ode_linear,
     sol = solve(prob, AN5(), reltol=1e-6)
     @test length(sol.t) < 11
     exact = prob.f(Val{:analytic}, prob.u0, prob.p, prob.tspan[end])
-    @test Float64(norm(exact-sol[end])) < 1e-5
+    @test exact ≈ sol[end] atol=1e-5
   end
 end
 

--- a/test/ode/ode_convergence_tests.jl
+++ b/test/ode/ode_convergence_tests.jl
@@ -16,169 +16,169 @@ for i = 1:2
   global dts
   prob = probArr[i]
   sim = test_convergence(dts,prob,Euler())
-  @test abs(sim.𝒪est[:final]-1) < testTol
+  @test sim.𝒪est[:final] ≈ 1 atol=testTol
   sim2 = test_convergence(dts,prob,Heun())
-  @test abs(sim2.𝒪est[:l∞]-2) < testTol
+  @test sim2.𝒪est[:l∞] ≈ 2 atol=testTol
   sim2 = test_convergence(dts,prob,Ralston())
-  @test abs(sim2.𝒪est[:l∞]-2) < testTol
+  @test sim2.𝒪est[:l∞] ≈ 2 atol=testTol
   sim2 = test_convergence(dts,prob,Midpoint())
-  @test abs(sim2.𝒪est[:l∞]-2) < testTol
+  @test sim2.𝒪est[:l∞] ≈ 2 atol=testTol
   sim3 = test_convergence(dts,prob,RK4())
-  @test abs(sim3.𝒪est[:l∞]-4) < testTol
+  @test sim3.𝒪est[:l∞] ≈ 4 atol=testTol
   sim4 = test_convergence(dts,prob,BS3())
-  @test abs(sim4.𝒪est[:l2]-3) < testTol
+  @test sim4.𝒪est[:l2] ≈ 3 atol=testTol
   alg = CarpenterKennedy2N54()
-  @test abs(test_convergence(dts,prob,alg).𝒪est[:l∞]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test test_convergence(dts,prob,alg).𝒪est[:l∞] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
   sim5 = test_convergence(dts, prob, AB3())
-  @test abs(sim5.𝒪est[:l2]-3) < testTol
+  @test sim5.𝒪est[:l2] ≈ 3 atol=testTol
   sim6 = test_convergence(dts,prob,ABM32())
-  @test abs(sim6.𝒪est[:l2]-3) < testTol
+  @test sim6.𝒪est[:l2] ≈ 3 atol=testTol
   sim7 = test_convergence(dts, prob, AB4())
-  @test abs(sim7.𝒪est[:l2]-4) < testTol
+  @test sim7.𝒪est[:l2] ≈ 4 atol=testTol
   sim8 = test_convergence(dts1,prob,ABM43())  #using dts1 due to floating point error in convergence test
-  @test abs(sim8.𝒪est[:l2]-4) < testTol
+  @test sim8.𝒪est[:l2] ≈ 4 atol=testTol
   sim9 = test_convergence(dts,prob,AB5())
-  @test abs(sim9.𝒪est[:l2]-5) < testTol
+  @test sim9.𝒪est[:l2] ≈ 5 atol=testTol
   sim10 = test_convergence(dts,prob,ABM54())
-  @test abs(sim10.𝒪est[:l2]-5) < testTol
+  @test sim10.𝒪est[:l2] ≈ 5 atol=testTol
   sim101 = test_convergence(dts,prob,VCAB3())
-  @test abs(sim101.𝒪est[:l2]-3) < testTol
+  @test sim101.𝒪est[:l2] ≈ 3 atol=testTol
   sim102 = test_convergence(dts,prob,VCAB4())
-  @test abs(sim102.𝒪est[:l2]-4) < testTol
+  @test sim102.𝒪est[:l2] ≈ 4 atol=testTol
   sim103 = test_convergence(dts,prob,VCAB5())
-  @test abs(sim103.𝒪est[:l2]-5) < testTol
+  @test sim103.𝒪est[:l2] ≈ 5 atol=testTol
   sim104 = test_convergence(dts,prob,VCABM3())
-  @test abs(sim104.𝒪est[:l2]-3) < testTol
+  @test sim104.𝒪est[:l2] ≈ 3 atol=testTol
   sim105 = test_convergence(dts,prob,VCABM4())
-  @test abs(sim105.𝒪est[:l2]-4) < testTol
+  @test sim105.𝒪est[:l2] ≈ 4 atol=testTol
   sim106 = test_convergence(dts,prob,VCABM5())
-  @test abs(sim106.𝒪est[:l2]-5) < testTol
+  @test sim106.𝒪est[:l2] ≈ 5 atol=testTol
   sim160 = test_convergence(dts,prob,Anas5(w=2))
-  @test abs(sim160.𝒪est[:l2]-4) < 2*testTol
+  @test sim160.𝒪est[:l2] ≈ 4 atol=2*testTol
 
   println("Stiff Solvers")
 
   dts = 1 .//2 .^(9:-1:5)
 
   sim11 = test_convergence(dts,prob,ImplicitEuler(extrapolant = :linear))
-  @test abs(sim11.𝒪est[:final]-1) < testTol
+  @test sim11.𝒪est[:final] ≈ 1 atol=testTol
 
   sim112 = test_convergence(dts,prob,ImplicitEuler(nlsolve = NLFunctional()))
-  @test abs(sim112.𝒪est[:final]-1) < testTol
+  @test sim112.𝒪est[:final] ≈ 1 atol=testTol
 
   sim12 = test_convergence(dts,prob,
           GenericImplicitEuler(nlsolve=OrdinaryDiffEq.NLSOLVEJL_SETUP(autodiff=true)))
-  @test abs(sim12.𝒪est[:final]-1) < testTol
+  @test sim12.𝒪est[:final] ≈ 1 atol=testTol
 
   sim122 = test_convergence(dts,prob,
            GenericImplicitEuler(nlsolve=OrdinaryDiffEq.NLSOLVEJL_SETUP(autodiff=false)))
 
   sim13 = test_convergence(dts,prob,ImplicitMidpoint())
-  @test abs(sim13.𝒪est[:final]-2) < testTol
+  @test sim13.𝒪est[:final] ≈ 2 atol=testTol
 
   sim132 = test_convergence(dts,prob,ImplicitMidpoint(nlsolve = NLFunctional()))
-  @test abs(sim132.𝒪est[:final]-2) < testTol
+  @test sim132.𝒪est[:final] ≈ 2 atol=testTol
 
   sim13 = test_convergence(dts,prob,Trapezoid())
-  @test abs(sim13.𝒪est[:final]-2) < testTol
+  @test sim13.𝒪est[:final] ≈ 2 atol=testTol
 
   sim133 = test_convergence(dts,prob,Trapezoid(nlsolve = NLFunctional()))
-  @test abs(sim133.𝒪est[:final]-2) < testTol
+  @test sim133.𝒪est[:final] ≈ 2 atol=testTol
 
   sim14 = test_convergence(dts,prob,
           GenericTrapezoid(nlsolve=OrdinaryDiffEq.NLSOLVEJL_SETUP(autodiff=true)))
-  @test abs(sim14.𝒪est[:final]-2) < testTol
+  @test sim14.𝒪est[:final] ≈ 2 atol=testTol
 
   sim142 = test_convergence(dts,prob,
            GenericTrapezoid(nlsolve=OrdinaryDiffEq.NLSOLVEJL_SETUP(autodiff=false)))
-  @test abs(sim142.𝒪est[:final]-2) < testTol
+  @test sim142.𝒪est[:final] ≈ 2 atol=testTol
 
   sim14 = test_convergence(dts,prob,TRBDF2())
-  @test abs(sim14.𝒪est[:final]-2) < testTol
+  @test sim14.𝒪est[:final] ≈ 2 atol=testTol
 
   sim152 = test_convergence(dts,prob,TRBDF2(autodiff=false))
-  @test abs(sim152.𝒪est[:final]-2) < testTol+0.1
+  @test sim152.𝒪est[:final] ≈ 2 atol=testTol+0.1
 
   sim15 = test_convergence(dts,prob,SDIRK2())
-  @test abs(sim15.𝒪est[:final]-2) < testTol
+  @test sim15.𝒪est[:final] ≈ 2 atol=testTol
 
   sim152 = test_convergence(dts,prob,SSPSDIRK2())
-  @test abs(sim152.𝒪est[:final]-2) < testTol
+  @test sim152.𝒪est[:final] ≈ 2 atol=testTol
 
   sim16 = test_convergence(dts,prob,Kvaerno3())
-  @test abs(sim16.𝒪est[:final]-3) < testTol
+  @test sim16.𝒪est[:final] ≈ 3 atol=testTol
 
   sim162 = test_convergence(dts,prob,Kvaerno3(nlsolve = NLFunctional()))
-  @test abs(sim162.𝒪est[:final]-3) < testTol
+  @test sim162.𝒪est[:final] ≈ 3 atol=testTol
 
   sim17 = test_convergence(dts,prob,KenCarp3())
-  @test abs(sim17.𝒪est[:final]-3) < testTol
+  @test sim17.𝒪est[:final] ≈ 3 atol=testTol
 
   #####################################
   # BDF
   #####################################
 
   sim = test_convergence(dts,prob,ABDF2(extrapolant = :linear))
-  @test abs(sim.𝒪est[:final]-2) < testTol
-  @test abs(sim.𝒪est[:l2]-2) < testTol
-  @test abs(sim.𝒪est[:l∞]-2) < testTol
+  @test sim.𝒪est[:final] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
   sim = test_convergence(dts,prob,ABDF2(nlsolve = NLFunctional()))
-  @test abs(sim.𝒪est[:final]-2) < testTol
-  @test abs(sim.𝒪est[:l2]-2) < testTol
-  @test abs(sim.𝒪est[:l∞]-2) < testTol
+  @test sim.𝒪est[:final] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
   # QBDF
   sim = test_convergence(dts,prob,QBDF1())
-  @test abs(sim.𝒪est[:final]-1) < testTol
-  @test abs(sim.𝒪est[:l2]-1) < testTol
-  @test abs(sim.𝒪est[:l∞]-1) < testTol
+  @test sim.𝒪est[:final] ≈ 1 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 1 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
   sim = test_convergence(dts,prob,QBDF2())
-  @test abs(sim.𝒪est[:final]-2) < testTol
-  @test abs(sim.𝒪est[:l2]-2) < testTol
-  @test abs(sim.𝒪est[:l∞]-2) < testTol
+  @test sim.𝒪est[:final] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
   # QNDF
   sim = test_convergence(dts,prob,QNDF1())
-  @test abs(sim.𝒪est[:final]-1) < testTol
-  @test abs(sim.𝒪est[:l2]-1) < testTol
-  @test abs(sim.𝒪est[:l∞]-1) < testTol
+  @test sim.𝒪est[:final] ≈ 1 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 1 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
   sim = test_convergence(dts,prob,QNDF2())
-  @test abs(sim.𝒪est[:final]-2) < testTol
-  @test abs(sim.𝒪est[:l2]-2) < testTol
-  @test abs(sim.𝒪est[:l∞]-2) < testTol
+  @test sim.𝒪est[:final] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
   sim = test_convergence(dts,prob,QNDF2(nlsolve = NLFunctional()))
-  @test abs(sim.𝒪est[:final]-2) < testTol
-  @test abs(sim.𝒪est[:l2]-2) < testTol
-  @test abs(sim.𝒪est[:l∞]-2) < testTol
+  @test sim.𝒪est[:final] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l2] ≈ 2 atol=testTol
+  @test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
   dts = 1 .//2 .^(7:-1:4)
   println("Higher Order")
 
   sim18 = test_convergence(dts,prob,Cash4())
-  @test abs(sim18.𝒪est[:final]-4) < testTol
+  @test sim18.𝒪est[:final] ≈ 4 atol=testTol
 
   sim19 = test_convergence(dts,prob,Hairer4())
-  @test abs(sim19.𝒪est[:final]-4) < testTol
+  @test sim19.𝒪est[:final] ≈ 4 atol=testTol
 
   sim110 = test_convergence(dts,prob,Hairer42())
-  @test abs(sim110.𝒪est[:final]-4) < testTol
+  @test sim110.𝒪est[:final] ≈ 4 atol=testTol
 
   sim111 = test_convergence(dts,prob,Kvaerno4())
-  @test abs(sim111.𝒪est[:final]-4) < testTol
+  @test sim111.𝒪est[:final] ≈ 4 atol=testTol
 
   sim112 = test_convergence(dts,prob,KenCarp4())
-  @test abs(sim112.𝒪est[:final]-4) < testTol
+  @test sim112.𝒪est[:final] ≈ 4 atol=testTol
 
   sim113 = test_convergence(dts,prob,Kvaerno5())
-  @test abs(sim113.𝒪est[:final]-5) < testTol
+  @test sim113.𝒪est[:final] ≈ 5 atol=testTol
 
   sim114 = test_convergence(dts,prob,KenCarp5())
-  @test abs(sim114.𝒪est[:final]-5) < testTol
+  @test sim114.𝒪est[:final] ≈ 5 atol=testTol
 
   sim115 = test_convergence(dts,prob,KenCarp5(nlsolve = NLFunctional()))
-  @test_broken abs(sim115.𝒪est[:final]-5) < testTol
+  @test_broken sim115.𝒪est[:final] ≈ 5 atol=testTol
 end

--- a/test/ode/ode_rosenbrock_tests.jl
+++ b/test/ode/ode_rosenbrock_tests.jl
@@ -14,7 +14,7 @@ testTol = 0.2
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Rosenbrock23())
-@test abs(sim.𝒪est[:final]-2) < testTol
+@test sim.𝒪est[:final] ≈ 2 atol=testTol
 
 sol = solve(prob,Rosenbrock23())
 @test length(sol) < 20
@@ -22,7 +22,7 @@ sol = solve(prob,Rosenbrock23())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Rosenbrock23())
-@test abs(sim.𝒪est[:final]-2) < testTol
+@test sim.𝒪est[:final] ≈ 2 atol=testTol
 
 sol = solve(prob,Rosenbrock23())
 @test length(sol) < 20
@@ -30,7 +30,7 @@ sol = solve(prob,Rosenbrock23())
 prob = prob_ode_bigfloat2Dlinear
 
 sim = test_convergence(dts,prob,Rosenbrock23(linsolve=LinSolveFactorize(qr!)))
-@test abs(sim.𝒪est[:final]-2) < testTol
+@test sim.𝒪est[:final] ≈ 2 atol=testTol
 
 sol = solve(prob,Rosenbrock23(linsolve=LinSolveFactorize(qr!)))
 @test length(sol) < 20
@@ -40,7 +40,7 @@ sol = solve(prob,Rosenbrock23(linsolve=LinSolveFactorize(qr!)))
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Rosenbrock32())
-@test abs(sim.𝒪est[:final]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
 
 sol = solve(prob,Rosenbrock32())
 @test length(sol) < 20
@@ -48,7 +48,7 @@ sol = solve(prob,Rosenbrock32())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Rosenbrock32())
-@test abs(sim.𝒪est[:final]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
 
 sol = solve(prob,Rosenbrock32())
 @test length(sol) < 20
@@ -58,7 +58,7 @@ sol = solve(prob,Rosenbrock32())
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,ROS3P())
-@test abs(sim.𝒪est[:final]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
 
 sol = solve(prob,ROS3P())
 @test length(sol) < 20
@@ -66,7 +66,7 @@ sol = solve(prob,ROS3P())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,ROS3P())
-@test abs(sim.𝒪est[:final]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
 
 sol = solve(prob,ROS3P())
 @test length(sol) < 20
@@ -76,7 +76,7 @@ sol = solve(prob,ROS3P())
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Rodas3())
-@test abs(sim.𝒪est[:final]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
 
 sol = solve(prob,Rodas3())
 @test length(sol) < 20
@@ -84,7 +84,7 @@ sol = solve(prob,Rodas3())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Rodas3())
-@test abs(sim.𝒪est[:final]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
 
 sol = solve(prob,Rodas3())
 @test length(sol) < 20
@@ -96,7 +96,7 @@ println("4th order Rosenbrocks")
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,RosShamp4())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,RosShamp4())
 @test length(sol) < 20
@@ -104,7 +104,7 @@ sol = solve(prob,RosShamp4())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,RosShamp4())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,RosShamp4())
 @test length(sol) < 20
@@ -114,7 +114,7 @@ sol = solve(prob,RosShamp4())
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Veldd4())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,Veldd4())
 @test length(sol) < 20
@@ -122,7 +122,7 @@ sol = solve(prob,Veldd4())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Veldd4())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,Veldd4())
 @test length(sol) < 20
@@ -132,7 +132,7 @@ sol = solve(prob,Veldd4())
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Velds4())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,Velds4())
 @test length(sol) < 20
@@ -140,7 +140,7 @@ sol = solve(prob,Velds4())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Velds4())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,Velds4())
 @test length(sol) < 20
@@ -150,7 +150,7 @@ sol = solve(prob,Velds4())
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,GRK4T())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,GRK4T())
 @test length(sol) < 20
@@ -158,7 +158,7 @@ sol = solve(prob,GRK4T())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,GRK4T())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,GRK4T())
 @test length(sol) < 20
@@ -169,7 +169,7 @@ dts = (1/2) .^ (7:-1:4)
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,GRK4A())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,GRK4A())
 @test length(sol) < 20
@@ -177,7 +177,7 @@ sol = solve(prob,GRK4A())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,GRK4A())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,GRK4A())
 @test length(sol) < 20
@@ -187,7 +187,7 @@ sol = solve(prob,GRK4A())
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Ros4LStab())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,Ros4LStab())
 @test length(sol) < 20
@@ -195,7 +195,7 @@ sol = solve(prob,Ros4LStab())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Ros4LStab())
-@test abs(sim.𝒪est[:final]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
 
 sol = solve(prob,Ros4LStab())
 @test length(sol) < 20
@@ -209,29 +209,29 @@ dts = (1/2) .^ (7:-1:4)
 prob = prob_ode_linear
 
 sim = test_convergence(dts,prob,Rodas4(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4())
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas4(autodiff=false),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4(autodiff=false))
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas42(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-5) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 5 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas42())
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas4P(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4P())
 @test length(sol) < 20
@@ -239,8 +239,8 @@ sol = solve(prob,Rodas4P())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Rodas4(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4())
 @test length(sol) < 20
@@ -248,38 +248,38 @@ sol = solve(prob,Rodas4())
 println("Rodas4 with finite diff")
 
 sim = test_convergence(dts,prob,Rodas4(autodiff=false),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4(autodiff=false))
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas4(autodiff=false,
                        diff_type=Val{:forward}),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4(autodiff=false,diff_type=Val{:forward}))
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas4(autodiff=false,
                        diff_type=Val{:complex}),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4(autodiff=false,diff_type=Val{:complex}))
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas42(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-5) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 5 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas42())
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,Rodas4P(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas4P())
 @test length(sol) < 20
@@ -291,8 +291,8 @@ prob = prob_ode_linear
 
 dts = (1/2) .^ (7:-1:3)
 sim = test_convergence(dts,prob,Rodas5(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-5) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 5 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas5())
 @test length(sol) < 20
@@ -300,8 +300,8 @@ sol = solve(prob,Rodas5())
 prob = prob_ode_2Dlinear
 
 sim = test_convergence(dts,prob,Rodas5(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-5) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 5 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 
 sol = solve(prob,Rodas5())
 @test length(sol) < 20

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -50,15 +50,15 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg)+1
 alg = SSPRK22()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -79,11 +79,11 @@ for prob in test_problems_only_time
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -98,15 +98,15 @@ sol = solve(test_problem_ssp_inplace, alg, dt=1.)
 alg = SSPRK53()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -116,15 +116,15 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 alg = SSPRK63()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -134,15 +134,15 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 alg = SSPRK73()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -152,15 +152,15 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 alg = SSPRK83()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -175,11 +175,11 @@ for prob in test_problems_only_time
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
@@ -194,15 +194,15 @@ sol = solve(test_problem_ssp_inplace, alg, dt=8/5, adaptive=false)
 alg = SSPRK932()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false,maxiters=1e7)
@@ -217,7 +217,7 @@ for prob in test_problems_only_time
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
@@ -232,15 +232,15 @@ sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), 
 alg = SSPRK104()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_linear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
-  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)

--- a/test/ode/rkc_tests.jl
+++ b/test/ode/rkc_tests.jl
@@ -25,7 +25,7 @@ end
   dts = 1 .//2 .^(8:-1:4)
   testTol = 0.1
   for prob in probArr
-    sim2 = test_convergence(dts,prob,ROCK2())
-    @test abs(sim2.𝒪est[:l∞]-2) < testTol
+    sim = test_convergence(dts,prob,ROCK2())
+    @test sim.𝒪est[:l∞] ≈ 2 atol=testTol
   end
 end

--- a/test/owrenzen_tests.jl
+++ b/test/owrenzen_tests.jl
@@ -18,14 +18,14 @@ sol = solve(prob,OwrenZen5())
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,OwrenZen3(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-3) < testTol
-@test abs(sim.𝒪est[:L2]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
+@test sim.𝒪est[:L2] ≈ 3 atol=testTol
 sim = test_convergence(dts,prob,OwrenZen4(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 sim = test_convergence(dts,prob,OwrenZen5(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-5) < testTol
-@test abs(sim.𝒪est[:L2]-5) < testTol
+@test sim.𝒪est[:final] ≈ 5 atol=testTol
+@test sim.𝒪est[:L2] ≈ 5 atol=testTol
 
 prob = prob_ode_2Dlinear
 sol = solve(prob,OwrenZen3())
@@ -36,11 +36,11 @@ sol = solve(prob,OwrenZen5())
 @test length(sol) < 20
 
 sim = test_convergence(dts,prob,OwrenZen3(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-3) < testTol
-@test abs(sim.𝒪est[:L2]-3) < testTol
+@test sim.𝒪est[:final] ≈ 3 atol=testTol
+@test sim.𝒪est[:L2] ≈ 3 atol=testTol
 sim = test_convergence(dts,prob,OwrenZen4(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-4) < testTol
-@test abs(sim.𝒪est[:L2]-4) < testTol
+@test sim.𝒪est[:final] ≈ 4 atol=testTol
+@test sim.𝒪est[:L2] ≈ 4 atol=testTol
 sim = test_convergence(dts,prob,OwrenZen5(),dense_errors=true)
-@test abs(sim.𝒪est[:final]-5) < testTol
-@test abs(sim.𝒪est[:L2]-5) < testTol
+@test sim.𝒪est[:final] ≈ 5 atol=testTol
+@test sim.𝒪est[:L2] ≈ 5 atol=testTol

--- a/test/split_methods_tests.jl
+++ b/test/split_methods_tests.jl
@@ -49,52 +49,52 @@ prob = SplitODEProblem(ff_split,1.0,(0.0,1.0))
 sol = solve(prob,KenCarp3())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp3(nlsolve=NLFunctional()))
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp4())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp4())
-@test abs(sim.𝒪est[:l∞]-4) < testTol
+@test sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 sol = solve(prob,KenCarp5())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp5())
-@test abs(sim.𝒪est[:l∞]-5) < testTol
+@test sim.𝒪est[:l∞] ≈ 5 atol=testTol
 
 # IMEXEuler
 dts = 1 .//2 .^(8:-1:4)
-sim1 = test_convergence(dts,prob,IMEXEuler())
-@test abs(sim1.𝒪est[:l∞]-1) < testTol
+sim = test_convergence(dts,prob,IMEXEuler())
+@test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
 # CNAB2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNAB2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # CNLF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNLF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF3
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF3())
-@test_broken abs(sim.𝒪est[:l∞]-3) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 # SBDF4
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF4())
-@test_broken abs(sim.𝒪est[:l∞]-4) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 # Now test only the second part
 
@@ -107,47 +107,47 @@ prob = SplitODEProblem(ff_split2,1.0,(0.0,1.0))
 sol = solve(prob,KenCarp3())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp4())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp4())
-@test abs(sim.𝒪est[:l∞]-4) < testTol
+@test sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 sol = solve(prob,KenCarp5())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp5())
-@test abs(sim.𝒪est[:l∞]-5) < testTol
+@test sim.𝒪est[:l∞] ≈ 5 atol=testTol
 
 # IMEXEuler
 dts = 1 .//2 .^(8:-1:4)
-sim2 = test_convergence(dts,prob,IMEXEuler())
-@test abs(sim2.𝒪est[:l∞]-1) < testTol
+sim = test_convergence(dts,prob,IMEXEuler())
+@test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
 # CNAB2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNAB2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # CNLF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNLF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF3
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF3())
-@test_broken abs(sim.𝒪est[:l∞]-3) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 # SBDF4
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF4())
-@test_broken abs(sim.𝒪est[:l∞]-4) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 # Test together
 
@@ -160,47 +160,47 @@ prob = SplitODEProblem(ff_split3,1.0,(0.0,1.0))
 sol = solve(prob,KenCarp3())
 dts = 1 .//2 .^(12:-1:8)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp4())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp4())
-@test abs(sim.𝒪est[:l∞]-4) < testTol
+@test sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 sol = solve(prob,KenCarp5())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp5())
-@test abs(sim.𝒪est[:l∞]-5) < testTol
+@test sim.𝒪est[:l∞] ≈ 5 atol=testTol
 
 # IMEXEuler
 dts = 1 .//2 .^(8:-1:4)
-sim3 = test_convergence(dts,prob,IMEXEuler())
-@test abs(sim3.𝒪est[:l∞]-1) < testTol
+sim = test_convergence(dts,prob,IMEXEuler())
+@test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
 # CNAB2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNAB2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # CNLF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNLF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF3
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF3())
-@test_broken abs(sim.𝒪est[:l∞]-3) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 # SBDF4
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF4())
-@test_broken abs(sim.𝒪est[:l∞]-4) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 # Now test only the first part
 
@@ -213,37 +213,37 @@ prob = SplitODEProblem(ff_split4,rand(4,2),(0.0,1.0))
 sol = solve(prob,KenCarp3())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp4())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp4())
-@test abs(sim.𝒪est[:l∞]-4) < testTol
+@test sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 sol = solve(prob,KenCarp5())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp5())
-@test abs(sim.𝒪est[:l∞]-5) < testTol
+@test sim.𝒪est[:l∞] ≈ 5 atol=testTol
 
 # IMEXEuler
 dts = 1 .//2 .^(8:-1:4)
-sim1 = test_convergence(dts,prob,IMEXEuler())
-@test abs(sim1.𝒪est[:l∞]-1) < testTol
+sim = test_convergence(dts,prob,IMEXEuler())
+@test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
 # CNAB2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNAB2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # CNLF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNLF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF3
 dts = 1 .//2 .^(8:-1:4)
@@ -253,7 +253,7 @@ sim = test_convergence(dts,prob,SBDF3())
 # SBDF4
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF4())
-@test_broken abs(sim.𝒪est[:l∞]-4) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 # Now test only the second part
 
@@ -266,47 +266,47 @@ prob = SplitODEProblem(ff_split5,rand(4,2),(0.0,1.0))
 sol = solve(prob,KenCarp3())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp4())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp4())
-@test abs(sim.𝒪est[:l∞]-4) < testTol
+@test sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 sol = solve(prob,KenCarp5())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp5())
-@test abs(sim.𝒪est[:l∞]-5) < testTol
+@test sim.𝒪est[:l∞] ≈ 5 atol=testTol
 
 # IMEXEuler
 dts = 1 .//2 .^(8:-1:4)
-sim2 = test_convergence(dts,prob,IMEXEuler())
-@test abs(sim2.𝒪est[:l∞]-1) < testTol
+sim = test_convergence(dts,prob,IMEXEuler())
+@test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
 # CNAB2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNAB2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # CNLF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNLF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF3
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF3())
-@test_broken abs(sim.𝒪est[:l∞]-3) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 # SBDF4
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF4())
-@test_broken abs(sim.𝒪est[:l∞]-4) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 # Test together
 
@@ -319,44 +319,44 @@ prob = SplitODEProblem(ff_split6,rand(4,2),(0.0,1.0))
 sol = solve(prob,KenCarp3())
 dts = 1 .//2 .^(12:-1:8)
 sim = test_convergence(dts,prob,KenCarp3())
-@test abs(sim.𝒪est[:l∞]-3) < testTol
+@test sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 sol = solve(prob,KenCarp4())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp4())
-@test abs(sim.𝒪est[:l∞]-4) < testTol
+@test sim.𝒪est[:l∞] ≈ 4 atol=testTol
 
 sol = solve(prob,KenCarp5())
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,KenCarp5())
-@test abs(sim.𝒪est[:l∞]-5) < testTol
+@test sim.𝒪est[:l∞] ≈ 5 atol=testTol
 
 # IMEXEuler
 dts = 1 .//2 .^(8:-1:4)
-sim3 = test_convergence(dts,prob,IMEXEuler())
-@test abs(sim3.𝒪est[:l∞]-1) < testTol
+sim = test_convergence(dts,prob,IMEXEuler())
+@test sim.𝒪est[:l∞] ≈ 1 atol=testTol
 
 # CNAB2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNAB2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # CNLF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,CNLF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF2
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF2())
-@test abs(sim.𝒪est[:l∞]-2) < testTol
+@test sim.𝒪est[:l∞] ≈ 2 atol=testTol
 
 # SBDF3
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF3())
-@test_broken abs(sim.𝒪est[:l∞]-3) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 3 atol=testTol
 
 # SBDF4
 dts = 1 .//2 .^(8:-1:4)
 sim = test_convergence(dts,prob,SBDF4())
-@test_broken abs(sim.𝒪est[:l∞]-4) < testTol
+@test_broken sim.𝒪est[:l∞] ≈ 4 atol=testTol


### PR DESCRIPTION
I've also checked all other uses of some `norm` (`internalopnorm`, `internalnorm`, `opnorm) and everything seems to be fine, cf. #387.