### PR TITLE
`MArray` compatibility

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -28,7 +28,7 @@ module OrdinaryDiffEq
 
   # Required by temporary fix in not in-place methods with 12+ broadcasts
   # `MVector` is used by Nordsieck forms
-  import StaticArrays: SArray, MVector, SVector, @SVector
+  import StaticArrays: SArray, MArray, MVector, SVector, @SVector
 
   # Integrator Interface
   import DiffEqBase: resize!,deleteat!,addat!,full_cache,user_cache,u_cache,du_cache,

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -19,15 +19,16 @@
     f(f₀,u0,p,t)
   else
     # TODO: use more caches
-    f₀ = zero.(u0./t)
-    u0 isa MArray && (f₀ = MArray(f₀))
+    Tf = typeof(oneunit(eltype(u0))/oneunit(t))
+    f₀ = similar(u0,Tf)
     f(f₀,u0,p,t)
   end
 
   # TODO: use more caches
   #tmp = cache[2]
-  tmp = @. u0/sk
-  u0 isa MArray && (tmp = MArray(tmp))
+  Ttmp = typeof(oneunit(eltype(u0))/oneunit(eltype(sk)))
+  tmp = similar(u0,Ttmp)
+  @. tmp = u0/sk
 
   d₀ = internalnorm(tmp)
 

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -20,12 +20,14 @@
   else
     # TODO: use more caches
     f₀ = zero.(u0./t)
+    u0 isa MArray && (f₀ = MArray(f₀))
     f(f₀,u0,p,t)
   end
 
   # TODO: use more caches
   #tmp = cache[2]
   tmp = @. u0/sk
+  u0 isa MArray && (tmp = MArray(tmp))
 
   d₀ = internalnorm(tmp)
 

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -13,19 +13,22 @@
     sk = @. abstol+internalnorm(u0)*reltol
   end
 
+  # enforce array type of u0
+  UArray = typeof(u0).name.wrapper # T{Params}.name.wrapper == T
   if get_current_isfsal(integrator.alg, integrator.cache) && typeof(integrator) <: ODEIntegrator
     # Right now DelayDiffEq has issues with fsallast not being initialized
     f₀ = integrator.fsallast
     f(f₀,u0,p,t)
   else
-    f₀ = OrdinaryDiffEq.get_du(integrator)
+    f₀ = UArray(u0./t)
+    !(typeof(f₀) <: UArray) && (f₀ = UArray(tmp))
     f(f₀,u0,p,t)
   end
 
   # TODO: use more caches
   #tmp = cache[2]
-  tmp = similar(u0)
-  @. tmp = u0/sk
+  tmp = @. u0/sk
+  !(typeof(tmp) <: UArray) && (tmp = UArray(tmp))
 
   d₀ = internalnorm(tmp)
 

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -18,16 +18,13 @@
     f₀ = integrator.fsallast
     f(f₀,u0,p,t)
   else
-    # TODO: use more caches
-    Tf = typeof(oneunit(eltype(u0))/oneunit(t))
-    f₀ = similar(u0,Tf)
+    f₀ = OrdinaryDiffEq.get_du(integrator)
     f(f₀,u0,p,t)
   end
 
   # TODO: use more caches
   #tmp = cache[2]
-  Ttmp = typeof(oneunit(eltype(u0))/oneunit(eltype(sk)))
-  tmp = similar(u0,Ttmp)
+  tmp = similar(u0)
   @. tmp = u0/sk
 
   d₀ = internalnorm(tmp)

--- a/test/static_array_tests.jl
+++ b/test/static_array_tests.jl
@@ -7,6 +7,7 @@ f = (du,u,p,t) -> du .= u
 ode = ODEProblem(f, u0, (0.,1.))
 sol = solve(ode, Euler(), dt=1.e-2)
 sol = solve(ode, Tsit5())
+ode = ODEProblem(f, MVector{2}([1,2.]), (0.,1.))
 
 u0 = fill(zero(SVector{2,Float64}), 2) .+ 1
 u0[1] = ones(SVector{2,Float64}) .+ 1

--- a/test/static_array_tests.jl
+++ b/test/static_array_tests.jl
@@ -8,6 +8,7 @@ ode = ODEProblem(f, u0, (0.,1.))
 sol = solve(ode, Euler(), dt=1.e-2)
 sol = solve(ode, Tsit5())
 ode = ODEProblem(f, MVector{2}([1,2.]), (0.,1.))
+sol = solve(ode, Tsit5())
 
 u0 = fill(zero(SVector{2,Float64}), 2) .+ 1
 u0[1] = ones(SVector{2,Float64}) .+ 1


### PR DESCRIPTION
There is
```julia
    f₀ = zero.(u0./t)
    u0 isa MArray && (f₀ = MArray(f₀))
```
because broadcasting an `MArray` results an `SArray`.
```julia
julia> ode.u0
2-element MArray{Tuple{2},Float64,1,2}:
 1.0
 2.0

julia> ode.u0 ./ 1
2-element SArray{Tuple{2},Float64,1,2}:
 1.0
 2.0
```