### PR TITLE
Implemented NDBLSRK134 from Niegemann, Diehl, Busch (2012)

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -154,7 +154,7 @@ module OrdinaryDiffEq
   export FunctionMap, Euler, Heun, Ralston, Midpoint, SSPRK22,
          SSPRK33, SSPRK53, SSPRK53_2N1,SSPRK53_2N2, SSPRK63, SSPRK73, SSPRK83, SSPRK432, SSPRK932,
          SSPRK54, SSPRK104, RK4, ExplicitRK, OwrenZen3, OwrenZen4, OwrenZen5,
-         LDDRK64, CFRLDDRK64, BS3, BS5, CarpenterKennedy2N54,
+         LDDRK64, CFRLDDRK64, NDBLSRK134, BS3, BS5, CarpenterKennedy2N54,
          ORK256, RK46NL, DP5, DP5Threaded, Tsit5, DP8, Vern6, Vern7, Vern8, TanYam7, TsitPap8,
          Vern9,Feagin10, Feagin12, Feagin14, CompositeAlgorithm, Anas5
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -186,6 +186,7 @@ alg_order(alg::OwrenZen4) = 4
 alg_order(alg::OwrenZen5) = 5
 alg_order(alg::LDDRK64) = 4
 alg_order(alg::CFRLDDRK64) = 4
+alg_order(alg::NDBLSRK134) = 4
 
 alg_order(alg::DP5) = 5
 alg_order(alg::DP5Threaded) = 5

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -47,6 +47,7 @@ struct OwrenZen4 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct OwrenZen5 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct LDDRK64 <: OrdinaryDiffEqAlgorithm end
 struct CFRLDDRK64 <: OrdinaryDiffEqAlgorithm end
+struct NDBLSRK134 <: OrdinaryDiffEqAlgorithm end
 struct CarpenterKennedy2N54 <: OrdinaryDiffEqAlgorithm end
 struct ORK256 <: OrdinaryDiffEqAlgorithm end
 struct SSPRK22{StageLimiter,StepLimiter} <: OrdinaryDiffEqAlgorithm

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -595,3 +595,105 @@ end
 function alg_cache(alg::CFRLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   CFRLDDRK64ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
+
+@cache struct NDBLSRK134Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  k::rateType
+  tmp::uType
+  fsalfirst::rateType
+  tab::TabType
+end
+
+struct NDBLSRK134ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  α2::T
+  α3::T
+  α4::T
+  α5::T
+  α6::T
+  α7::T
+  α8::T
+  α9::T
+  α10::T
+  α11::T
+  α12::T
+  α13::T
+  β1::T
+  β2::T
+  β3::T
+  β4::T
+  β5::T
+  β6::T
+  β7::T
+  β8::T
+  β9::T
+  β10::T
+  β11::T
+  β12::T
+  β13::T
+  c2::T2
+  c3::T2
+  c4::T2
+  c5::T2
+  c6::T2
+  c7::T2
+  c8::T2
+  c9::T2
+  c10::T2
+  c11::T2
+  c12::T2
+  c13::T2
+
+  function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    α2  = T(-0.6160178650170565)
+    α3  = T(-0.4449487060774118)
+    α4  = T(-1.0952033345276178)
+    α5  = T(-1.2256030785959187)
+    α6  = T(-0.2740182222332805)
+    α7  = T(-0.0411952089052647)
+    α8  = T(-0.1797084899153560)
+    α9  = T(-1.1771530652064288)
+    α10 = T(-0.4078831463120878)
+    α11 = T(-0.8295636426191777)
+    α12 = T(-4.7895970584252288)
+    α13 = T(-0.6606671432964504)
+    β1  = T(0.0271990297818803)
+    β2  = T(0.1772488819905108)
+    β3  = T(0.0378528418949694)
+    β4  = T(0.6086431830142991)
+    β5  = T(0.2154313974316100)
+    β6  = T(0.2066152563885843)
+    β7  = T(0.0415864076069797)
+    β8  = T(0.0219891884310925)
+    β9  = T(0.9893081222650993)
+    β10 = T(0.0063199019859826)
+    β11 = T(0.3749640721105318)
+    β12 = T(1.6080235151003195)
+    β13 = T(0.0961209123818189)
+    c2  = T2(0.0271990297818803)
+    c3  = T2(0.0952594339119365)
+    c4  = T2(0.1266450286591127)
+    c5  = T2(0.1825883045699772)
+    c6  = T2(0.3737511439063931)
+    c7  = T2(0.5301279418422206)
+    c8  = T2(0.5704177433952291)
+    c9  = T2(0.5885784947099155)
+    c10 = T2(0.6160769826246714)
+    c11 = T2(0.6223252334314046)
+    c12 = T2(0.6897593128753419)
+    c13 = T2(0.9126827615920843)
+    new{T,T2}(α2, α3, α4, α5, α6, α7, α8, α9, α10, α11, α12, α13, β1, β2, β3, β4, β5, β6, β7, β8, β9, β10, β11, β12, β13, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)
+  end
+end
+
+function alg_cache(alg::NDBLSRK134,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  tmp = similar(u)
+  k = zero(rate_prototype)
+  fsalfirst = zero(rate_prototype)
+  tab = NDBLSRK134ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  NDBLSRK134Cache(u,uprev,k,tmp,fsalfirst,tab)
+end
+
+function alg_cache(alg::NDBLSRK134,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  NDBLSRK134ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+end

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -887,3 +887,135 @@ end
 
   f( k,  u, p, t+dt)
 end
+
+function initialize!(integrator,cache::NDBLSRK134ConstantCache)
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.kshortsize = 1
+  integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+end
+
+@muladd function perform_step!(integrator,cache::NDBLSRK134ConstantCache,repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack α2, α3, α4, α5, α6, α7, α8, α9, α10, α11, α12, α13, β1, β2, β3, β4, β5, β6, β7, β8, β9, β10, β11, β12, β13, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13 = cache
+
+  # u0
+  u   = uprev
+  #u1
+  tmp = dt*integrator.fsalfirst
+  u   = u + β1*tmp
+  #u2
+  tmp = α2*tmp + dt*f(u, p, t+c2*dt)
+  u   = u + β2*tmp
+  #u3
+  tmp = α3*tmp + dt*f(u, p, t+c3*dt)
+  u   = u + β3*tmp
+  #u4
+  tmp = α4*tmp + dt*f(u, p, t+c4*dt)
+  u   = u + β4*tmp
+  #u5
+  tmp = α5*tmp + dt*f(u, p, t+c5*dt)
+  u   = u + β5*tmp
+  #u6
+  tmp = α6*tmp + dt*f(u, p, t+c6*dt)
+  u   = u + β6*tmp
+  #u7
+  tmp = α7*tmp + dt*f(u, p, t+c7*dt)
+  u   = u + β7*tmp
+  #u8
+  tmp = α8*tmp + dt*f(u, p, t+c8*dt)
+  u   = u + β8*tmp
+  #u9
+  tmp = α9*tmp + dt*f(u, p, t+c9*dt)
+  u   = u + β9*tmp
+  #u10
+  tmp = α10*tmp + dt*f(u, p, t+c10*dt)
+  u   = u + β10*tmp
+  #u11
+  tmp = α11*tmp + dt*f(u, p, t+c11*dt)
+  u   = u + β11*tmp
+  #u12
+  tmp = α12*tmp + dt*f(u, p, t+c12*dt)
+  u   = u + β12*tmp
+  #u13
+  tmp = α13*tmp + dt*f(u, p, t+c13*dt)
+  u   = u + β13*tmp
+  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.k[1] = integrator.fsalfirst
+  integrator.u = u
+end
+
+function initialize!(integrator,cache::NDBLSRK134Cache)
+  @unpack k,fsalfirst = cache
+  integrator.fsalfirst = fsalfirst
+  integrator.fsallast = k
+  integrator.kshortsize = 1
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+end
+
+@muladd function perform_step!(integrator,cache::NDBLSRK134Cache,repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack k,fsalfirst,tmp = cache
+  @unpack α2, α3, α4, α5, α6, α7, α8, α9, α10, α11, α12, α13, β1, β2, β3, β4, β5, β6, β7, β8, β9, β10, β11, β12, β13, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13 = cache.tab
+
+  #u0
+  @. u   = uprev
+  #u1
+  @. tmp = dt*fsalfirst
+  @. u   = u + β1*tmp
+  #u2
+  f(k, u, p, t+c2*dt)
+  @. tmp = α2*tmp + dt*k
+  @. u   = u + β2*tmp
+  #u3
+  f(k, u, p, t+c3*dt)
+  @. tmp = α3*tmp + dt*k
+  @. u   = u + β3*tmp
+  #u4
+  f(k, u, p, t+c4*dt)
+  @. tmp = α4*tmp + dt*k
+  @. u   = u + β4*tmp
+  #u5
+  f(k, u, p, t+c5*dt)
+  @. tmp = α5*tmp + dt*k
+  @. u   = u + β5*tmp
+  #u6
+  f(k, u, p, t+c6*dt)
+  @. tmp = α6*tmp + dt*k
+  @. u   = u + β6*tmp
+  #u7
+  f(k, u, p, t+c7*dt)
+  @. tmp = α7*tmp + dt*k
+  @. u   = u + β7*tmp
+  #u8
+  f(k, u, p, t+c8*dt)
+  @. tmp = α8*tmp + dt*k
+  @. u   = u + β8*tmp
+  #u9
+  f(k, u, p, t+c9*dt)
+  @. tmp = α9*tmp + dt*k
+  @. u   = u + β9*tmp
+  #u10
+  f(k, u, p, t+c10*dt)
+  @. tmp = α10*tmp + dt*k
+  @. u   = u + β10*tmp
+  #u11
+  f(k, u, p, t+c11*dt)
+  @. tmp = α11*tmp + dt*k
+  @. u   = u + β11*tmp
+  #u12
+  f(k, u, p, t+c12*dt)
+  @. tmp = α12*tmp + dt*k
+  @. u   = u + β12*tmp
+  #u13
+  f(k, u, p, t+c13*dt)
+  @. tmp = α13*tmp + dt*k
+  @. u   = u + β13*tmp
+
+  f( k,  u, p, t+dt)
+end

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -149,8 +149,8 @@ end
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
 @test all(sol.u .>= 0)
 
-#reverting back to original dts
-dts = 1 .//2 .^(8:-1:4)
+# for SSPRK53_2N2 to be in asymptotic range
+dts = 1 .//2 .^(9:-1:5)
 alg = SSPRK63()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
@@ -312,6 +312,8 @@ for prob in test_problems_nonlinear
   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 
+# for SSPRK53_2N2 to be in asymptotic range
+dts = 1 .//2 .^(7:-1:4)
 alg = CFRLDDRK64()
 for prob in test_problems_only_time
 	sim = test_convergence(dts, prob, alg)
@@ -325,6 +327,8 @@ for prob in test_problems_nonlinear
 	sim = test_convergence(dts, prob, alg)
 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
+#reverting back to original dts
+dts = 1 .//2 .^(8:-1:4)
 
 alg = NDBLSRK134()
 for prob in test_problems_only_time

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -149,8 +149,8 @@ end
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
 @test all(sol.u .>= 0)
 
-# for SSPRK53_2N2 to be in asymptotic range
-dts = 1 .//2 .^(9:-1:5)
+#reverting back to original dts
+dts = 1 .//2 .^(8:-1:4)
 alg = SSPRK63()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -325,3 +325,17 @@ for prob in test_problems_nonlinear
 	sim = test_convergence(dts, prob, alg)
 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
+
+alg = NDBLSRK134()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end


### PR DESCRIPTION
@ChrisRackauckas  @YingboMa Implemented a 13 stage, four-order low storage RK scheme NDBLSRK134. It seems to be working fine. I've also added one convergence test and an example.
**Convergence Test**
```
dts = 1 .//2 .^(8:-1:4)
f = (u,p,t)->sin(u)
(::typeof(f))(::Type{Val{:analytic}},u0,p,t) = 2*acot(exp(-t)*cot(0.5))
prob_ode_nonlinear = ODEProblem(f, 1.,(0.,0.5))
sim = test_convergence(dts, prob_ode_nonlinear, NDBLSRK134())
plot(sim)
```
![image](https://user-images.githubusercontent.com/26359940/51439667-88377300-1ce3-11e9-89d4-5028262a9193.png)

**Example**
```
f(u,p,t) = 3*t^2 - 8*t
u0 = 0.0
tspan = (0.0,5.0)
prob = ODEProblem(f,u0,tspan)
sol1 = solve(prob, Tsit5())
sol2 = solve(prob, NDBLSRK134(), dt = 1/100)
tf(t) = t^3 - 4*t^2
plot(sol2.t, tf, title="f'=3*t^2 - 8*t",label="True Solution")
plot!(sol1, label="Tsit5")
plot!(sol2, label="LSRK134")
```
![image](https://user-images.githubusercontent.com/26359940/51439684-d0569580-1ce3-11e9-984c-6c055ede6391.png)
#493 