### PR TITLE
Converts Matrices in anderson.jl to arrays of arrays

### DIFF
--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -56,13 +56,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = nothing
     linsolve = nothing
     z₊ = similar(z)
-    if typeof(z) <: AbstractArray
-      zs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
-      gs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
-    else
-      zs = [zero(z) for i in 1:alg.nlsolve.n+1]
-      gs = [zero(z) for i in 1:alg.nlsolve.n+1]
-    end
+    zs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+    gs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
   end
 
   if κ !== nothing

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -20,6 +20,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = nothing
     linsolve = alg.linsolve(Val{:init},nf,u)
     z₊ = z
+    zs = []
+    gs = []
   elseif alg.nlsolve isa NLNewton
     if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
       W = WOperator(f, dt, true)
@@ -34,6 +36,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = build_jac_config(alg,nf,uf,du1,uprev,u,tmp,dz)
     linsolve = alg.linsolve(Val{:init},uf,u)
     z₊ = z
+    zs = []
+    gs = []
   elseif typeof(alg.nlsolve) <: NLFunctional
     J = nothing
     W = nothing
@@ -42,6 +46,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = nothing
     linsolve = nothing
     z₊ = similar(z)
+    zs = []
+    gs = []
   elseif typeof(alg.nlsolve) <: NLAnderson
     J = nothing
     W = nothing
@@ -50,6 +56,13 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = nothing
     linsolve = nothing
     z₊ = similar(z)
+    if typeof(z) <: AbstractArray
+      zs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+      gs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+    else
+      zs = [zero(z) for i in 1:alg.nlsolve.n+1]
+      gs = [zero(z) for i in 1:alg.nlsolve.n+1]
+    end
   end
 
   if κ !== nothing
@@ -98,17 +111,29 @@ DiffEqBase.@def oopnlcachefields begin
   else
     tol = uToltype(min(0.03,first(reltol)^(0.5)))
   end
+  if typeof(alg.nlsolve) <: NLAnderson
+    if typeof(z) <: AbstractArray
+      zs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+      gs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+    else
+      zs = [zero(z) for i in 1:alg.nlsolve.n+1]
+      gs = [zero(z) for i in 1:alg.nlsolve.n+1]
+    end
+  else
+    zs = []
+    gs = []
+  end
   z₊,dz,tmp,b,k = z,z,z,z,rate_prototype
 end
 
 DiffEqBase.@def iipnlsolve begin
   _nlsolve = typeof(alg.nlsolve).name.wrapper
-  nlcache = NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,γ,c,ηold,z₊,dz,tmp,b,k)
+  nlcache = NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,γ,c,ηold,z₊,dz,tmp,b,k,zs,gs)
   nlsolve = _nlsolve{true, typeof(nlcache)}(nlcache)
 end
 DiffEqBase.@def oopnlsolve begin
   _nlsolve = typeof(alg.nlsolve).name.wrapper
-  nlcache = NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,γ,c,ηold,z₊,dz,tmp,b,k)
+  nlcache = NLSolverCache(κ,tol,min_iter,max_iter,10000,new_W,z,W,γ,c,ηold,z₊,dz,tmp,b,k,zs,gs)
   nlsolve = _nlsolve{false, typeof(nlcache)}(nlcache)
 end
 

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -20,8 +20,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = nothing
     linsolve = alg.linsolve(Val{:init},nf,u)
     z₊ = z
-    zs = []
-    gs = []
+    zs = nothing
+    gs = nothing
   elseif alg.nlsolve isa NLNewton
     if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
       W = WOperator(f, dt, true)
@@ -36,8 +36,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = build_jac_config(alg,nf,uf,du1,uprev,u,tmp,dz)
     linsolve = alg.linsolve(Val{:init},uf,u)
     z₊ = z
-    zs = []
-    gs = []
+    zs = nothing
+    gs = nothing
   elseif typeof(alg.nlsolve) <: NLFunctional
     J = nothing
     W = nothing
@@ -46,8 +46,8 @@ DiffEqBase.@def iipnlcachefields begin
     jac_config = nothing
     linsolve = nothing
     z₊ = similar(z)
-    zs = []
-    gs = []
+    zs = nothing
+    gs = nothing
   elseif typeof(alg.nlsolve) <: NLAnderson
     J = nothing
     W = nothing
@@ -120,8 +120,8 @@ DiffEqBase.@def oopnlcachefields begin
       gs = [zero(z) for i in 1:alg.nlsolve.n+1]
     end
   else
-    zs = []
-    gs = []
+    zs = nothing
+    gs = nothing
   end
   z₊,dz,tmp,b,k = z,z,z,z,rate_prototype
 end

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -108,11 +108,11 @@ DiffEqBase.@def oopnlcachefields begin
   end
   if typeof(alg.nlsolve) <: NLAnderson
     if typeof(z) <: AbstractArray
-      zs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
-      gs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+      zs = [vec(z) for i in 1:alg.nlsolve.n+1]
+      gs = [vec(z) for i in 1:alg.nlsolve.n+1]
     else
-      zs = [zero(z) for i in 1:alg.nlsolve.n+1]
-      gs = [zero(z) for i in 1:alg.nlsolve.n+1]
+      zs = [z for i in 1:alg.nlsolve.n+1]
+      gs = [z for i in 1:alg.nlsolve.n+1]
     end
   else
     zs = nothing

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -79,8 +79,8 @@ end
 function (S::NLAnderson{true})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,z₊,dz,tmp,κ,tol,k,c,γ,min_iter,max_iter = nlcache
-  ztmp = u
+  @unpack z,z₊,dz,b,tmp,κ,tol,k,c,γ,min_iter,max_iter = nlcache
+  ztmp = b
   mass_matrix = integrator.f.mass_matrix
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1
@@ -141,8 +141,7 @@ function (S::NLAnderson{true})(integrator)
 
     mk = min(S.n, iter-1)
     ztmp = vec(u)
-    ztmp .= gs[1]
-    ztmp .-= zs[1]
+    @. ztmp = gs[1] - zs[1]
     for i in 2:mk+1
       residuals[:,i-1] .= (gs[i] .- zs[i]) .- ztmp
     end

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -79,8 +79,8 @@ end
 function (S::NLAnderson{true})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,z₊,b,dz,tmp,κ,tol,k,c,γ,min_iter,max_iter = nlcache
-  ztmp = b
+  @unpack z,z₊,dz,tmp,κ,tol,k,c,γ,min_iter,max_iter = nlcache
+  ztmp = u
   mass_matrix = integrator.f.mass_matrix
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1
@@ -132,6 +132,7 @@ function (S::NLAnderson{true})(integrator)
     if mass_matrix == I
       @. z₊ = dt*k
     else
+      ztmp = u
       @. z₊ = dt*k + z
       mul!(ztmp, mass_matrix, z)
       @. z₊ -= ztmp
@@ -139,7 +140,9 @@ function (S::NLAnderson{true})(integrator)
     gs[1] .= vec(z₊)
 
     mk = min(S.n, iter-1)
-    ztmp = (gs[1] - zs[1])
+    ztmp = vec(u)
+    ztmp .= gs[1]
+    ztmp .-= zs[1]
     for i in 2:mk+1
       residuals[:,i-1] .= (gs[i] .- zs[i]) .- ztmp
     end

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -139,9 +139,9 @@ function (S::NLAnderson{true})(integrator)
     gs[1] .= vec(z₊)
 
     mk = min(S.n, iter-1)
-    tmp = (gs[1] - zs[1])
+    ztmp = (gs[1] - zs[1])
     for i in 2:mk+1
-      residuals[:,i-1] .= (gs[i] .- zs[i]) .- (gs[1] - zs[1])
+      residuals[:,i-1] .= (gs[i] .- zs[i]) .- ztmp
     end
     alphas[1:mk] .= residuals[:,1:mk] \ (zs[1] .- gs[1])
     vecz₊ = vec(z₊)

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -149,7 +149,8 @@ function (S::NLAnderson{true})(integrator)
     for i in 2:mk+1
       @. residuals[:,i-1] = gs[i] - zs[i] + ztmp
     end
-    alphas[1:mk] .= @view(residuals[:,1:mk]) \ ztmp
+    resqr = qr!(residuals[:,1:mk], Val(true))
+    ldiv!(@view(alphas[1:mk]), resqr, ztmp)
     vecz₊ = vec(z₊)
     for i = 1:mk
         vecz₊ .+= alphas[i].*(gs[i+1] .- gs[1])

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -90,13 +90,9 @@ function (S::NLAnderson{true})(integrator)
   # precalculations
   κtol = κ*tol
 
-  zs = fill(Any[], S.n+1)
-  gs = fill(Any[], S.n+1)
+  zs = [zero(z) for i in 1:S.n+1]
+  gs = [zero(z) for i in 1:S.n+1]
   residuals = zeros(length(vec(z)), S.n+1)
-  for e = 1:1:(S.n+1)
-    zs[e] = zeros(length(vec(z)))
-    gs[e] = zeros(length(vec(z)))
-  end
   alphas = zeros(S.n)
   # initial step of NLAnderson iteration
   zs[1] .= vec(z)
@@ -115,10 +111,12 @@ function (S::NLAnderson{true})(integrator)
   gs[1] .= vec(z₊)
   @. dz = z₊ - z
   ndz = integrator.opts.internalnorm(dz)
+  zptr = zs[S.n+1]
   for t = (S.n+1):-1:2
     zs[t] = zs[t-1]
     gs[t] = gs[t-1]
   end
+  zs[1] = zptr
   # zs = circshift(zs, 1)
   # gs = circshift(gs, 1)
   z .= z₊
@@ -150,10 +148,12 @@ function (S::NLAnderson{true})(integrator)
     for i = 1:mk
         vecz₊ .+= alphas[i].*(gs[i+1] .- gs[1])
     end
+    zptr = zs[S.n+1]
     for t = (S.n+1):-1:2
       zs[t] = zs[t-1]
       gs[t] = gs[t-1]
     end
+    zs[1] = zptr
     # zs = circshift(zs, 1)
     # gs = circshift(gs, 1)
     zs[1] .= vec(z₊)

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -90,8 +90,8 @@ function (S::NLAnderson{true})(integrator)
   # precalculations
   κtol = κ*tol
 
-  zs = [zero(z) for i in 1:S.n+1]
-  gs = [zero(z) for i in 1:S.n+1]
+  zs = [zero(vec(z)) for i in 1:S.n+1]
+  gs = [zero(vec(z)) for i in 1:S.n+1]
   residuals = zeros(length(vec(z)), S.n+1)
   alphas = zeros(S.n)
   # initial step of NLAnderson iteration

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -1,7 +1,7 @@
 function (S::NLAnderson{false,<:NLSolverCache})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,tmp,W,κ,tol,c,γ,max_iter,min_iter = nlcache
+  @unpack z,tmp,W,κ,tol,c,γ,max_iter,min_iter,zs,gs = nlcache
   if typeof(integrator.f) <: SplitFunction
     f = integrator.f.f1
   else
@@ -10,8 +10,8 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
   # precalculations
   κtol = κ*tol
 
-  zs = zeros(S.n+1)
-  gs = zeros(S.n+1)
+  # zs = zeros(S.n+1)
+  # gs = zeros(S.n+1)
   residuals = zeros(S.n+1)
   alphas = zeros(S.n)
   # initial step of NLAnderson iteration
@@ -23,10 +23,12 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
   gs[1] = z₊
   dz = z₊ - z
   ndz = integrator.opts.internalnorm(dz)
+  zptr = zs[S.n+1]
   for t = (S.n+1):-1:2
     zs[t] = zs[t-1]
     gs[t] = gs[t-1]
   end
+  zs[1] = zptr
   # zs = circshift(zs, 1)
   # gs = circshift(gs, 1)
   z = z₊
@@ -43,15 +45,17 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
     gs[1] = z₊
     
     mk = min(S.n, iter-1)
-    residuals[1:mk] = (gs[2:mk+1] .- zs[2:mk+1]) .- (gs[1] - zs[1])
+    residuals[1:mk] .= (gs[2:mk+1] .- zs[2:mk+1]) .- (gs[1] - zs[1])
     alphas[1:mk] .= residuals[1:mk] \ [(zs[1] - gs[1])]
     for i = 1:mk
         z₊ += alphas[i]*(gs[i+1] - gs[1])
     end
+    zptr = zs[S.n+1]
     for t = (S.n+1):-1:2
       zs[t] = zs[t-1]
       gs[t] = gs[t-1]
     end
+    zs[1] = zptr
     # zs = circshift(zs, 1)
     # gs = circshift(gs, 1)
     zs[1] = z₊
@@ -79,7 +83,7 @@ end
 function (S::NLAnderson{true})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,z₊,dz,b,tmp,κ,tol,k,c,γ,min_iter,max_iter = nlcache
+  @unpack z,z₊,dz,b,tmp,κ,tol,k,c,γ,min_iter,max_iter,zs,gs = nlcache
   ztmp = b
   mass_matrix = integrator.f.mass_matrix
   if typeof(integrator.f) <: SplitFunction
@@ -90,8 +94,8 @@ function (S::NLAnderson{true})(integrator)
   # precalculations
   κtol = κ*tol
 
-  zs = [zero(vec(z)) for i in 1:S.n+1]
-  gs = [zero(vec(z)) for i in 1:S.n+1]
+  # zs = [zero(vec(z)) for i in 1:S.n+1]
+  # gs = [zero(vec(z)) for i in 1:S.n+1]
   residuals = zeros(length(vec(z)), S.n+1)
   alphas = zeros(S.n)
   # initial step of NLAnderson iteration
@@ -132,7 +136,7 @@ function (S::NLAnderson{true})(integrator)
     if mass_matrix == I
       @. z₊ = dt*k
     else
-      ztmp = u
+      ztmp = b
       @. z₊ = dt*k + z
       mul!(ztmp, mass_matrix, z)
       @. z₊ -= ztmp
@@ -140,12 +144,12 @@ function (S::NLAnderson{true})(integrator)
     gs[1] .= vec(z₊)
 
     mk = min(S.n, iter-1)
-    ztmp = vec(u)
-    @. ztmp = gs[1] - zs[1]
+    ztmp = vec(b)
+    @. ztmp = zs[1] - gs[1]
     for i in 2:mk+1
-      residuals[:,i-1] .= (gs[i] .- zs[i]) .- ztmp
+      @. residuals[:,i-1] = gs[i] - zs[i] + ztmp
     end
-    alphas[1:mk] .= residuals[:,1:mk] \ (zs[1] .- gs[1])
+    alphas[1:mk] .= @view(residuals[:,1:mk]) \ ztmp
     vecz₊ = vec(z₊)
     for i = 1:mk
         vecz₊ .+= alphas[i].*(gs[i+1] .- gs[1])

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -24,11 +24,13 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
   dz = z₊ - z
   ndz = integrator.opts.internalnorm(dz)
   zptr = zs[S.n+1]
+  gptr = gs[S.n+1]
   for t = (S.n+1):-1:2
     zs[t] = zs[t-1]
     gs[t] = gs[t-1]
   end
   zs[1] = zptr
+  gs[1] = gptr
   # zs = circshift(zs, 1)
   # gs = circshift(gs, 1)
   z = z₊
@@ -51,11 +53,13 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
         z₊ += alphas[i]*(gs[i+1] - gs[1])
     end
     zptr = zs[S.n+1]
+    gptr = gs[S.n+1]
     for t = (S.n+1):-1:2
       zs[t] = zs[t-1]
       gs[t] = gs[t-1]
     end
     zs[1] = zptr
+    gs[1] = gptr
     # zs = circshift(zs, 1)
     # gs = circshift(gs, 1)
     zs[1] = z₊
@@ -116,11 +120,13 @@ function (S::NLAnderson{true})(integrator)
   @. dz = z₊ - z
   ndz = integrator.opts.internalnorm(dz)
   zptr = zs[S.n+1]
+  gptr = gs[S.n+1]
   for t = (S.n+1):-1:2
     zs[t] = zs[t-1]
     gs[t] = gs[t-1]
   end
   zs[1] = zptr
+  gs[1] = gptr
   # zs = circshift(zs, 1)
   # gs = circshift(gs, 1)
   z .= z₊
@@ -156,11 +162,13 @@ function (S::NLAnderson{true})(integrator)
         vecz₊ .+= alphas[i].*(gs[i+1] .- gs[1])
     end
     zptr = zs[S.n+1]
+    gptr = gs[S.n+1]
     for t = (S.n+1):-1:2
       zs[t] = zs[t-1]
       gs[t] = gs[t-1]
     end
     zs[1] = zptr
+    gs[1] = gptr
     # zs = circshift(zs, 1)
     # gs = circshift(gs, 1)
     zs[1] .= vec(z₊)

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -1,6 +1,6 @@
 abstract type AbstractNLsolveSolver end
 abstract type AbstractNLsolveCache end
-mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType} <: AbstractNLsolveCache
+mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType,zsType} <: AbstractNLsolveCache
   κ::uToltype
   tol::uToltype
   min_iter::Int
@@ -18,8 +18,8 @@ mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType} <: AbstractN
   tmp::uType
   b::uType # can be aliased with `k` if no unit
   k::rateType
-  zs::Array
-  gs::Array
+  zs::zsType
+  gs::zsType
 end
 
 struct NLFunctional{iip,T<:NLSolverCache} <: AbstractNLsolveSolver

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -38,7 +38,7 @@ NLSolverCache(;κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
 NLSolverCache(κ, tol, min_iter, max_iter, 0, true,
               ntuple(i->nothing, 4)...,
               κ === nothing ? κ : zero(κ),
-              ntuple(i->nothing, 5)..., [], [])
+              ntuple(i->nothing, 7)...)
 
 # Default `iip` to `true`, but the whole type will be reinitialized in `alg_cache`
 function NLFunctional(;kwargs...)

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -18,6 +18,8 @@ mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType} <: AbstractN
   tmp::uType
   b::uType # can be aliased with `k` if no unit
   k::rateType
+  zs::Array
+  gs::Array
 end
 
 struct NLFunctional{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
@@ -36,7 +38,7 @@ NLSolverCache(;κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
 NLSolverCache(κ, tol, min_iter, max_iter, 0, true,
               ntuple(i->nothing, 4)...,
               κ === nothing ? κ : zero(κ),
-              ntuple(i->nothing, 5)...)
+              ntuple(i->nothing, 5)..., [], [])
 
 # Default `iip` to `true`, but the whole type will be reinitialized in `alg_cache`
 function NLFunctional(;kwargs...)

--- a/test/mass_matrix_tests.jl
+++ b/test/mass_matrix_tests.jl
@@ -112,13 +112,13 @@ using OrdinaryDiffEq, Test, LinearAlgebra, Statistics
     if iip
       sol = solve(prob,ImplicitEuler(nlsolve=NLAnderson()),dt=1/10,adaptive=false)
       sol2 = solve(prob2,ImplicitEuler(nlsolve=NLAnderson()),dt=1/10,adaptive=false)
-      @test_broken norm(sol .- sol2) ≈ 0 atol=1e-7
+      @test norm(sol .- sol2) ≈ 0 atol=1e-7
       @test norm(sol[end] .- sol2[end]) ≈ 0 atol=1e-7
 
       sol = solve(prob, ImplicitMidpoint(extrapolant = :constant, nlsolve=NLAnderson()),dt=1/10,adaptive=false)
       sol2 = solve(prob2,ImplicitMidpoint(extrapolant = :constant, nlsolve=NLAnderson()),dt=1/10,adaptive=false)
-      @test_broken norm(sol .- sol2) ≈ 0 atol=1e-7
-      @test_broken norm(sol[end] .- sol2[end]) ≈ 0 atol=1e-7
+      @test norm(sol .- sol2) ≈ 0 atol=1e-7
+      @test norm(sol[end] .- sol2[end]) ≈ 0 atol=1e-7
     end
   end
 end

--- a/test/mass_matrix_tests.jl
+++ b/test/mass_matrix_tests.jl
@@ -112,11 +112,13 @@ using OrdinaryDiffEq, Test, LinearAlgebra, Statistics
     if iip
       sol = solve(prob,ImplicitEuler(nlsolve=NLAnderson()),dt=1/10,adaptive=false)
       sol2 = solve(prob2,ImplicitEuler(nlsolve=NLAnderson()),dt=1/10,adaptive=false)
-      @test norm(sol .- sol2) ≈ 0 atol=1e-7
+      @test_broken norm(sol .- sol2) ≈ 0 atol=1e-7
+      @test norm(sol[end] .- sol2[end]) ≈ 0 atol=1e-7
 
-      sol = solve(prob, ImplicitMidpoint(extrapolant = :constant),dt=1/10,adaptive=false)
-      sol2 = solve(prob2,ImplicitMidpoint(extrapolant = :constant),dt=1/10)
-      @test norm(sol .- sol2) ≈ 0 atol=1e-7
+      sol = solve(prob, ImplicitMidpoint(extrapolant = :constant, nlsolve=NLAnderson()),dt=1/10,adaptive=false)
+      sol2 = solve(prob2,ImplicitMidpoint(extrapolant = :constant, nlsolve=NLAnderson()),dt=1/10,adaptive=false)
+      @test_broken norm(sol .- sol2) ≈ 0 atol=1e-7
+      @test_broken norm(sol[end] .- sol2[end]) ≈ 0 atol=1e-7
     end
   end
 end


### PR DESCRIPTION
Though the `ode_convergence_tests.jl` pass successfully, I wrote a small experiment code which throws instability warning (it ran perfectly on my previous version):
```
using OrdinaryDiffEq
function f(du,u,p,t)
	du[1] = 2*u[1] + 3*u[2]
	du[2] = 4*u[1] + 5*u[2]
end
u0 = [1.0;1.0]
tspan = (0.0,1.0)
prob = ODEProblem(f,u0,tspan)
sol = solve(prob,ImplicitEuler())
print("hello")
sol2 = solve(prob,ImplicitEuler(nlsolve=NLAnderson()))


println(sol(0.5))
println(sol2(0.5))
println(sol(0.6))
println(sol2(0.6))
println(sol(0.7))
println(sol2(0.7))
println(sol(0.8))
println(sol2(0.8))
```
Which throws:
```
hello┌ Warning: Instability detected. Aborting
└ @ DiffEqBase ~/.julia/packages/DiffEqBase/8usQ9/src/integrator_interface.jl:162
[28.2652, 49.038]
ERROR: LoadError: Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] macro expansion at /home/kanav/.julia/packages/Parameters/NholY/src/Parameters.jl:743 [inlined]
 [3] ode_interpolation(::Float64, ::Function, ::Nothing, ::Type, ::Nothing, ::Symbol) at /home/kanav/.julia/dev/OrdinaryDiffEq/src/dense/generic_dense.jl:236
 [4] #call#6 at /home/kanav/.julia/dev/OrdinaryDiffEq/src/interp_func.jl:70 [inlined]
 [5] ODESolution at /home/kanav/.julia/packages/DiffEqBase/8usQ9/src/solutions/ode_solutions.jl:14 [inlined] (repeats 2 times)
 [6] top-level scope at none:0
 [7] include at ./boot.jl:317 [inlined]
 [8] include_relative(::Module, ::String) at ./loading.jl:1044
 [9] include(::Module, ::String) at ./sysimg.jl:29
 [10] exec_options(::Base.JLOptions) at ./client.jl:231
 [11] _start() at ./client.jl:425
in expression starting at /home/kanav/Projects/DiffEqExperiments/anderson-inplace.jl:15
```
 