### PR TITLE
RFC/WIP: Use macro to auto switch between `for` loop and broadcast

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -27,8 +27,7 @@ module OrdinaryDiffEq
   using ExponentialUtilities
 
   # Required by temporary fix in not in-place methods with 12+ broadcasts
-  # `MVector` is used by Nordsieck forms
-  import StaticArrays: SArray, MVector, SVector, @SVector
+  import StaticArrays: SArray, MArray, MVector, SVector, @SVector
 
   # Integrator Interface
   import DiffEqBase: resize!,deleteat!,addat!,full_cache,user_cache,u_cache,du_cache,

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -26,8 +26,7 @@ module OrdinaryDiffEq
 
   using ExponentialUtilities
 
-  # Required by temporary fix in not in-place methods with 12+ broadcasts
-  import StaticArrays: SArray, MArray, MVector, SVector, @SVector
+  using StaticArrays
 
   # Integrator Interface
   import DiffEqBase: resize!,deleteat!,addat!,full_cache,user_cache,u_cache,du_cache,

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -20,6 +20,7 @@ macro loop(ex)
     else
       @. @muladd $ex
     end
+    $lhs
   end |> esc
 end
 

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -13,8 +13,8 @@ macro loop(ex)
   lhs = ex.args[1]
   rhs = add_getindex(ex.args[2], iter)
   quote
-    if $lhs isa Array
-      for $iter in Base.eachindex($lhs)
+    if $lhs isa Union{Array, MArray}
+      @inbounds @simd for $iter in Base.eachindex($lhs)
         $lhs[$iter] = @muladd $rhs
       end
     else

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -580,32 +580,41 @@ function initialize!(integrator, cache::Tsit5Cache)
   integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
 end
 
-#=
 @muladd function perform_step!(integrator, cache::Tsit5Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
   a = dt*a21
-  @. tmp = uprev+a*k1
+  @loop tmp = uprev+a*k1
   f(k2, tmp, p, t+c1*dt)
-  @. tmp = uprev+dt*(a31*k1+a32*k2)
+  @loop tmp = uprev+dt*(a31*k1+a32*k2)
   f(k3, tmp, p, t+c2*dt)
-  @. tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
+  @loop tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
   f(k4, tmp, p, t+c3*dt)
-  @. tmp = uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
+  @loop tmp = uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
   f(k5, tmp, p, t+c4*dt)
-  @. tmp = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
+  @loop tmp = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
   f(k6, tmp, p, t+dt)
-  @. u = uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
+  @loop u = uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
   f(k7, u, p, t+dt)
+  if typeof(integrator.alg) <: CompositeAlgorithm
+    g7 = u
+    g6 = tmp
+    # Hairer II, page 22
+    @loop utilde = k7 - k6
+    ϱu = integrator.opts.internalnorm(utilde)
+    @loop utilde = g7 - g6
+    ϱd = integrator.opts.internalnorm(utilde)
+    integrator.eigen_est = ϱu/ϱd
+  end
   if integrator.opts.adaptive
-    @. utilde = dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7)
+    @loop utilde = dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7)
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
 end
-=#
 
+#=
 @muladd function perform_step!(integrator, cache::Tsit5Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   uidx = eachindex(integrator.uprev)
@@ -654,6 +663,7 @@ end
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end
 end
+=#
 
 function initialize!(integrator, cache::DP5ConstantCache)
   integrator.kshortsize = 4

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -537,21 +537,21 @@ end
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(uprev+a*k1, p, t+c1*dt)
-  k3 = f(uprev+dt*(a31*k1+a32*k2), p, t+c2*dt)
-  k4 = f(uprev+dt*(a41*k1+a42*k2+a43*k3), p, t+c3*dt)
-  k5 = f(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4), p, t+c4*dt)
-  g6 = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
+  k2 = f(@loop(u, uprev+a*k1), p, t+c1*dt)
+  k3 = f(@loop(u, uprev+dt*(a31*k1+a32*k2)), p, t+c2*dt)
+  k4 = f(@loop(u, uprev+dt*(a41*k1+a42*k2+a43*k3)), p, t+c3*dt)
+  k5 = f(@loop(u, uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)), p, t+c4*dt)
+  g6 = @loop u uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
   k6 = f(g6, p, t+dt)
-  u = uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
+  u = @loop u uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
   integrator.fsallast = f(u, p, t+dt); k7 = integrator.fsallast
   if typeof(integrator.alg) <: CompositeAlgorithm
     g7 = u
     # Hairer II, page 22
-    integrator.eigen_est = integrator.opts.internalnorm(k7 - k6)/integrator.opts.internalnorm(g7 - g6)
+    integrator.eigen_est = integrator.opts.internalnorm(@loop(k7, k7 - k6))/integrator.opts.internalnorm(@loop(g7, g7 - g6))
   end
   if integrator.opts.adaptive
-    utilde = dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7)
+    utilde = @loop u dt*(btilde1*k1 + btilde2*k2 + btilde3*k3 + btilde4*k4 + btilde5*k5 + btilde6*k6 + btilde7*k7)
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm)
     integrator.EEst = integrator.opts.internalnorm(atmp)
   end


### PR DESCRIPTION
`@loop u = uprev+dt*(a31*k1 + a32*k2)` is functionally equivalent with `@. u = uprev+dt*(a31*k1 + a32*k2)`.

`@loop u = uprev+dt*(a31*k1 + a32*k2)` is functionally equivalent with
```julia
k = similar(u)
@. k = uprev+dt*(a31*k1 + a32*k2)
```
.

```julia
julia> @macroexpand @loop u = uprev+dt*(a31*k1 + a32*k2)
quote
    #= REPL[115]:8 =#
    if u isa Array
        #= REPL[115]:9 =#
        for ##II#1344 = Base.eachindex(u)
            #= REPL[115]:10 =#
            u[##II#1344] = (muladd)(_getindex(dt, ##II#1344), (muladd)(_getindex(a32, ##II#1344), _getindex(k2, ##II#1344), _getindex(a31, ##II#1344) * _getindex(k1, ##II#1344)), _getindex(uprev, ##II#1344))
        end
    else
        #= REPL[115]:13 =#
        u .= (muladd).(dt, (muladd).(a32, k2, (*).(a31, k1)), uprev)
    end
end

julia> @macroexpand @loop u uprev+dt*(a31*k1 + a32*k2)
quote
    #= REPL[114]:4 =#
    if u isa Array
        #= REPL[114]:5 =#
        ##1345 = Base.similar(u)
        #= REPL[114]:6 =#
        begin
            #= REPL[115]:8 =#
            if ##1345 isa Array
                #= REPL[115]:9 =#
                for ##II#1346 = Base.eachindex(##1345)
                    #= REPL[115]:10 =#
                    ##1345[##II#1346] = (muladd)(_getindex(dt, ##II#1346), (muladd)(_getindex(a32, ##II#1346), _getindex(k2, ##II#1346), _getindex(a31, ##II#1346) * _getindex(k1, ##II#1346)), _getindex(uprev, ##II#1346))
                end
            else
                #= REPL[115]:13 =#
                ##1345 .= (muladd).(dt, (muladd).(a32, k2, (*).(a31, k1)), uprev)
            end
        end
    else
        #= REPL[114]:8 =#
        (+).(uprev, (*).(dt, (+).((*).(a31, k1), (*).(a32, k2))))
    end
end
```