### PR TITLE
Add `vec` and `reshape` in out-of-place stiff solvers

### DIFF
--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -165,3 +165,8 @@ macro cache(expr)
     $(esc(:jac_iter))($(esc(:c))::$name) = tuple($(jac_vars...))
   end
 end
+
+_reshape(v, siz) = reshape(v, siz)
+_reshape(v::Number, siz) = v
+_vec(v) = vec(v)
+_vec(v::Number) = v

--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -57,7 +57,7 @@ function (S::NLNewton{false,<:NLSolverCache})(integrator)
   if DiffEqBase.has_invW(f)
     dz = W * b # Here W is actually invW
   else
-    dz = reshape(W \ vec(b), axes(b))
+    dz = _reshape(W \ _vec(b), axes(b))
   end
   ndz = integrator.opts.internalnorm(dz)
   z = z .+ dz
@@ -79,7 +79,7 @@ function (S::NLNewton{false,<:NLSolverCache})(integrator)
     if DiffEqBase.has_invW(f)
       dz = W * b # Here W is actually invW
     else
-      dz = reshape(W \ vec(b), axes(b))
+      dz = _reshape(W \ _vec(b), axes(b))
     end
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)

--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -57,7 +57,7 @@ function (S::NLNewton{false,<:NLSolverCache})(integrator)
   if DiffEqBase.has_invW(f)
     dz = W * b # Here W is actually invW
   else
-    dz = W \ b
+    dz = reshape(W \ vec(b), axes(b))
   end
   ndz = integrator.opts.internalnorm(dz)
   z = z .+ dz
@@ -79,7 +79,7 @@ function (S::NLNewton{false,<:NLSolverCache})(integrator)
     if DiffEqBase.has_invW(f)
       dz = W * b # Here W is actually invW
     else
-      dz = W \ b
+      dz = reshape(W \ vec(b), axes(b))
     end
     ndzprev = ndz
     ndz = integrator.opts.internalnorm(dz)

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -81,7 +81,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -275,7 +275,7 @@ end
       tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     end
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -499,7 +499,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -744,7 +744,7 @@ end
       tmp = btilde1*z₁ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆
     end
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -1046,7 +1046,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆ + btilde7*z₇
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -1360,7 +1360,7 @@ end
       tmp = btilde1*z₁ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆ + btilde7*z₇ + btilde8*z₈
     end
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -81,7 +81,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -275,7 +275,7 @@ end
       tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     end
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -499,7 +499,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -744,7 +744,7 @@ end
       tmp = btilde1*z₁ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆
     end
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -1046,7 +1046,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆ + btilde7*z₇
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -1360,7 +1360,7 @@ end
       tmp = btilde1*z₁ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆ + btilde7*z₇ + btilde8*z₈
     end
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -167,16 +167,16 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W!(integrator, cache, γ, repeat_step)
-  k₁ = reshape(W\vec((integrator.fsalfirst + γ*dT)), axes(uprev))
+  k₁ = _reshape(W\_vec((integrator.fsalfirst + γ*dT)), axes(uprev))
   f₁ = f(uprev  + dto2*k₁, p, t+dto2)
 
-  k₂ = reshape(W\vec((f₁-k₁) + k₁), axes(uprev))
+  k₂ = _reshape(W\_vec(f₁-k₁), axes(uprev)) + k₁
   u = uprev  + dt*k₂
 
   if integrator.opts.adaptive
     integrator.fsallast = f(u, p, t+dt)
 
-    k₃ = reshape(W\vec((integrator.fsallast - c₃₂*(k₂-f₁) - 2*(k₁-integrator.fsalfirst) + dt*dT)), axes(uprev))
+    k₃ = _reshape(W\_vec((integrator.fsallast - c₃₂*(k₂-f₁) - 2*(k₁-integrator.fsalfirst) + dt*dT)), axes(uprev))
 
     utilde =  dto6*(k₁ - 2*k₂ + k₃)
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol,
@@ -204,14 +204,14 @@ end
 
   #f₀ = f(uprev, p, t)
 
-  k₁ = reshape(W\vec((integrator.fsalfirst + γ*dT)), axes(uprev))
+  k₁ = _reshape(W\_vec((integrator.fsalfirst + γ*dT)), axes(uprev))
   f₁ = f(uprev  + dto2*k₁, p, t+dto2)
 
-  k₂ = reshape(W\vec((f₁-k₁) + k₁), axes(uprev))
+  k₂ = _reshape(W\_vec(f₁-k₁), axes(uprev)) + k₁
   tmp = uprev  + dt*k₂
   integrator.fsallast = f(tmp, p, t+dt)
 
-  k₃ = reshape(W\vec((integrator.fsallast - c₃₂*(k₂-f₁) - 2(k₁-integrator.fsalfirst) + dt*dT)), axes(uprev))
+  k₃ = _reshape(W\_vec((integrator.fsallast - c₃₂*(k₂-f₁) - 2(k₁-integrator.fsalfirst) + dt*dT)), axes(uprev))
   u = uprev  + dto6*(k₁ + 4k₂ + k₃)
 
   if integrator.opts.adaptive
@@ -276,19 +276,19 @@ end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
-  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k1 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k2 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + dtC31*k1 + dtC32*k2
 
-  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k3 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + b1*k1 + b2*k2 + b3*k3
   integrator.fsallast = f(u, p, t + dt)
 
@@ -407,22 +407,22 @@ end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
-  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k1 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev # +a21*k1 a21 == 0
   # du = f(u, p, t+c2*dt) c2 == 0 and a21 == 0 => du = f(uprev, p, t) == fsalfirst
 
   linsolve_tmp =  integrator.fsalfirst + dtd2*dT + dtC21*k1
 
-  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k2 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + dtC31*k1 + dtC32*k2
 
-  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k3 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   linsolve_tmp =  du + dtd4*dT + dtC41*k1 + dtC42*k2 + dtC43*k3
 
-  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k4 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + b1*k1 + b2*k2 + b3*k3 + b4*k4
   integrator.fsallast = f(u, p, t + dt)
 
@@ -568,23 +568,23 @@ end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
-  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k1 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev +a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k2 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + dtC31*k1 + dtC32*k2
 
-  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k3 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
 
   linsolve_tmp =  du + dtd4*dT + dtC41*k1 + dtC42*k2 + dtC43*k3
 
-  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k4 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + b1*k1 + b2*k2 + b3*k3 + b4*k4
   integrator.fsallast = f(u, p, t + dt)
 
@@ -742,37 +742,37 @@ end
 
   linsolve_tmp =  du + dtd1*dT
 
-  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k1 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k2 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + (dtC31*k1 + dtC32*k2)
 
-  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k3 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a41*k1 + a42*k2 + a43*k3
   du = f(u, p, t+c4*dt)
 
   linsolve_tmp =  du + dtd4*dT + (dtC41*k1 + dtC42*k2 + dtC43*k3)
 
-  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k4 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a51*k1 + a52*k2 + a53*k3 + a54*k4
   du = f(u, p, t+dt)
 
   linsolve_tmp =  du + (dtC52*k2 + dtC54*k4 + dtC51*k1 + dtC53*k3)
 
-  k5 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k5 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = u + k5
   du = f(u, p, t+dt)
 
   linsolve_tmp =  du + (dtC61*k1 + dtC62*k2 + dtC65*k5 + dtC64*k4 + dtC63*k3)
 
-  k6 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k6 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = u + k6
 
   if integrator.opts.adaptive
@@ -1000,49 +1000,49 @@ end
 
   linsolve_tmp =  du1 + dtd1*dT
 
-  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k1 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k2 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + (dtC31*k1 + dtC32*k2)
 
-  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k3 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a41*k1 + a42*k2 + a43*k3
   du = f(u, p, t+c4*dt)
 
   linsolve_tmp =  du + dtd4*dT + (dtC41*k1 + dtC42*k2 + dtC43*k3)
 
-  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k4 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a51*k1 + a52*k2 + a53*k3 + a54*k4
   du = f(u, p, t+c5*dt)
 
   linsolve_tmp = du + dtd5*dT + (dtC52*k2 + dtC54*k4 + dtC51*k1 + dtC53*k3)
 
-  k5 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k5 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = uprev  + a61*k1 + a62*k2 + a63*k3 + a64*k4 + a65*k5
   du = f(u, p, t+dt)
 
   linsolve_tmp =  du + (dtC61*k1 + dtC62*k2 + dtC63*k3 + dtC64*k4 + dtC65*k5)
 
-  k6 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k6 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = u + k6
   du = f(u, p, t+dt)
 
   linsolve_tmp = du + (dtC71*k1 + dtC72*k2 + dtC73*k3 + dtC74*k4 + dtC75*k5 + dtC76*k6)
 
-  k7 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k7 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = u + k7
   du = f(u, p, t+dt)
 
   linsolve_tmp = du + (dtC81*k1 + dtC82*k2 + dtC83*k3 + dtC84*k4 + dtC85*k5 + dtC86*k6 + dtC87*k7)
 
-  k8 = reshape(W\vec(linsolve_tmp), axes(uprev))
+  k8 = _reshape(W\_vec(linsolve_tmp), axes(uprev))
   u = u + k8
   du = f(u, p, t+dt)
 

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -167,16 +167,16 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W!(integrator, cache, γ, repeat_step)
-  k₁ = W\(integrator.fsalfirst + γ*dT)
+  k₁ = reshape(W\vec((integrator.fsalfirst + γ*dT)), axes(uprev))
   f₁ = f(uprev  + dto2*k₁, p, t+dto2)
 
-  k₂ = W\(f₁-k₁) + k₁
+  k₂ = reshape(W\vec((f₁-k₁) + k₁), axes(uprev))
   u = uprev  + dt*k₂
 
   if integrator.opts.adaptive
     integrator.fsallast = f(u, p, t+dt)
 
-    k₃ = W\(integrator.fsallast - c₃₂*(k₂-f₁) - 2*(k₁-integrator.fsalfirst) + dt*dT)
+    k₃ = reshape(W\vec((integrator.fsallast - c₃₂*(k₂-f₁) - 2*(k₁-integrator.fsalfirst) + dt*dT)), axes(uprev))
 
     utilde =  dto6*(k₁ - 2*k₂ + k₃)
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol,
@@ -204,14 +204,14 @@ end
 
   #f₀ = f(uprev, p, t)
 
-  k₁ = W\(integrator.fsalfirst + γ*dT)
+  k₁ = reshape(W\vec((integrator.fsalfirst + γ*dT)), axes(uprev))
   f₁ = f(uprev  + dto2*k₁, p, t+dto2)
 
-  k₂ = W\(f₁-k₁) + k₁
+  k₂ = reshape(W\vec((f₁-k₁) + k₁), axes(uprev))
   tmp = uprev  + dt*k₂
   integrator.fsallast = f(tmp, p, t+dt)
 
-  k₃ = W\(integrator.fsallast - c₃₂*(k₂-f₁) - 2(k₁-integrator.fsalfirst) + dt*dT)
+  k₃ = reshape(W\vec((integrator.fsallast - c₃₂*(k₂-f₁) - 2(k₁-integrator.fsalfirst) + dt*dT)), axes(uprev))
   u = uprev  + dto6*(k₁ + 4k₂ + k₃)
 
   if integrator.opts.adaptive
@@ -276,19 +276,19 @@ end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
-  k1 = W\linsolve_tmp
+  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = W\linsolve_tmp
+  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + dtC31*k1 + dtC32*k2
 
-  k3 = W\linsolve_tmp
+  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + b1*k1 + b2*k2 + b3*k3
   integrator.fsallast = f(u, p, t + dt)
 
@@ -407,22 +407,22 @@ end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
-  k1 = W\linsolve_tmp
+  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev # +a21*k1 a21 == 0
   # du = f(u, p, t+c2*dt) c2 == 0 and a21 == 0 => du = f(uprev, p, t) == fsalfirst
 
   linsolve_tmp =  integrator.fsalfirst + dtd2*dT + dtC21*k1
 
-  k2 = W\linsolve_tmp
+  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + dtC31*k1 + dtC32*k2
 
-  k3 = W\linsolve_tmp
+  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
   linsolve_tmp =  du + dtd4*dT + dtC41*k1 + dtC42*k2 + dtC43*k3
 
-  k4 = W\linsolve_tmp
+  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + b1*k1 + b2*k2 + b3*k3 + b4*k4
   integrator.fsallast = f(u, p, t + dt)
 
@@ -568,23 +568,23 @@ end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
-  k1 = W\linsolve_tmp
+  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev +a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = W\linsolve_tmp
+  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + dtC31*k1 + dtC32*k2
 
-  k3 = W\linsolve_tmp
+  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
 
   linsolve_tmp =  du + dtd4*dT + dtC41*k1 + dtC42*k2 + dtC43*k3
 
-  k4 = W\linsolve_tmp
+  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + b1*k1 + b2*k2 + b3*k3 + b4*k4
   integrator.fsallast = f(u, p, t + dt)
 
@@ -742,37 +742,37 @@ end
 
   linsolve_tmp =  du + dtd1*dT
 
-  k1 = W\linsolve_tmp
+  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = W\linsolve_tmp
+  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + (dtC31*k1 + dtC32*k2)
 
-  k3 = W\linsolve_tmp
+  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a41*k1 + a42*k2 + a43*k3
   du = f(u, p, t+c4*dt)
 
   linsolve_tmp =  du + dtd4*dT + (dtC41*k1 + dtC42*k2 + dtC43*k3)
 
-  k4 = W\linsolve_tmp
+  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a51*k1 + a52*k2 + a53*k3 + a54*k4
   du = f(u, p, t+dt)
 
   linsolve_tmp =  du + (dtC52*k2 + dtC54*k4 + dtC51*k1 + dtC53*k3)
 
-  k5 = W\linsolve_tmp
+  k5 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = u + k5
   du = f(u, p, t+dt)
 
   linsolve_tmp =  du + (dtC61*k1 + dtC62*k2 + dtC65*k5 + dtC64*k4 + dtC63*k3)
 
-  k6 = W\linsolve_tmp
+  k6 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = u + k6
 
   if integrator.opts.adaptive
@@ -1000,49 +1000,49 @@ end
 
   linsolve_tmp =  du1 + dtd1*dT
 
-  k1 = W\linsolve_tmp
+  k1 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
 
   linsolve_tmp =  du + dtd2*dT + dtC21*k1
 
-  k2 = W\linsolve_tmp
+  k2 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
 
   linsolve_tmp =  du + dtd3*dT + (dtC31*k1 + dtC32*k2)
 
-  k3 = W\linsolve_tmp
+  k3 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a41*k1 + a42*k2 + a43*k3
   du = f(u, p, t+c4*dt)
 
   linsolve_tmp =  du + dtd4*dT + (dtC41*k1 + dtC42*k2 + dtC43*k3)
 
-  k4 = W\linsolve_tmp
+  k4 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a51*k1 + a52*k2 + a53*k3 + a54*k4
   du = f(u, p, t+c5*dt)
 
   linsolve_tmp = du + dtd5*dT + (dtC52*k2 + dtC54*k4 + dtC51*k1 + dtC53*k3)
 
-  k5 = W\linsolve_tmp
+  k5 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = uprev  + a61*k1 + a62*k2 + a63*k3 + a64*k4 + a65*k5
   du = f(u, p, t+dt)
 
   linsolve_tmp =  du + (dtC61*k1 + dtC62*k2 + dtC63*k3 + dtC64*k4 + dtC65*k5)
 
-  k6 = W\linsolve_tmp
+  k6 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = u + k6
   du = f(u, p, t+dt)
 
   linsolve_tmp = du + (dtC71*k1 + dtC72*k2 + dtC73*k3 + dtC74*k4 + dtC75*k5 + dtC76*k6)
 
-  k7 = W\linsolve_tmp
+  k7 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = u + k7
   du = f(u, p, t+dt)
 
   linsolve_tmp = du + (dtC81*k1 + dtC82*k2 + dtC83*k3 + dtC84*k4 + dtC85*k5 + dtC86*k6 + dtC87*k7)
 
-  k8 = W\linsolve_tmp
+  k8 = reshape(W\vec(linsolve_tmp), axes(uprev))
   u = u + k8
   du = f(u, p, t+dt)
 

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -357,7 +357,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*zprev + btilde2*zᵧ + btilde3*z
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -468,7 +468,7 @@ end
   if integrator.opts.adaptive
     tmp = z₁/2 - z₂/2
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -727,7 +727,7 @@ end
 
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -906,7 +906,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = nlcache.W\tmp
+      est = reshape(nlcache.W\vec(tmp), axes(tmp))
     else
       est = tmp
     end

--- a/test/ode/ode_rosenbrock_tests.jl
+++ b/test/ode/ode_rosenbrock_tests.jl
@@ -305,15 +305,4 @@ sim = test_convergence(dts,prob,Rodas5(),dense_errors=true)
 
 sol = solve(prob,Rodas5())
 @test length(sol) < 20
-
-# test vec & reshape
-sz=[1 0;0 -1];
-rhs_oop(u,p,t) = du=-(.3+.5im)*u+sz
-rhs_iip(du,u,p,t) = du.=-(.3+.5im)*u+sz
-ft0=zeros(ComplexF64, 2, 2)
-tspan=(0.0,30.0)
-prob=ODEProblem(rhs_oop,ft0,tspan)
-@test_nowarn solve(prob,Rosenbrock23(autodiff=false))
-prob=ODEProblem(rhs_iip,ft0,tspan)
-@test_nowarn solve(prob,Rosenbrock23(autodiff=false))
 end

--- a/test/ode/ode_rosenbrock_tests.jl
+++ b/test/ode/ode_rosenbrock_tests.jl
@@ -305,4 +305,15 @@ sim = test_convergence(dts,prob,Rodas5(),dense_errors=true)
 
 sol = solve(prob,Rodas5())
 @test length(sol) < 20
+
+# test vec & reshape
+sz=[1 0;0 -1];
+rhs_oop(u,p,t) = du=-(.3+.5im)*u+sz
+rhs_iip(du,u,p,t) = du.=-(.3+.5im)*u+sz
+ft0=zeros(ComplexF64, 2, 2)
+tspan=(0.0,30.0)
+prob=ODEProblem(rhs_oop,ft0,tspan)
+@test_nowarn solve(prob,Rosenbrock23(autodiff=false))
+prob=ODEProblem(rhs_iip,ft0,tspan)
+@test_nowarn solve(prob,Rosenbrock23(autodiff=false))
 end

--- a/test/ode/ode_twodimlinear_tests.jl
+++ b/test/ode/ode_twodimlinear_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq
+using OrdinaryDiffEq, Test
 using DiffEqProblemLibrary.ODEProblemLibrary: importodeproblems; importodeproblems()
 import DiffEqProblemLibrary.ODEProblemLibrary: prob_ode_2Dlinear
 prob = prob_ode_2Dlinear
@@ -14,3 +14,12 @@ sol =solve(prob,Tsit5();dt=1//2^(20),progress=true,adaptive=false,maxiters=Inf)
 # plot(sol,plot_analytic=true)
 
 sol =solve(prob,ExplicitRK();dt=1//2^(4))
+
+# out-of-place 2D prob to test vec & reshape
+rhs_oop(u,p,t) = u
+ft0=ones(2, 2)
+tspan=(0.0,30.0)
+prob=ODEProblem(rhs_oop,ft0,tspan)
+@test_nowarn solve(prob,Rosenbrock23())
+@test_nowarn solve(prob,Rodas4())
+@test_nowarn solve(prob,Kvaerno5())


### PR DESCRIPTION
Fixes https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/416
regex:
```
%s/\(k. = \)W\\\(.*\)/\1reshape(W\\vec(\2), axes(uprev))/g
%s/\(est = .*\)W\\\(.*\)/\1reshape(W\\vec(\2), axes(tmp))/g
```