### PR TITLE
changed name to be consistent with SSPRK nomenclature

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -154,7 +154,7 @@ module OrdinaryDiffEq
   export FunctionMap, Euler, Heun, Ralston, Midpoint, SSPRK22,
          SSPRK33, SSPRK53, SSPRK53_2N1,SSPRK53_2N2, SSPRK63, SSPRK73, SSPRK83, SSPRK432, SSPRK932,
          SSPRK54, SSPRK104, RK4, ExplicitRK, OwrenZen3, OwrenZen4, OwrenZen5,
-         LDDRK64, LDDRK46, BS3, BS5, CarpenterKennedy2N54,
+         LDDRK64, CFRLDDRK64, BS3, BS5, CarpenterKennedy2N54,
          ORK256, RK46NL, DP5, DP5Threaded, Tsit5, DP8, Vern6, Vern7, Vern8, TanYam7, TsitPap8,
          Vern9,Feagin10, Feagin12, Feagin14, CompositeAlgorithm, Anas5
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -185,7 +185,7 @@ alg_order(alg::OwrenZen3) = 3
 alg_order(alg::OwrenZen4) = 4
 alg_order(alg::OwrenZen5) = 5
 alg_order(alg::LDDRK64) = 4
-alg_order(alg::LDDRK46) = 4
+alg_order(alg::CFRLDDRK64) = 4
 
 alg_order(alg::DP5) = 5
 alg_order(alg::DP5Threaded) = 5

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -46,7 +46,7 @@ struct OwrenZen3 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct OwrenZen4 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct OwrenZen5 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct LDDRK64 <: OrdinaryDiffEqAlgorithm end
-struct LDDRK46 <: OrdinaryDiffEqAlgorithm end
+struct CFRLDDRK64 <: OrdinaryDiffEqAlgorithm end
 struct CarpenterKennedy2N54 <: OrdinaryDiffEqAlgorithm end
 struct ORK256 <: OrdinaryDiffEqAlgorithm end
 struct SSPRK22{StageLimiter,StepLimiter} <: OrdinaryDiffEqAlgorithm

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -536,7 +536,7 @@ end
 
 alg_cache(alg::Anas5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}}) = Anas5ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
 
-@cache struct LDDRK46Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
+@cache struct CFRLDDRK64Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
@@ -545,7 +545,7 @@ alg_cache(alg::Anas5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeN
   tab::TabType
 end
 
-struct LDDRK46ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+struct CFRLDDRK64ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   α1::T
   α2::T
   α3::T
@@ -563,7 +563,7 @@ struct LDDRK46ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   c5::T2
   c6::T2
 
-  function LDDRK46ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+  function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
     α1 = T(0.17985400977138)
     α2 = T(0.14081893152111)
     α3 = T(0.08255631629428)
@@ -584,14 +584,14 @@ struct LDDRK46ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   end
 end
 
-function alg_cache(alg::LDDRK46,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+function alg_cache(alg::CFRLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u)
   k = zero(rate_prototype)
   fsalfirst = zero(rate_prototype)
-  tab = LDDRK46ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
-  LDDRK46Cache(u,uprev,k,tmp,fsalfirst,tab)
+  tab = CFRLDDRK64ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  CFRLDDRK64Cache(u,uprev,k,tmp,fsalfirst,tab)
 end
 
-function alg_cache(alg::LDDRK46,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  LDDRK46ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+function alg_cache(alg::CFRLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  CFRLDDRK64ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -804,7 +804,7 @@ end
   end
 end
 
-function initialize!(integrator,cache::LDDRK46ConstantCache)
+function initialize!(integrator,cache::CFRLDDRK64ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -814,7 +814,7 @@ function initialize!(integrator,cache::LDDRK46ConstantCache)
   integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(integrator,cache::LDDRK46ConstantCache,repeat_step=false)
+@muladd function perform_step!(integrator,cache::CFRLDDRK64ConstantCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack α1,α2,α3,α4,α5,β1,β2,β3,β4,β5,β6,c2,c3,c4,c5,c6 = cache
 
@@ -844,7 +844,7 @@ end
   integrator.u = u
 end
 
-function initialize!(integrator,cache::LDDRK46Cache)
+function initialize!(integrator,cache::CFRLDDRK64Cache)
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
@@ -854,7 +854,7 @@ function initialize!(integrator,cache::LDDRK46Cache)
   integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
 end
 
-@muladd function perform_step!(integrator,cache::LDDRK46Cache,repeat_step=false)
+@muladd function perform_step!(integrator,cache::CFRLDDRK64Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack k,fsalfirst,tmp = cache
   @unpack α1,α2,α3,α4,α5,β1,β2,β3,β4,β5,β6,c2,c3,c4,c5,c6 = cache.tab

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -312,7 +312,7 @@ for prob in test_problems_nonlinear
   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 
-alg = LDDRK46()
+alg = CFRLDDRK64()
 for prob in test_problems_only_time
 	sim = test_convergence(dts, prob, alg)
 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol


### PR DESCRIPTION
@ChrisRackauckas @YingboMa  I changed the name of LDDRK46 to CFRLDDRK64 to match the nomenclature scheme as discussed here(#608) 