### PR TITLE
Parameterize NLSolver

### DIFF
--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -922,7 +922,8 @@ function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev3 = u
   tprev2 = t
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//2,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//2, 1
+  @oopnlsolve
   CNAB2ConstantCache(k2,uf,nlsolve,uprev3,tprev2)
 end
 
@@ -936,7 +937,8 @@ function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev3 = similar(u)
   tprev2 = t
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//2,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//2, 1
+  @iipnlsolve
   CNAB2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
 end
 
@@ -983,7 +985,8 @@ function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev3 = u
   tprev2 = t
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//1,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//1, 1
+  @oopnlsolve
   CNLF2ConstantCache(k2,uf,nlsolve,uprev2,uprev3,tprev2)
 end
 
@@ -998,6 +1001,7 @@ function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev3 = similar(u)
   tprev2 = t
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//1,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//1, 1
+  @iipnlsolve
   CNLF2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
 end

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -9,7 +9,8 @@ end
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   @oopnlcachefields
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//1,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//1, 1
+  @oopnlsolve
   eulercache = ImplicitEulerConstantCache(uf,nlsolve)
   dtₙ₋₁ = one(dt)
   fsalfirstprev = rate_prototype
@@ -45,7 +46,8 @@ end
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   @iipnlcachefields
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//1,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//1, 1
+  @iipnlsolve
   atmp = similar(u,uEltypeNoUnits)
 
   fsalfirstprev = similar(rate_prototype)
@@ -115,7 +117,8 @@ function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   du₁ = rate_prototype
   du₂ = rate_prototype
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//1,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//1, 1
+  @oopnlsolve
   SBDFConstantCache(1,k2,uf,nlsolve,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
@@ -132,7 +135,8 @@ function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   du₁ = zero(rate_prototype)
   du₂ = zero(rate_prototype)
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,1//1,1,ηold,z₊,dz,tmp,b,k))
+  γ, c = 1//1, 1
+  @iipnlsolve
   SBDFCache(1,u,uprev,fsalfirst,k,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
@@ -184,7 +188,8 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   U = fill(zero(typeof(t)), 1, 1)
 
   U!(1,U)
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,zero(inv((1-alg.kappa))),1,ηold,z₊,dz,tmp,b,k))
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @oopnlsolve
 
   QNDF1ConstantCache(uf,nlsolve,D,D2,R,U,uprev2,dtₙ₋₁)
 end
@@ -205,7 +210,8 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   utilde = similar(u)
   uprev2 = similar(u)
   dtₙ₋₁ = one(dt)
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,zero(inv((1-alg.kappa))),1,ηold,z₊,dz,tmp,b,k))
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @iipnlsolve
 
   QNDF1Cache(uprev2,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
               W,uf,jac_config,linsolve,nlsolve,dtₙ₋₁)
@@ -266,7 +272,8 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   U!(2,U)
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,zero(inv((1-alg.kappa))),1,ηold,z₊,dz,tmp,b,k))
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @oopnlsolve
   QNDF2ConstantCache(uf,nlsolve,D,D2,R,U,uprev2,uprev3,dtₙ₋₁,dtₙ₋₂)
 end
 
@@ -289,7 +296,8 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   dtₙ₋₁ = zero(dt)
   dtₙ₋₂ = zero(dt)
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,zero(inv((1-alg.kappa))),1,ηold,z₊,dz,tmp,b,k))
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @iipnlsolve
   QNDF2Cache(uprev2,uprev3,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
              W,uf,jac_config,linsolve,nlsolve,dtₙ₋₁,dtₙ₋₂)
 end
@@ -352,7 +360,8 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
 
   max_order = 5
 
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,zero(eltype(alg.kappa)),1,ηold,z₊,dz,tmp,b,k))
+  γ, c = zero(inv((alg.kappa))), 1
+  @oopnlsolve
   QNDFConstantCache(uf,nlsolve,D,D2,R,U,1,max_order,udiff,dts,tmp,h,0)
 end
 
@@ -382,7 +391,8 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   max_order = 5
   atmp = similar(u,uEltypeNoUnits)
   utilde = similar(u)
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,zero(eltype(alg.kappa)),1,ηold,z₊,dz,tmp,b,k))
+  γ, c = zero(inv((alg.kappa))), 1
+  @iipnlsolve
 
   QNDFCache(du1,fsalfirst,k,z,dz,b,D,D2,R,U,1,max_order,udiff,dts,tmp,atmp,utilde,J,
             W,uf,jac_config,linsolve,nlsolve,h,0)

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -8,7 +8,8 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   @oopnlcachefields
   tab = KenCarp3Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @oopnlsolve
 
   KenCarp3ConstantCache(uf,nlsolve,tab)
 end
@@ -56,7 +57,8 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
   tab = KenCarp3Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   KenCarp3Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,k1,k2,k3,k4,dz,b,tmp,atmp,J,
                 W,uf,jac_config,linsolve,nlsolve,tab)
@@ -75,7 +77,8 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tprev2 = t
 
   tab = Kvaerno4Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @oopnlsolve
 
   Kvaerno4ConstantCache(uf,nlsolve,tab)
 end
@@ -112,7 +115,8 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   z₅ = z
   atmp = similar(u,uEltypeNoUnits)
   tab = Kvaerno4Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   Kvaerno4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
                 W,uf,jac_config,linsolve,nlsolve,tab)
@@ -130,7 +134,8 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   uprev3 = u
   tprev2 = t
   tab = KenCarp4Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @oopnlsolve
 
   KenCarp4ConstantCache(uf,nlsolve,tab)
 end
@@ -186,7 +191,8 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   end
 
   tab = KenCarp4Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   KenCarp4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,k1,k2,k3,k4,k5,k6,
                 dz,b,tmp,atmp,J,
@@ -203,7 +209,8 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   @oopnlcachefields
   tab = Kvaerno5Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @oopnlsolve
 
   Kvaerno5ConstantCache(uf,nlsolve,tab)
 end
@@ -243,7 +250,8 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   z₇ = z
   atmp = similar(u,uEltypeNoUnits)
   tab = Kvaerno5Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   Kvaerno5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,dz,b,tmp,atmp,J,
                 W,uf,jac_config,linsolve,nlsolve,tab)
@@ -259,7 +267,8 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   @oopnlcachefields
   tab = KenCarp5Tableau(uToltype,real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @oopnlsolve
 
   KenCarp5ConstantCache(uf,nlsolve,tab)
 end
@@ -322,7 +331,8 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   end
 
   tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
-  nlsolve = typeof(_nlsolve)(NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,tab.γ,tab.c3,ηold,z₊,dz,tmp,b,k))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   KenCarp5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,
                 k1,k2,k3,k4,k5,k6,k7,k8,

--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -31,7 +31,7 @@ Equations II, Springer Series in Computational Mathematics. ISBN
 978-3-642-05221-7. Section IV.8.
 [doi:10.1007/978-3-642-05221-7](https://doi.org/10.1007/978-3-642-05221-7)
 """
-function (S::NLNewton{false})(integrator)
+function (S::NLNewton{false,<:NLSolverCache})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,tmp,W,κ,tol,c,γ,max_iter,min_iter = nlcache
@@ -84,7 +84,7 @@ function (S::NLNewton{false})(integrator)
   return (z, η, iter, false)
 end
 
-function (S::NLNewton{true})(integrator)
+function (S::NLNewton{true,<:NLSolverCache})(integrator)
   nlcache = S.cache
   cache = integrator.cache
   @unpack t,dt,uprev,u,f,p = integrator

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -20,15 +20,15 @@ mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType} <: AbstractN
   k::rateType
 end
 
-struct NLFunctional{iip} <: AbstractNLsolveSolver
-  cache::NLSolverCache
+struct NLFunctional{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
+  cache::T
 end
-struct NLAnderson{iip} <: AbstractNLsolveSolver
-  cache::NLSolverCache
+struct NLAnderson{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
+  cache::T
   n::Int
 end
-struct NLNewton{iip} <: AbstractNLsolveSolver
-  cache::NLSolverCache
+struct NLNewton{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
+  cache::T
 end
 
 NLSolverCache(;κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
@@ -36,10 +36,15 @@ NLSolverCache(κ, tol, min_iter, max_iter, 0, true,
               (nothing for i in 1:10)...)
 
 # Default `iip` to `true`, but the whole type will be reinitialized in `alg_cache`
-NLFunctional(;kwargs...) = NLFunctional{true}(NLSolverCache(;kwargs...))
-NLAnderson(n=5; kwargs...) = NLAnderson{true}(NLSolverCache(;kwargs...), n)
-NLNewton(;kwargs...) = NLNewton{true}(NLSolverCache(;kwargs...))
-
-oop_nlsolver(s::NLFunctional{true}) = NLFunctional{false}(s.cache)
-oop_nlsolver(s::NLAnderson{true}) = NLAnderson{false}(s.cache, s.n)
-oop_nlsolver(s::NLNewton{true}) = NLNewton{false}(s.cache)
+function NLFunctional(;kwargs...)
+  nlcache = NLSolverCache(;kwargs...)
+  NLFunctional{true, typeof(nlcache)}(nlcache)
+end
+function NLAnderson(n=5; kwargs...)
+  nlcache = NLSolverCache(;kwargs...)
+  NLAnderson{true, typeof(nlcache)}(nlcache, n)
+end
+function NLNewton(;kwargs...)
+  nlcache = NLSolverCache(;kwargs...)
+  NLNewton{true, typeof(nlcache)}(nlcache)
+end


### PR DESCRIPTION
This PR fixes a type instability in the stiff solvers. Ref: https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/564
```julia
using ParameterizedFunctions, OrdinaryDiffEq, ProfileView, BenchmarkTools
using Profile
@eval begin
  f = @ode_def $(gensym()) begin
    dy1 = p1*(y2+y1*(1-p2*y1-y2))
    dy2 = (y3-(1+y1)*y2)/p1
    dy3 = p3*(y1-y3)
  end p1 p2 p3
end
p = [77.27,8.375e-6,0.161]
prob = ODEProblem(f,[1.0,2.0,3.0],(0.0,30.0),p)
```
```julia
@btime solve($prob,$(TRBDF2())); # Master 4.929 ms (73070 allocations: 1.33 MiB)
@btime solve($prob,$(TRBDF2())); # PR 658.705 μs (1830 allocations: 139.03 KiB)
```

@ChrisRackauckas could you run the benchmark again on this branch? Thanks!