### PR TITLE
Update nlsolve

### DIFF
--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -1,22 +1,17 @@
-function (S::NLAnderson{false,<:NLSolverCache})(integrator)
+@muladd function (S::NLAnderson{false})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,tmp,W,κ,tol,c,γ,max_iter,min_iter,zs,gs = nlcache
   mass_matrix = integrator.f.mass_matrix
-  if typeof(integrator.f) <: SplitFunction
-    f = integrator.f.f1
-  else
-    f = integrator.f
-  end
+  f = integrator.f isa SplitFunction ? integrator.f.f1 : integrator.f
   # precalculations
   κtol = κ*tol
+  residuals = Array{eltype(z)}(undef, length(z), S.n + 1)
+  alphas = Array{eltype(z)}(undef, S.n)
+  ztmp = Array{eltype(z)}(undef, z isa Number ? 1 : size(z))
+  vecztmp = vec(ztmp)
 
-  # zs = zeros(S.n+1)
-  # gs = zeros(S.n+1)
-  residuals = fill(zero(eltype(z)), length(z), S.n+1)
-  alphas = fill(zero(eltype(z)), S.n)
-  # initial step of NLAnderson iteration
-  zs[1] = z
+  # initial step of fixed point iteration with Anderson acceleration
   iter = 1
   tstep = t + c*dt
   u = @. tmp + γ*z
@@ -26,27 +21,31 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
     mz = mass_matrix * z
     z₊ = dt .* f(u, p, tstep) .- mz .+ z
   end
+  zs[1] = z
   gs[1] = z₊
-  dz = z₊ .- z
-  ndz = integrator.opts.internalnorm(dz)
+
+  # circularly shift zs and gs and update zs[1]
   zptr = zs[S.n+1]
   gptr = gs[S.n+1]
-  for t = (S.n+1):-1:2
-    zs[t] = zs[t-1]
-    gs[t] = gs[t-1]
+  for t in S.n:-1:1
+    zs[t + 1] = zs[t]
+    gs[t + 1] = gs[t]
   end
-  zs[1] = zptr
-  gs[1] = gptr
-  # zs = circshift(zs, 1)
-  # gs = circshift(gs, 1)
-  z = z₊
-  zs[1] = z
-  η = nlcache.ηold
-  do_anderson = true
+  zs[1] = z₊
 
-  # anderson acceleration for fixed point iteration
-  fail_convergence = false
-  while (do_anderson || iter < min_iter) && iter < max_iter
+  # compute initial values for early stopping criterion
+  ndz = integrator.opts.internalnorm(z₊ .- z)
+
+  # update solution
+  z = z₊
+
+  # check stopping criterion for initial step
+  η = nlcache.ηold
+  do_anderson = true # TODO: this makes `min_iter` ≥ 2
+
+  # fixed point iteration with Anderson acceleration
+  while do_anderson && iter < max_iter
+    # compute next iterate
     iter += 1
     u = @. tmp + γ*z
     if mass_matrix == I
@@ -58,156 +57,148 @@ function (S::NLAnderson{false,<:NLSolverCache})(integrator)
     gs[1] = z₊
 
     mk = min(S.n, iter-1)
-    ztmp = zs[1] .- gs[1]
-    for i in 2:mk+1
-      @. residuals[:,i-1] = gs[i] - zs[i] + ztmp
+    @. ztmp = zs[1] - gs[1]
+    for i in 2:(mk + 1)
+      residuals[:, i - 1] .= _vec(gs[i]) .- _vec(zs[i]) .+ vecztmp
     end
-    resqr = qr(residuals[:,1:mk], Val(true))
-    if typeof(ztmp) <: AbstractArray
-      alphas[1:mk] = resqr \ ztmp
-    else
-      alphas[1:mk] = resqr \ [ztmp]
+    resqr = qr!(view(residuals, :, 1:mk), Val(true))
+    ldiv!(view(alphas, 1:mk), resqr, vecztmp)
+    for i in 1:mk
+        z₊ = @. z₊ + alphas[i] * (gs[i+1] - gs[1])
     end
-    for i = 1:mk
-        z₊ += alphas[i].*(gs[i+1] .- gs[1])
-    end
+
+    # circularly shift zs and gs and update zs[1]
     zptr = zs[S.n+1]
     gptr = gs[S.n+1]
-    for t = (S.n+1):-1:2
-      zs[t] = zs[t-1]
-      gs[t] = gs[t-1]
+    for t in S.n:-1:1
+      zs[t + 1] = zs[t]
+      gs[t + 1] = gs[t]
     end
-    zs[1] = zptr
-    gs[1] = gptr
-    # zs = circshift(zs, 1)
-    # gs = circshift(gs, 1)
     zs[1] = z₊
+
+    # check early stopping criterion
     ndzprev = ndz
-    dz = z₊ .- z
-    ndz = integrator.opts.internalnorm(dz)
+    ndz = integrator.opts.internalnorm(z₊ .- z)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(max_iter - iter)/(1-θ)) > κtol
-      fail_convergence = true
+    if θ ≥ 1 || ndz * θ^(max_iter - iter) > κtol * (1 - θ)
       break
     end
-    η = θ/(1-θ)
-    do_anderson = (η*ndz > κtol)
+
+    # update solution
     z = z₊
+
+    # check stopping criterion
+    η = θ / (1 - θ) # calculated for possible early stopping
+    do_anderson = iter < min_iter || η * ndz > κtol
   end
 
-  if (iter >= max_iter && do_anderson) || fail_convergence
-    integrator.force_stepfail = true
-    return (z, η, iter, true)
-  end
-
-  return (z, η, iter, false)
+  integrator.force_stepfail = do_anderson
+  z, η, iter, do_anderson
 end
 
-function (S::NLAnderson{true})(integrator)
+@muladd function (S::NLAnderson{true})(integrator)
   nlcache = S.cache
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z,z₊,dz,b,tmp,κ,tol,k,c,γ,min_iter,max_iter,zs,gs = nlcache
-  ztmp = b
   mass_matrix = integrator.f.mass_matrix
-  if typeof(integrator.f) <: SplitFunction
-    f = integrator.f.f1
-  else
-    f = integrator.f
-  end
+  f = integrator.f isa SplitFunction ? integrator.f.f1 : integrator.f
   # precalculations
   κtol = κ*tol
+  residuals = Array{eltype(z)}(undef, length(z), S.n + 1)
+  alphas = Array{eltype(z)}(undef, S.n)
+  vecb = vec(b); vecz = vec(z); vecz₊ = vec(z₊)
 
-  # zs = [zero(vec(z)) for i in 1:S.n+1]
-  # gs = [zero(vec(z)) for i in 1:S.n+1]
-  residuals = zeros(length(vec(z)), S.n+1)
-  alphas = zeros(S.n)
-  # initial step of NLAnderson iteration
-  zs[1] .= vec(z)
+  # initial step of fixed point iteration with Anderson acceleration
   iter = 1
   tstep = t + c*dt
   @. u = tmp + γ*z
-  # z₊ = dt*f(u, p, tstep)
   f(k, u, p, tstep)
   if mass_matrix == I
     @. z₊ = dt*k
   else
     @. z₊ = dt*k + z
-    mul!(ztmp, mass_matrix, z)
-    @. z₊ -= ztmp
+    mul!(b, mass_matrix, z)
+    @. z₊ -= b
   end
-  gs[1] .= vec(z₊)
-  @. dz = z₊ - z
-  ndz = integrator.opts.internalnorm(dz)
+  zs[1] .= vecz
+  gs[1] .= vecz₊
+
+  # circularly shift zs and gs and update zs[1]
   zptr = zs[S.n+1]
   gptr = gs[S.n+1]
-  for t = (S.n+1):-1:2
-    zs[t] = zs[t-1]
-    gs[t] = gs[t-1]
+  for t in S.n:-1:1
+    zs[t + 1] = zs[t]
+    gs[t + 1] = gs[t]
   end
-  zs[1] = zptr
+  zs[1] = zptr # required to not update zs[2] implicitly in the next line
+  zs[1] .= vecz₊
   gs[1] = gptr
-  # zs = circshift(zs, 1)
-  # gs = circshift(gs, 1)
+
+  # compute initial values for early stopping criterion
+  @. dz = z₊ - z
+  ndz = integrator.opts.internalnorm(dz)
+
+  # update solution
   z .= z₊
-  zs[1] .= vec(z)
+
+  # check stopping criterion for initial step
   η = nlcache.ηold
-  do_anderson = true
-  # anderson acceleration for fixed point iteration
-  fail_convergence = false
-  while (do_anderson || iter < min_iter) && iter < max_iter
+  do_anderson = true # TODO: this makes `min_iter` ≥ 2
+
+  # fixed point iteration with Anderson acceleration
+  while do_anderson && iter < max_iter
+    # compute next iterate
     iter += 1
     @. u = tmp + γ*z
     f(k, u, p, tstep)
     if mass_matrix == I
       @. z₊ = dt*k
     else
-      ztmp = b
       @. z₊ = dt*k + z
-      mul!(ztmp, mass_matrix, z)
-      @. z₊ -= ztmp
+      mul!(b, mass_matrix, z)
+      @. z₊ -= b
     end
-    gs[1] .= vec(z₊)
+    gs[1] .= vecz₊
 
     mk = min(S.n, iter-1)
-    ztmp = vec(b)
-    @. ztmp = zs[1] - gs[1]
-    for i in 2:mk+1
-      @. residuals[:,i-1] = gs[i] - zs[i] + ztmp
+    @. vecb = zs[1] - gs[1]
+    for i in 1:mk
+      @. residuals[:, i] = gs[i + 1] - zs[i + 1] + vecb
     end
-    resqr = qr!(residuals[:,1:mk], Val(true))
-    ldiv!(@view(alphas[1:mk]), resqr, ztmp)
-    vecz₊ = vec(z₊)
-    for i = 1:mk
-        vecz₊ .+= alphas[i].*(gs[i+1] .- gs[1])
+    resqr = qr!(view(residuals, :, 1:mk), Val(true))
+    ldiv!(view(alphas, 1:mk), resqr, vecb)
+    for i in 1:mk
+        @. vecz₊ += alphas[i] * (gs[i + 1] - gs[1])
     end
+
+    # circularly shift zs and gs and update zs[1]
     zptr = zs[S.n+1]
     gptr = gs[S.n+1]
-    for t = (S.n+1):-1:2
-      zs[t] = zs[t-1]
-      gs[t] = gs[t-1]
+    for t in S.n:-1:1
+      zs[t + 1] = zs[t]
+      gs[t + 1] = gs[t]
     end
-    zs[1] = zptr
+    zs[1] = zptr # required to not update zs[2] implicitly in the next line
+    zs[1] .= vecz₊
     gs[1] = gptr
-    # zs = circshift(zs, 1)
-    # gs = circshift(gs, 1)
-    zs[1] .= vec(z₊)
+
+    # check early stopping criterion
     ndzprev = ndz
     @. dz = z₊ - z
     ndz = integrator.opts.internalnorm(dz)
     θ = ndz/ndzprev
-    if θ > 1 || ndz*(θ^(max_iter - iter)/(1-θ)) > κtol
-      fail_convergence = true
+    if θ ≥ 1 || ndz * θ^(max_iter - iter) > κtol * (1 - θ)
       break
     end
-    η = θ/(1-θ)
-    do_anderson = (η*ndz > κtol)
+
+    # update solution
     @. z = z₊
+
+    # check stopping criterion
+    η = θ / (1 - θ) # calculated for possible early stopping
+    do_anderson = iter < min_iter || η * ndz > κtol
   end
 
-  if (iter >= max_iter && do_anderson) || fail_convergence
-    integrator.force_stepfail = true
-    return (z, η, iter, true)
-  end
-
-  return (z, η, iter, false)
+  integrator.force_stepfail = do_anderson
+  z, η, iter, do_anderson
 end


### PR DESCRIPTION
I tried to update Anderson acceleration to the same format as functional iteration and Newton method. Maybe it would be possible to simplify the code even more by exploiting the similar structure of all algorithms and replacing different parts (such as initialization and computation of new iterates) by function calls.

Some questions/suggestions:
- Is there a reason for using a common `NLSolverCache` instead of different types for each algorithm? (BTW, the names `AbstractNLsolveSolver` and `AbstractNLsolveCache` seem to be a bit inconsistent with the name `NLSolverCache`)
- Is there a reason for not including `alphas` and `residuals` in the cache for Anderson acceleration?
- Since StochasticDiffEq can be updated by copying and only replacing lines such as https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/nlsolve/functional.jl#L30-L34 the non-linear solvers should better be moved to DiffEqBase (or another separate package), I guess. The relevant lines could be replaced by something like `f = nlsolve_f(integrator)` which then could be implemented differently in OrdinaryDiffEq and StochasticDiffEq