### PR TITLE
WIP: Implemented MEBDF for linear ODEs

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -154,6 +154,8 @@ module OrdinaryDiffEq
 
   # Reexport the Alg Types
 
+  export LinearMEBDF
+
   export FunctionMap, Euler, Heun, Ralston, Midpoint, SSPRK22,
          SSPRK33, SSPRK53, SSPRK53_2N1,SSPRK53_2N2, SSPRK63, SSPRK73, SSPRK83, SSPRK432, SSPRK932,
          SSPRK54, SSPRK104, RK4, ExplicitRK, OwrenZen3, OwrenZen4, OwrenZen5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -106,6 +106,7 @@ get_current_adaptive_order(alg::QNDF,cache) = cache.order
 get_current_adaptive_order(alg::OrdinaryDiffEqAlgorithm,cache) = alg_adaptive_order(alg)
 get_current_adaptive_order(alg::CompositeAlgorithm,cache) = alg_adaptive_order(alg.algs[cache.current])
 
+alg_order(alg::LinearMEBDF) = 2
 alg_order(alg::FunctionMap) = 0
 alg_order(alg::Euler) = 1
 alg_order(alg::Heun) = 2

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -21,6 +21,13 @@ FunctionMap(;scale_by_time=false) = FunctionMap{scale_by_time}()
 
 ###############################################################################
 
+# MEBDF
+
+struct LinearMEBDF{F} <: OrdinaryDiffEqAlgorithm
+  linsolve::F
+end
+LinearMEBDF(;linsolve=DEFAULT_LINSOLVE) = LinearMEBDF{typeof(linsolve)}(linsolve)
+
 # RK methods
 
 struct ExplicitRK{TabType} <: OrdinaryDiffEqAdaptiveAlgorithm
@@ -807,7 +814,7 @@ end
 
 const MassMatrixAlgorithms = Union{OrdinaryDiffEqRosenbrockAlgorithm,
                                    OrdinaryDiffEqRosenbrockAdaptiveAlgorithm,
-                                   ImplicitEuler,ImplicitMidpoint}
+                                   ImplicitEuler,ImplicitMidpoint,LinearMEBDF}
 
 const MultistepAlgorithms = Union{IRKN3,IRKN4,
                                   ABDF2,

--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -57,3 +57,45 @@ function alg_cache(alg::LinearExponential,u,rate_prototype,uEltypeNoUnits,uBotto
   end
   LinearExponentialCache(u,uprev,tmp,rtmp,KsCache)
 end
+
+@cache mutable struct LinearMEBDFCache{uType,rateType,J,F} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+
+  z₁::rateType
+  z₂::rateType
+  z₃::rateType
+  tmp::rateType
+
+  k::rateType
+  fsalfirst::rateType
+
+  W::J
+  W₂::J
+
+  step::Bool
+  linsolve::F
+  linsolve2::F
+
+end
+
+function alg_cache(alg::LinearMEBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
+  tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+
+  k = zero(rate_prototype)
+  fsalfirst = zero(rate_prototype)
+
+  W  = similar(f.f*1)
+  W₂ = similar(W)
+
+  z₁ = zero(rate_prototype)
+  z₂ = similar(z₁)
+  z₃ = similar(z₁)
+  tmp = similar(z₁)
+
+  linsolve = alg.linsolve(Val{:init},W,u)
+  linsolve2 = alg.linsolve(Val{:init},W,u)
+
+
+LinearMEBDFCache(u,uprev,z₁,z₂,z₃,tmp,k,fsalfirst,W,W₂,true,linsolve,linsolve2)
+end

--- a/test/ode/ode_LinearMEBDF_tests.jl
+++ b/test/ode/ode_LinearMEBDF_tests.jl
@@ -1,0 +1,54 @@
+using OrdinaryDiffEq, Test, DiffEqDevTools,  DiffEqOperators, SparseArrays, LinearAlgebra
+alg = LinearMEBDF(linsolve=LinSolveFactorize(lu))
+dts = 0.5 .^(12:-1:7)
+testTol = 0.2
+u0 = rand(100)
+tspan = (0.0, 1.0)
+
+###constant linear Opeartor:
+A = spdiagm(-1 => ones(99) , 0 => fill(-2, 100) , 1 => ones(99));
+f = DiffEqArrayOperator(A);
+
+sol_analytic = (u0,p,t) -> exp(convert(Array,(t * A)))*u0
+prob = ODEProblem(ODEFunction(f; analytic = sol_analytic),u0,tspan)
+
+sim = test_convergence(dts, prob, alg)
+println("LinearMEBDF, order = ", sim.𝒪est[:l2])
+@test sim.𝒪est[:final] ≈ 2 atol=0.2
+
+
+### M≠I:
+M = rand(100,100)
+sol_analytic = (u0,p,t) -> exp(convert(Array,(t*inv(M)*A))) * u0
+prob = ODEProblem(ODEFunction(f;
+   analytic = sol_analytic, mass_matrix = M),u0,tspan)
+
+sim = test_convergence(dts, prob, alg)
+println("LinearMEBDF, order = ", sim.𝒪est[:l2])
+@test sim.𝒪est[:final] ≈ 2 atol=0.2
+
+####Non constant linear Operator:
+
+B = spdiagm(0 => ones(100));
+update_func = (_A,u,p,t) -> _A.nzval  .= t
+L = DiffEqArrayOperator(B; update_func = update_func);
+sol_analytic = (u0,p,t) -> exp(t^2/2) .* u0
+prob = ODEProblem(ODEFunction(L; analytic = sol_analytic),u0,tspan)
+
+sim = test_convergence(dts, prob, alg)
+println("LinearMEBDF, order = ", sim.𝒪est[:l2])
+@test sim.𝒪est[:final] ≈ 2 atol=0.2
+
+### M≠I:
+M= 0.5*Diagonal(ones(100))
+C = spdiagm(0 => ones(100));
+update_func = (_A,u,p,t) -> _A.nzval  .= t
+  L = DiffEqArrayOperator(C; update_func = update_func);
+
+  sol_analytic = (u0,p,t) -> exp(t^2/(2*0.5)) .* u0
+  prob = ODEProblem(ODEFunction(L;
+     analytic = sol_analytic, mass_matrix = M),u0,tspan)
+
+sim = test_convergence(dts, prob, alg)
+println("LinearMEBDF, order = ", sim.𝒪est[:l2])
+@test sim.𝒪est[:final] ≈ 2 atol=0.2

--- a/test/ode/ode_LinearMEBDF_tests.jl
+++ b/test/ode/ode_LinearMEBDF_tests.jl
@@ -5,7 +5,7 @@ testTol = 0.2
 u0 = rand(100)
 tspan = (0.0, 1.0)
 
-###constant linear Opeartor:
+### constant linear Opeartor:
 A = spdiagm(-1 => ones(99) , 0 => fill(-2, 100) , 1 => ones(99));
 f = DiffEqArrayOperator(A);
 
@@ -27,8 +27,7 @@ sim = test_convergence(dts, prob, alg)
 println("LinearMEBDF, order = ", sim.𝒪est[:l2])
 @test sim.𝒪est[:final] ≈ 2 atol=0.2
 
-####Non constant linear Operator:
-
+#### nonconstant linear Operator:
 B = spdiagm(0 => ones(100));
 update_func = (_A,u,p,t) -> _A.nzval  .= t
 L = DiffEqArrayOperator(B; update_func = update_func);


### PR DESCRIPTION
I tried to implement the MEBDF method (https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/529) for the linear case, assuming the ODE function is a DiffEqArrayOperator. It is meant to solve stiff ODEs of the form Mu’=A(t)u.