### PR TITLE
Implemented TSLDDRK74 Tselios, Simos (2007)

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -159,7 +159,7 @@ module OrdinaryDiffEq
   export FunctionMap, Euler, Heun, Ralston, Midpoint, SSPRK22,
          SSPRK33, SSPRK53, SSPRK53_2N1,SSPRK53_2N2, SSPRK63, SSPRK73, SSPRK83, SSPRK432, SSPRKMSVS32, SSPRKMSVS43,SSPRK932,
          SSPRK54, SSPRK104, RK4, ExplicitRK, OwrenZen3, OwrenZen4, OwrenZen5,
-         LDDRK64, CFRLDDRK64, NDBLSRK124, NDBLSRK134, NDBLSRK144, BS3, BS5, CarpenterKennedy2N54,
+         LDDRK64, CFRLDDRK64, TSLDDRK74, NDBLSRK124, NDBLSRK134, NDBLSRK144, BS3, BS5, CarpenterKennedy2N54,
          ORK256, RK46NL, DP5, DP5Threaded, Tsit5, DP8, Vern6, Vern7, Vern8, TanYam7, TsitPap8,
          Vern9,Feagin10, Feagin12, Feagin14, CompositeAlgorithm, Anas5
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -191,6 +191,7 @@ alg_order(alg::OwrenZen4) = 4
 alg_order(alg::OwrenZen5) = 5
 alg_order(alg::LDDRK64) = 4
 alg_order(alg::CFRLDDRK64) = 4
+alg_order(alg::TSLDDRK74) = 4
 alg_order(alg::NDBLSRK124) = 4
 alg_order(alg::NDBLSRK134) = 4
 alg_order(alg::NDBLSRK144) = 4

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -48,6 +48,7 @@ struct OwrenZen4 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct OwrenZen5 <: OrdinaryDiffEqAdaptiveAlgorithm end
 struct LDDRK64 <: OrdinaryDiffEqAlgorithm end
 struct CFRLDDRK64 <: OrdinaryDiffEqAlgorithm end
+struct TSLDDRK74 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK124 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK134 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK144 <: OrdinaryDiffEqAlgorithm end

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -596,7 +596,7 @@ function alg_cache(alg::CFRLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltype
   CFRLDDRK64ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
-@cache struct NDBLSRK124Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
+@cache struct TSLDDRK74Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
@@ -605,6 +605,72 @@ end
   tab::TabType
 end
 
+struct TSLDDRK74ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  α1::T
+  α2::T
+  α3::T
+  α4::T
+  α5::T
+  α6::T
+  β1::T
+  β2::T
+  β3::T
+  β4::T
+  β5::T
+  β6::T
+  β7::T
+  c2::T2
+  c3::T2
+  c4::T2
+  c5::T2
+  c6::T2
+  c7::T2
+
+  function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    α1 = T(0.241566650129646868)
+    α2 = T(0.0423866513027719953)
+    α3 = T(0.215602732678803776)
+    α4 = T(0.232328007537583987)
+    α5 = T(0.256223412574146438)
+    α6 = T(0.0978694102142697230)
+    β1 = T(0.0941840925477795334)
+    β2 = T(0.149683694803496998)
+    β3 = T(0.285204742060440058)
+    β4 = T(-0.122201846148053668)
+    β5 = T(0.0605151571191401122)
+    β6 = T(0.345986987898399296)
+    β7 = T(0.186627171718797670)
+    c2 = T2(0.335750742677426401)
+    c3 = T2(0.286254438654048527)
+    c4 = T2(0.744675262090520366)
+    c5 = T2(0.639198690801246909)
+    c6 = T2(0.723609252956949472)
+    c7 = T2(0.91124223849547205)
+    new{T,T2}(α1, α2, α3, α4, α5, α6, β1, β2, β3, β4, β5, β6, β7, c2, c3, c4, c5, c6, c7)
+  end
+end
+
+function alg_cache(alg::TSLDDRK74,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  tmp = similar(u)
+  k = zero(rate_prototype)
+  fsalfirst = zero(rate_prototype)
+  tab = TSLDDRK74ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  TSLDDRK74Cache(u,uprev,k,tmp,fsalfirst,tab)
+end
+
+function alg_cache(alg::TSLDDRK74,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  TSLDDRK74ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+end
+
+
+@cache struct NDBLSRK124Cache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  k::rateType
+  tmp::uType
+  fsalfirst::rateType
+  tab::TabType
+end
 
 struct NDBLSRK124ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   α2::T

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -902,11 +902,9 @@ end
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack α1,α2,α3,α4,α5,α6,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache
 
-  # u0
-  u   = uprev
   tmp = dt*integrator.fsalfirst
   #u1
-  u   = u + β1*tmp
+  u   = uprev + β1*tmp
   tmp = dt*f(u+α1*tmp, p, t+c2*dt)
   #u2
   u   = u + β2*tmp
@@ -946,11 +944,9 @@ end
   @unpack k,fsalfirst,tmp = cache
   @unpack α1,α2,α3,α4,α5,α6,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache.tab
 
-  #u0
-  @. u   = uprev
   @. tmp = dt*fsalfirst
   #u1
-  @. u   = u + β1*tmp
+  @. u   = uprev + β1*tmp
   f(k, u+α1*tmp, p, t+c2*dt)
   @. tmp = dt*k
   #u2

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -888,6 +888,97 @@ end
   f( k,  u, p, t+dt)
 end
 
+function initialize!(integrator,cache::TSLDDRK74ConstantCache)
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.kshortsize = 1
+  integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+end
+
+@muladd function perform_step!(integrator,cache::TSLDDRK74ConstantCache,repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack α1,α2,α3,α4,α5,α6,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache
+
+  # u0
+  u   = uprev
+  tmp = dt*integrator.fsalfirst
+  #u1
+  u   = u + β1*tmp
+  tmp = dt*f(u+α1*tmp, p, t+c2*dt)
+  #u2
+  u   = u + β2*tmp
+  tmp = dt*f(u+α2*tmp, p, t+c3*dt)
+  #u3
+  u   = u + β3*tmp
+  tmp = dt*f(u+α3*tmp, p, t+c4*dt)
+  #u4
+  u   = u + β4*tmp
+  tmp = dt*f(u+α4*tmp, p, t+c5*dt)
+  #u5
+  u   = u + β5*tmp
+  tmp = dt*f(u+α5*tmp, p, t+c6*dt)
+  #u6
+  u   = u + β6*tmp
+  tmp = dt*f(u+α6*tmp, p, t+c7*dt)
+  #u7
+  u   = u + β7*tmp
+
+  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.k[1] = integrator.fsalfirst
+  integrator.u = u
+end
+
+function initialize!(integrator,cache::TSLDDRK74Cache)
+  @unpack k,fsalfirst = cache
+  integrator.fsalfirst = fsalfirst
+  integrator.fsallast = k
+  integrator.kshortsize = 1
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+end
+
+@muladd function perform_step!(integrator,cache::TSLDDRK74Cache,repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack k,fsalfirst,tmp = cache
+  @unpack α1,α2,α3,α4,α5,α6,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache.tab
+
+  #u0
+  @. u   = uprev
+  @. tmp = dt*fsalfirst
+  #u1
+  @. u   = u + β1*tmp
+  f(k, u+α1*tmp, p, t+c2*dt)
+  @. tmp = dt*k
+  #u2
+  @. u   = u + β2*tmp
+  f(k, u+α2*tmp, p, t+c3*dt)
+  @. tmp = dt*k
+  #u3
+  @. u   = u + β3*tmp
+  f(k, u+α3*tmp, p, t+c4*dt)
+  @. tmp = dt*k
+  #u4
+  @. u   = u + β4*tmp
+  f(k, u+α4*tmp, p, t+c5*dt)
+  @. tmp = dt*k
+  #u5
+  @. u   = u + β5*tmp
+  f(k, u+α5*tmp, p, t+c6*dt)
+  @. tmp = dt*k
+  #u6
+  @. u   = u + β6*tmp
+  f(k, u+α6*tmp, p, t+c7*dt)
+  @. tmp = dt*k
+  #u7
+  @. u   = u + β7*tmp
+
+  f( k,  u, p, t+dt)
+end
+
 function initialize!(integrator,cache::NDBLSRK124ConstantCache)
   integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
   integrator.kshortsize = 1

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -356,6 +356,22 @@ for prob in test_problems_nonlinear
   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
 
+# reverting back to the original dts
+dts = 1 .//2 .^(8:-1:4)
+alg = TSLDDRK74()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
 # for NDBLSRK124 to be in asymptotic range
 dts = 1 .//2 .^(7:-1:3)
 alg = NDBLSRK124()


### PR DESCRIPTION
@ChrisRackauckas @YingboMa Implemented TSLDDRK74 from [Tselios, Simos (2007)](https://www.sciencedirect.com/science/article/pii/S0375960106016951).
**Convergence Test**
```
f = (u,p,t)->sin(u)
(::typeof(f))(::Type{Val{:analytic}},u0,p,t) = 2*acot(exp(-t)*cot(0.5))
prob_ode_nonlinear = ODEProblem(f, 1.,(0.,0.5))
dts = 1 .//2 .^(8:-1:4)
testTol = 0.25
sim = test_convergence(dts, prob_ode_nonlinear, TSLDDRK74())
plot(sim)
```
![image](https://user-images.githubusercontent.com/26359940/52171467-a42b2200-2783-11e9-8c5e-26526f9a0d5f.png)

**Example**
```
f(u,p,t) = 2*t + u
u0 = 1.0
tspan = (0.0,10.0)
prob = ODEProblem(f,u0,tspan)
sol1 = solve(prob, Tsit5())
sol2 = solve(prob, TSLDDRK74(), dt = 1/100)
tf(t) = exp(t)*(2*(-t*exp(-t) - exp(-t)) + 3)
plot(sol2.t, tf, title="Solution for f'=2*t + u",label="True")
plot!(sol1, label="Tsit5")
plot!(sol2, label="TSLDDRK74")
```
![image](https://user-images.githubusercontent.com/26359940/52171488-e8b6bd80-2783-11e9-8539-86a8f02c6392.png)

#493 