### PR TITLE
Equality checks with nothing

### DIFF
--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -192,7 +192,7 @@ function alg_cache_expRK(alg::OrdinaryDiffEqExponentialAlgorithm,u,uEltypeNoUnit
   # Allocate cache for the Jacobian
   if isa(f, SplitFunction)
     J = nothing
-  elseif DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  elseif DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), n, n)
@@ -247,7 +247,7 @@ function alg_cache(alg::LawsonEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
   # Allocate cache for the Jacobian
   if isa(f, SplitFunction)
     J = nothing
-  elseif DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  elseif DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), n, n)
@@ -452,7 +452,7 @@ function alg_cache(alg::Exp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -495,7 +495,7 @@ function alg_cache(alg::EPIRK4s3A,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -537,7 +537,7 @@ function alg_cache(alg::EPIRK4s3B,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -579,7 +579,7 @@ function alg_cache(alg::EPIRK5s3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -620,7 +620,7 @@ function alg_cache(alg::EXPRB53s3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -662,7 +662,7 @@ function alg_cache(alg::EPIRK5P1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -705,7 +705,7 @@ function alg_cache(alg::EPIRK5P2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), length(u), length(u))
@@ -763,7 +763,7 @@ function alg_cache_exprb(alg::OrdinaryDiffEqAdaptiveExponentialAlgorithm,u,uElty
     jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
   end
   # Allocate cache for the Jacobian
-  if DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
     J = deepcopy(f.jac_prototype)
   else
     J = fill(zero(uEltypeNoUnits), n, n)

--- a/src/caches/rosenbrock_caches.jl
+++ b/src/caches/rosenbrock_caches.jl
@@ -62,7 +62,7 @@ function alg_cache(alg::Rosenbrock23,u,rate_prototype,uEltypeNoUnits,uBottomElty
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -95,7 +95,7 @@ function alg_cache(alg::Rosenbrock32,u,rate_prototype,uEltypeNoUnits,uBottomElty
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -198,7 +198,7 @@ function alg_cache(alg::ROS3P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -260,7 +260,7 @@ function alg_cache(alg::Rodas3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -340,7 +340,7 @@ function alg_cache(alg::RosShamp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -378,7 +378,7 @@ function alg_cache(alg::Veldd4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -416,7 +416,7 @@ function alg_cache(alg::Velds4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -454,7 +454,7 @@ function alg_cache(alg::GRK4T,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -492,7 +492,7 @@ function alg_cache(alg::GRK4A,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -530,7 +530,7 @@ function alg_cache(alg::Ros4LStab,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -611,7 +611,7 @@ function alg_cache(alg::Rodas4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -654,7 +654,7 @@ function alg_cache(alg::Rodas42,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -697,7 +697,7 @@ function alg_cache(alg::Rodas4P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
@@ -783,7 +783,7 @@ function alg_cache(alg::Rodas5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   fsalfirst = zero(rate_prototype)
   fsallast = zero(rate_prototype)
   dT = zero(rate_prototype)
-  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -21,7 +21,7 @@ DiffEqBase.@def iipnlcachefields begin
     linsolve = alg.linsolve(Val{:init},nf,u)
     z₊ = z
   elseif alg.nlsolve isa NLNewton
-    if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype != nothing
+    if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
       W = WOperator(f, dt, true)
       J = nothing # is J = W.J better?
     else
@@ -44,12 +44,12 @@ DiffEqBase.@def iipnlcachefields begin
     z₊ = similar(z)
   end
 
-  if κ != nothing
+  if κ !== nothing
     κ = uToltype(nlcache.κ)
   else
     κ = uToltype(1//100)
   end
-  if tol != nothing
+  if tol !== nothing
     tol = uToltype(nlcache.tol)
   else
     tol = uToltype(min(0.03,first(reltol)^(0.5)))
@@ -80,12 +80,12 @@ DiffEqBase.@def oopnlcachefields begin
   uToltype = real(uBottomEltypeNoUnits)
   ηold = one(uToltype)
 
-  if κ != nothing
+  if κ !== nothing
     κ = uToltype(nlcache.κ)
   else
     κ = uToltype(1//100)
   end
-  if tol != nothing
+  if tol !== nothing
     tol = uToltype(nlcache.tol)
   else
     tol = uToltype(min(0.03,first(reltol)^(0.5)))

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -130,13 +130,13 @@ function ode_interpolation(tvals,id,idxs,deriv,p,continuity::Symbol=:left)
     if !avoid_constant_ends && ts[i] == t
       lasti = lastindex(ts)
       k = continuity == :right && i+1 <= lasti && ts[i+1] == t ? i+1 : i
-      if idxs == nothing
+      if idxs === nothing
         vals[j] = timeseries[k]
       else
         vals[j] = timeseries[k][idxs]
       end
     elseif !avoid_constant_ends && ts[i-1] == t # Can happen if it's the first value!
-      if idxs == nothing
+      if idxs === nothing
         vals[j] = timeseries[i-1]
       else
         vals[j] = timeseries[i-1][idxs]
@@ -181,13 +181,13 @@ function ode_interpolation!(vals,tvals,id,idxs,deriv,p,continuity::Symbol=:left)
     if !avoid_constant_ends && ts[i] == t
       lasti = lastindex(ts)
       k = continuity == :right && i+1 <= lasti && ts[i+1] == t ? i+1 : i
-      if idxs == nothing
+      if idxs === nothing
         vals[j] = timeseries[k]
       else
         vals[j] = timeseries[k][idxs]
       end
     elseif !avoid_constant_ends && ts[i-1] == t # Can happen if it's the first value!
-      if idxs == nothing
+      if idxs === nothing
         vals[j] = timeseries[i-1]
       else
         vals[j] = timeseries[i-1][idxs]
@@ -243,13 +243,13 @@ function ode_interpolation(tval::Number,id,idxs,deriv,p,continuity::Symbol=:left
   @inbounds if !avoid_constant_ends && ts[i] == tval
     lasti = lastindex(ts)
     k = continuity == :right && i+1 <= lasti && ts[i+1] == tval ? i+1 : i
-    if idxs == nothing
+    if idxs === nothing
       val = timeseries[k]
     else
       val = timeseries[k][idxs]
     end
   elseif !avoid_constant_ends && ts[i-1] == tval # Can happen if it's the first value!
-    if idxs == nothing
+    if idxs === nothing
       val = timeseries[i-1]
     else
       val = timeseries[i-1][idxs]
@@ -289,13 +289,13 @@ function ode_interpolation!(out,tval::Number,id,idxs,deriv,p,continuity::Symbol=
   if !avoid_constant_ends && ts[i] == tval
     lasti = lastindex(ts)
     k = continuity == :right && i+1 <= lasti && ts[i+1] == tval ? i+1 : i
-    if idxs == nothing
+    if idxs === nothing
       @inbounds copyto!(out,timeseries[k])
     else
       @inbounds copyto!(out,timeseries[k][idxs])
     end
   elseif !avoid_constant_ends && ts[i-1] == tval # Can happen if it's the first value!
-    if idxs == nothing
+    if idxs === nothing
       @inbounds copyto!(out,timeseries[i-1])
     else
       @inbounds copyto!(out,timeseries[i-1][idxs])

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -146,7 +146,7 @@ end
 set_gamma!(W::WOperator, gamma) = (W.gamma = gamma; W)
 DiffEqBase.update_coefficients!(W::WOperator,u,p,t) = (update_coefficients!(W.J,u,p,t); W)
 function Base.convert(::Type{AbstractMatrix}, W::WOperator)
-  if W._concrete_form == nothing || !W.inplace
+  if W._concrete_form === nothing || !W.inplace
     # Allocating
     if W.transform
       W._concrete_form = W.mass_matrix / W.gamma - convert(AbstractMatrix,W.J)
@@ -204,7 +204,7 @@ function Base.:\(W::WOperator, x::Union{AbstractVecOrMat,Number})
 end
 
 function LinearAlgebra.mul!(Y::AbstractVecOrMat, W::WOperator, B::AbstractVecOrMat)
-  if W._func_cache == nothing
+  if W._func_cache === nothing
     # Allocate cache only if needed
     W._func_cache = Vector{eltype(W)}(undef, size(Y, 1))
   end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -261,7 +261,7 @@ function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_
                                     f.invW(W, uprev, p, dtgamma, t) # W == inverse W
       is_compos && calc_J!(integrator, cache, true)
 
-    elseif DiffEqBase.has_jac(f) && f.jac_prototype != nothing
+    elseif DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
       # skip calculation of J if step is repeated
       if repeat_step || (alg_can_repeat_jac(alg) &&
                          (!integrator.last_stepfail && nl_iters == 1 &&

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -197,7 +197,7 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
         copyat_or_push!(integrator.sol.u,1,u_initial,Val{false})
       end
     end
-    if integrator.sol.u_analytic != nothing
+    if integrator.sol.u_analytic !== nothing
       resize!(integrator.sol.u_analytic,0)
     end
     if typeof(integrator.alg) <: OrdinaryDiffEqCompositeAlgorithm

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -190,7 +190,7 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
     resize!(integrator.sol.k,resize_start)
     if integrator.opts.save_start
       copyat_or_push!(integrator.sol.t,1,t0)
-      if integrator.opts.save_idxs == nothing
+      if integrator.opts.save_idxs === nothing
         copyat_or_push!(integrator.sol.u,1,u0)
       else
         u_initial = u0[integrator.opts.save_idxs]

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -67,7 +67,7 @@ function savevalues!(integrator::ODEIntegrator,force_save=false,reduce_size=true
     else # ==t, just save
       savedexactly = true
       copyat_or_push!(integrator.sol.t,integrator.saveiter,integrator.t)
-      if integrator.opts.save_idxs == nothing
+      if integrator.opts.save_idxs === nothing
         copyat_or_push!(integrator.sol.u,integrator.saveiter,integrator.u)
       else
         copyat_or_push!(integrator.sol.u,integrator.saveiter,integrator.u[integrator.opts.save_idxs],Val{false})
@@ -75,7 +75,7 @@ function savevalues!(integrator::ODEIntegrator,force_save=false,reduce_size=true
       if typeof(integrator.alg) <: FunctionMap || integrator.opts.dense
         integrator.saveiter_dense +=1
         if integrator.opts.dense
-          if integrator.opts.save_idxs == nothing
+          if integrator.opts.save_idxs === nothing
             copyat_or_push!(integrator.sol.k,integrator.saveiter_dense,integrator.k)
           else
             copyat_or_push!(integrator.sol.k,integrator.saveiter_dense,[k[integrator.opts.save_idxs] for k in integrator.k],Val{false})
@@ -89,7 +89,7 @@ function savevalues!(integrator::ODEIntegrator,force_save=false,reduce_size=true
   end
   if force_save || (integrator.opts.save_everystep && integrator.iter%integrator.opts.timeseries_steps==0)
     integrator.saveiter += 1; saved, savedexactly = true, true
-    if integrator.opts.save_idxs == nothing
+    if integrator.opts.save_idxs === nothing
       copyat_or_push!(integrator.sol.u,integrator.saveiter,integrator.u)
     else
       copyat_or_push!(integrator.sol.u,integrator.saveiter,integrator.u[integrator.opts.save_idxs],Val{false})
@@ -98,7 +98,7 @@ function savevalues!(integrator::ODEIntegrator,force_save=false,reduce_size=true
     if typeof(integrator.alg) <: FunctionMap || integrator.opts.dense
       integrator.saveiter_dense +=1
       if integrator.opts.dense
-        if integrator.opts.save_idxs == nothing
+        if integrator.opts.save_idxs === nothing
           copyat_or_push!(integrator.sol.k,integrator.saveiter_dense,integrator.k)
         else
           copyat_or_push!(integrator.sol.k,integrator.saveiter_dense,[k[integrator.opts.save_idxs] for k in integrator.k],Val{false})
@@ -131,7 +131,7 @@ function solution_endpoint_match_cur_integrator!(integrator)
   if integrator.opts.save_end && (integrator.saveiter == 0 || integrator.sol.t[integrator.saveiter] !=  integrator.t)
     integrator.saveiter += 1
     copyat_or_push!(integrator.sol.t,integrator.saveiter,integrator.t)
-    if integrator.opts.save_idxs == nothing
+    if integrator.opts.save_idxs === nothing
       copyat_or_push!(integrator.sol.u,integrator.saveiter,integrator.u)
     else
       copyat_or_push!(integrator.sol.u,integrator.saveiter,integrator.u[integrator.opts.save_idxs],Val{false})
@@ -139,7 +139,7 @@ function solution_endpoint_match_cur_integrator!(integrator)
     if typeof(integrator.alg) <: FunctionMap || integrator.opts.dense
       integrator.saveiter_dense +=1
       if integrator.opts.dense
-        if integrator.opts.save_idxs == nothing
+        if integrator.opts.save_idxs === nothing
           copyat_or_push!(integrator.sol.k,integrator.saveiter_dense,integrator.k)
         else
           copyat_or_push!(integrator.sol.k,integrator.saveiter_dense,[k[integrator.opts.save_idxs] for k in integrator.k],Val{false})

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -111,7 +111,7 @@ function DiffEqBase.__init(
 
   if typeof(alg) <: FunctionMap
     abstol_internal = real.(zero.(u))
-  elseif abstol == nothing
+  elseif abstol === nothing
     if uBottomEltypeNoUnits == uBottomEltype
       abstol_internal = real(convert(uBottomEltype,oneunit(uBottomEltype)*1//10^6))
     else
@@ -123,7 +123,7 @@ function DiffEqBase.__init(
 
   if typeof(alg) <: FunctionMap
     reltol_internal = real.(zero(first(u)/t))
-  elseif reltol == nothing
+  elseif reltol === nothing
     if uBottomEltypeNoUnits == uBottomEltype
       reltol_internal = real(convert(uBottomEltype,oneunit(uBottomEltype)*1//10^3))
     else
@@ -157,7 +157,7 @@ function DiffEqBase.__init(
   callbacks_internal = CallbackSet(callback,prob.callback)
 
   ### Algorithm-specific defaults ###
-  if save_idxs == nothing
+  if save_idxs === nothing
     ksEltype = Vector{rateType}
   else
     ks_prototype = rate_prototype[save_idxs]
@@ -165,7 +165,7 @@ function DiffEqBase.__init(
   end
 
   # Have to convert incase passed in wrong.
-  if save_idxs == nothing
+  if save_idxs === nothing
     timeseries = convert(Vector{uType},timeseries_init)
   else
     u_initial = u[save_idxs]
@@ -199,7 +199,7 @@ function DiffEqBase.__init(
     saveiter = 1 # Starts at 1 so first save is at 2
     saveiter_dense = 1
     copyat_or_push!(ts,1,t)
-    if save_idxs == nothing
+    if save_idxs === nothing
       copyat_or_push!(timeseries,1,u)
       copyat_or_push!(ks,1,[rate_prototype])
     else
@@ -234,12 +234,12 @@ function DiffEqBase.__init(
 
   if typeof(alg) <: OrdinaryDiffEqCompositeAlgorithm
     id = CompositeInterpolationData(f,timeseries,ts,ks,alg_choice,dense,cache)
-    beta2 == nothing && ( beta2=beta2_default(alg.algs[cache.current]) )
-    beta1 == nothing && ( beta1=beta1_default(alg.algs[cache.current],beta2) )
+    beta2 === nothing && ( beta2=beta2_default(alg.algs[cache.current]) )
+    beta1 === nothing && ( beta1=beta1_default(alg.algs[cache.current],beta2) )
   else
     id = InterpolationData(f,timeseries,ts,ks,dense,cache)
-    beta2 == nothing && ( beta2=beta2_default(alg) )
-    beta1 == nothing && ( beta1=beta1_default(alg,beta2) )
+    beta2 === nothing && ( beta2=beta2_default(alg) )
+    beta1 === nothing && ( beta1=beta1_default(alg,beta2) )
   end
 
   opts = DEOptions{typeof(abstol_internal),typeof(reltol_internal),QT,tType,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -25,8 +25,8 @@ function DiffEqBase.__init(
   save_end = save_everystep || isempty(saveat) || typeof(saveat) <: Number ? true : prob.tspan[2] in saveat,
   callback=nothing,
   dense = save_everystep && !(typeof(alg) <: FunctionMap) && isempty(saveat),
-  calck = (callback != nothing && callback != CallbackSet()) || # Empty callback
-          (prob.callback != nothing && prob.callback != CallbackSet()) || # Empty prob.callback
+  calck = (callback !== nothing && callback != CallbackSet()) || # Empty callback
+          (prob.callback !== nothing && prob.callback != CallbackSet()) || # Empty prob.callback
           (!isempty(setdiff(saveat,tstops)) || dense), # and no dense output
   dt = typeof(alg) <: FunctionMap && isempty(tstops) ? eltype(prob.tspan)(1) : eltype(prob.tspan)(0),
   adaptive = isadaptive(alg),


### PR DESCRIPTION
This is only a cosmetic change (as far as I can see) since we dispatch on the types of the checked variables and hence all checks should be compiled away, but apparently using `=== nothing` instead of `== nothing` can be slightly more performant (see https://github.com/JuliaLang/julia/issues/29674#issue-370706380) and it doesn't hurt to use `===` consistently. Additionally, `===` always returns a `Bool` whereas e.g. `missing == nothing` evaluates to `missing`.