### PR TITLE
Implemented DGLDDRK73_C from Toulorge, Desmet (2012)

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -159,7 +159,7 @@ module OrdinaryDiffEq
   export FunctionMap, Euler, Heun, Ralston, Midpoint, SSPRK22,
          SSPRK33, SSPRK53, SSPRK53_2N1,SSPRK53_2N2, SSPRK63, SSPRK73, SSPRK83, SSPRK432, SSPRKMSVS32, SSPRKMSVS43,SSPRK932,
          SSPRK54, SSPRK104, RK4, ExplicitRK, OwrenZen3, OwrenZen4, OwrenZen5,
-         LDDRK64, CFRLDDRK64, TSLDDRK74, NDBLSRK124, NDBLSRK134, NDBLSRK144, DGLDDRG73_C, BS3, BS5, CarpenterKennedy2N54,
+         LDDRK64, CFRLDDRK64, TSLDDRK74, NDBLSRK124, NDBLSRK134, NDBLSRK144, DGLDDRK73_C, BS3, BS5, CarpenterKennedy2N54,
          ORK256, RK46NL, DP5, DP5Threaded, Tsit5, DP8, Vern6, Vern7, Vern8, TanYam7, TsitPap8,
          Vern9,Feagin10, Feagin12, Feagin14, CompositeAlgorithm, Anas5
 

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -159,7 +159,7 @@ module OrdinaryDiffEq
   export FunctionMap, Euler, Heun, Ralston, Midpoint, SSPRK22,
          SSPRK33, SSPRK53, SSPRK53_2N1,SSPRK53_2N2, SSPRK63, SSPRK73, SSPRK83, SSPRK432, SSPRKMSVS32, SSPRKMSVS43,SSPRK932,
          SSPRK54, SSPRK104, RK4, ExplicitRK, OwrenZen3, OwrenZen4, OwrenZen5,
-         LDDRK64, CFRLDDRK64, TSLDDRK74, NDBLSRK124, NDBLSRK134, NDBLSRK144, BS3, BS5, CarpenterKennedy2N54,
+         LDDRK64, CFRLDDRK64, TSLDDRK74, NDBLSRK124, NDBLSRK134, NDBLSRK144, DGLDDRG73_C, BS3, BS5, CarpenterKennedy2N54,
          ORK256, RK46NL, DP5, DP5Threaded, Tsit5, DP8, Vern6, Vern7, Vern8, TanYam7, TsitPap8,
          Vern9,Feagin10, Feagin12, Feagin14, CompositeAlgorithm, Anas5
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -195,7 +195,7 @@ alg_order(alg::TSLDDRK74) = 4
 alg_order(alg::NDBLSRK124) = 4
 alg_order(alg::NDBLSRK134) = 4
 alg_order(alg::NDBLSRK144) = 4
-alg_order(alg::DGLDDRG73_C) = 3
+alg_order(alg::DGLDDRK73_C) = 3
 
 alg_order(alg::DP5) = 5
 alg_order(alg::DP5Threaded) = 5

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -195,6 +195,7 @@ alg_order(alg::TSLDDRK74) = 4
 alg_order(alg::NDBLSRK124) = 4
 alg_order(alg::NDBLSRK134) = 4
 alg_order(alg::NDBLSRK144) = 4
+alg_order(alg::DGLDDRG73_C) = 3
 
 alg_order(alg::DP5) = 5
 alg_order(alg::DP5Threaded) = 5

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -52,6 +52,7 @@ struct TSLDDRK74 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK124 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK134 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK144 <: OrdinaryDiffEqAlgorithm end
+struct DGLDDRG73_C <: OrdinaryDiffEqAlgorithm end
 struct CarpenterKennedy2N54 <: OrdinaryDiffEqAlgorithm end
 struct ORK256 <: OrdinaryDiffEqAlgorithm end
 struct SSPRK22{StageLimiter,StepLimiter} <: OrdinaryDiffEqAlgorithm

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -52,7 +52,7 @@ struct TSLDDRK74 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK124 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK134 <: OrdinaryDiffEqAlgorithm end
 struct NDBLSRK144 <: OrdinaryDiffEqAlgorithm end
-struct DGLDDRG73_C <: OrdinaryDiffEqAlgorithm end
+struct DGLDDRK73_C <: OrdinaryDiffEqAlgorithm end
 struct CarpenterKennedy2N54 <: OrdinaryDiffEqAlgorithm end
 struct ORK256 <: OrdinaryDiffEqAlgorithm end
 struct SSPRK22{StageLimiter,StepLimiter} <: OrdinaryDiffEqAlgorithm

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -968,3 +968,69 @@ end
 function alg_cache(alg::NDBLSRK144,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   NDBLSRK144ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
+
+@cache struct DGLDDRG73_CCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  k::rateType
+  tmp::uType
+  fsalfirst::rateType
+  tab::TabType
+end
+
+struct DGLDDRG73_CConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+  α2::T
+  α3::T
+  α4::T
+  α5::T
+  α6::T
+  α7::T
+  β1::T
+  β2::T
+  β3::T
+  β4::T
+  β5::T
+  β6::T
+  β7::T
+  c2::T2
+  c3::T2
+  c4::T2
+  c5::T2
+  c6::T2
+  c7::T2
+
+  function DGLDDRG73_CConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+    α2 = T(-0.8083163874983830)
+    α3 = T(-1.503407858773331)
+    α4 = T(-1.053064525050744)
+    α5 = T(-1.463149119280508)
+    α6 = T(-0.6592881281087830)
+    α7 = T(-1.667891931891068)
+    β1 = T(0.01197052673097840)
+    β2 = T(0.8886897793820711)
+    β3 = T(0.4578382089261419)
+    β4 = T(0.5790045253338471)
+    β5 = T(0.3160214638138484)
+    β6 = T(0.2483525368264122)
+    β7 = T(0.06771230959408840)
+    c2 = T2(0.01197052673097840)
+    c3 = T2(0.1823177940361990)
+    c4 = T2(0.5082168062551849)
+    c5 = T2(0.6532031220148590)
+    c6 = T2(0.8534401385678250)
+    c7 = T2(0.9980466084623790)
+    new{T,T2}(α2, α3, α4, α5, α6, α7, β1, β2, β3, β4, β5, β6, β7, c2, c3, c4, c5, c6, c7)
+  end
+end
+
+function alg_cache(alg::DGLDDRG73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+  tmp = similar(u)
+  k = zero(rate_prototype)
+  fsalfirst = zero(rate_prototype)
+  tab = DGLDDRG73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  DGLDDRG73_CCache(u,uprev,k,tmp,fsalfirst,tab)
+end
+
+function alg_cache(alg::DGLDDRG73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  DGLDDRG73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+end

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -969,7 +969,7 @@ function alg_cache(alg::NDBLSRK144,u,rate_prototype,uEltypeNoUnits,uBottomEltype
   NDBLSRK144ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
-@cache struct DGLDDRG73_CCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
+@cache struct DGLDDRK73_CCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k::rateType
@@ -978,7 +978,7 @@ end
   tab::TabType
 end
 
-struct DGLDDRG73_CConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+struct DGLDDRK73_CConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   α2::T
   α3::T
   α4::T
@@ -999,7 +999,7 @@ struct DGLDDRG73_CConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   c6::T2
   c7::T2
 
-  function DGLDDRG73_CConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
+  function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T,T2}
     α2 = T(-0.8083163874983830)
     α3 = T(-1.503407858773331)
     α4 = T(-1.053064525050744)
@@ -1023,14 +1023,14 @@ struct DGLDDRG73_CConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   end
 end
 
-function alg_cache(alg::DGLDDRG73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
+function alg_cache(alg::DGLDDRK73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   tmp = similar(u)
   k = zero(rate_prototype)
   fsalfirst = zero(rate_prototype)
-  tab = DGLDDRG73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
-  DGLDDRG73_CCache(u,uprev,k,tmp,fsalfirst,tab)
+  tab = DGLDDRK73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+  DGLDDRK73_CCache(u,uprev,k,tmp,fsalfirst,tab)
 end
 
-function alg_cache(alg::DGLDDRG73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  DGLDDRG73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+function alg_cache(alg::DGLDDRK73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  DGLDDRK73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -1372,7 +1372,7 @@ end
   f( k,  u, p, t+dt)
 end
 
-function initialize!(integrator,cache::DGLDDRG73_CConstantCache)
+function initialize!(integrator,cache::DGLDDRK73_CConstantCache)
   integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -1382,7 +1382,7 @@ function initialize!(integrator,cache::DGLDDRG73_CConstantCache)
   integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(integrator,cache::DGLDDRG73_CConstantCache,repeat_step=false)
+@muladd function perform_step!(integrator,cache::DGLDDRK73_CConstantCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack α2,α3,α4,α5,α6,α7,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache
 
@@ -1413,7 +1413,7 @@ end
   integrator.u = u
 end
 
-function initialize!(integrator,cache::DGLDDRG73_CCache)
+function initialize!(integrator,cache::DGLDDRK73_CCache)
   @unpack k,fsalfirst = cache
   integrator.fsalfirst = fsalfirst
   integrator.fsallast = k
@@ -1423,7 +1423,7 @@ function initialize!(integrator,cache::DGLDDRG73_CCache)
   integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
 end
 
-@muladd function perform_step!(integrator,cache::DGLDDRG73_CCache,repeat_step=false)
+@muladd function perform_step!(integrator,cache::DGLDDRK73_CCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack k,fsalfirst,tmp = cache
   @unpack α2,α3,α4,α5,α6,α7,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache.tab

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -1371,3 +1371,90 @@ end
 
   f( k,  u, p, t+dt)
 end
+
+function initialize!(integrator,cache::DGLDDRG73_CConstantCache)
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.kshortsize = 1
+  integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+end
+
+@muladd function perform_step!(integrator,cache::DGLDDRG73_CConstantCache,repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack α2,α3,α4,α5,α6,α7,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache
+
+  #u1
+  tmp = dt*integrator.fsalfirst
+  u   = uprev + β1*tmp
+  #u2
+  tmp = α2*tmp + dt*f(u, p,t+c2*dt)
+  u   = u + β2*tmp
+  #u3
+  tmp = α3*tmp + dt*f(u, p,t+c3*dt)
+  u   = u + β3*tmp
+  #u4
+  tmp = α4*tmp + dt*f(u, p,t+c4*dt)
+  u   = u + β4*tmp
+  #u5
+  tmp = α5*tmp + dt*f(u, p,t+c5*dt)
+  u   = u + β5*tmp
+  #u6
+  tmp = α6*tmp + dt*f(u, p,t+c6*dt)
+  u   = u + β6*tmp
+  #u7
+  tmp = α7*tmp + dt*f(u, p,t+c7*dt)
+  u   = u + β7*tmp
+
+  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.k[1] = integrator.fsalfirst
+  integrator.u = u
+end
+
+function initialize!(integrator,cache::DGLDDRG73_CCache)
+  @unpack k,fsalfirst = cache
+  integrator.fsalfirst = fsalfirst
+  integrator.fsallast = k
+  integrator.kshortsize = 1
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+end
+
+@muladd function perform_step!(integrator,cache::DGLDDRG73_CCache,repeat_step=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack k,fsalfirst,tmp = cache
+  @unpack α2,α3,α4,α5,α6,α7,β1,β2,β3,β4,β5,β6,β7,c2,c3,c4,c5,c6,c7 = cache.tab
+
+  #u1
+  @. tmp = dt*fsalfirst
+  @. u   = uprev + β1*tmp
+  #u2
+  f(k, u, p, t+c2*dt)
+  @. tmp = α2*tmp + dt*k
+  @. u   = u + β2*tmp
+  #u3
+  f(k, u, p, t+c3*dt)
+  @. tmp = α3*tmp + dt*k
+  @. u   = u + β3*tmp
+  #u4
+  f(k, u, p, t+c4*dt)
+  @. tmp = α4*tmp + dt*k
+  @. u   = u + β4*tmp
+  #u5
+  f(k, u, p, t+c5*dt)
+  @. tmp = α5*tmp + dt*k
+  @. u   = u + β5*tmp
+  #u6
+  f(k, u, p, t+c6*dt)
+  @. tmp = α6*tmp + dt*k
+  @. u   = u + β6*tmp
+  #u7
+  f(k, u, p, t+c7*dt)
+  @. tmp = α7*tmp + dt*k
+  @. u   = u + β7*tmp
+
+  f( k,  u, p, t+dt)
+end

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -27,399 +27,399 @@ test_problems_only_time = [prob_ode_sin, prob_ode_sin_inplace]
 test_problems_linear = [prob_ode_linear, prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear]
 test_problems_nonlinear = [prob_ode_nonlinear, prob_ode_nonlinear_inplace]
 
-f_ssp = (u,p,t) -> begin
-  sin(10t) * u * (1-u)
-end
-test_problem_ssp = ODEProblem(f_ssp, 0.1, (0., 8.))
-test_problem_ssp_long = ODEProblem(f_ssp, 0.1, (0., 1.e3))
+# f_ssp = (u,p,t) -> begin
+#   sin(10t) * u * (1-u)
+# end
+# test_problem_ssp = ODEProblem(f_ssp, 0.1, (0., 8.))
+# test_problem_ssp_long = ODEProblem(f_ssp, 0.1, (0., 1.e3))
+#
+# f_ssp_inplace = (du,u,p,t) -> begin
+#   @. du = sin(10t) * u * (1-u)
+# end
+# test_problem_ssp_inplace = ODEProblem(f_ssp_inplace, rand(3,3), (0., 8.))
+#
+#
+# # test SSP coefficient for explicit Euler
+# alg = Euler()
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg)+1.e-3, dense=false)
+# @test any(sol.u .< 0)
+#
+#
+# alg = SSPRK22()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+# # test SSP property of dense output
+# sol = solve(test_problem_ssp, alg, dt=1.)
+# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+# sol = solve(test_problem_ssp_inplace, alg, dt=1.)
+# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+#
+#
+# alg = SSPRK33()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   # This corresponds to Simpson's rule; due to symmetric quadrature nodes,
+#   # it is of degree 4 instead of 3, as would be expected.
+#   @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+# # test SSP property of dense output
+# sol = solve(test_problem_ssp, alg, dt=1.)
+# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+# sol = solve(test_problem_ssp_inplace, alg, dt=1.)
+# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+#
+#
+# alg = SSPRK53()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+#
+# alg = SSPRK53_2N1()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+# # for SSPRK53_2N2 to be in asymptotic range
+# dts = 1 .//2 .^(9:-1:5)
+# alg = SSPRK53_2N2()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+# #reverting back to original dts
+# dts = 1 .//2 .^(8:-1:4)
+# alg = SSPRK63()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+#
+# alg = SSPRK73()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+#
+# alg = SSPRK83()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+#
+# alg = SSPRK432()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   # higher order as pure quadrature
+#   @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+# # test SSP property of dense output
+# sol = solve(test_problem_ssp, alg, dt=8/5, adaptive=false)
+# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+# sol = solve(test_problem_ssp_inplace, alg, dt=8/5, adaptive=false)
+# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+#
+# alg = SSPRKMSVS32()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   # higher order as pure quadrature
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# alg = SSPRKMSVS43()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg) #shows superconvergence to 4th order
+#   @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
+# end
+#
+# alg = SSPRK932()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false,maxiters=1e7)
+# @test all(sol.u .>= 0)
+#
+#
+# alg = SSPRK54()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   # convergence order seems to be worse for this problem
+#   @test abs(sim.𝒪est[:final]+0.25-OrdinaryDiffEq.alg_order(alg)) < testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   # convergence order seems to be better for this problem
+#   @test abs(sim.𝒪est[:final]-0.5-OrdinaryDiffEq.alg_order(alg)) < testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+#
+# alg = SSPRK104()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# # test SSP coefficient
+# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+# @test all(sol.u .>= 0)
+#
+# alg = ORK256()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# alg = LDDRK64()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# # for CFRLDDRK64 to be in asymptotic range
+# dts = 1 .//2 .^(7:-1:4)
+# alg = CFRLDDRK64()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# # reverting back to the original dts
+# dts = 1 .//2 .^(8:-1:4)
+# alg = TSLDDRK74()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# # for NDBLSRK124 to be in asymptotic range
+# dts = 1 .//2 .^(7:-1:3)
+# alg = NDBLSRK124()
+# for prob in test_problems_only_time
+# 	sim = test_convergence(dts, prob, alg)
+# 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+# 	sim = test_convergence(dts, prob, alg)
+# 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+# 	sim = test_convergence(dts, prob, alg)
+# 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# #reverting back to original dts
+# dts = 1 .//2 .^(8:-1:4)
+#
+# alg = NDBLSRK134()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+#
+# alg = NDBLSRK144()
+# for prob in test_problems_only_time
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_linear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
+# for prob in test_problems_nonlinear
+#   sim = test_convergence(dts, prob, alg)
+#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+# end
 
-f_ssp_inplace = (du,u,p,t) -> begin
-  @. du = sin(10t) * u * (1-u)
-end
-test_problem_ssp_inplace = ODEProblem(f_ssp_inplace, rand(3,3), (0., 8.))
-
-
-# test SSP coefficient for explicit Euler
-alg = Euler()
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg)+1.e-3, dense=false)
-@test any(sol.u .< 0)
-
-
-alg = SSPRK22()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-# test SSP property of dense output
-sol = solve(test_problem_ssp, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-sol = solve(test_problem_ssp_inplace, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-
-
-alg = SSPRK33()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  # This corresponds to Simpson's rule; due to symmetric quadrature nodes,
-  # it is of degree 4 instead of 3, as would be expected.
-  @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-# test SSP property of dense output
-sol = solve(test_problem_ssp, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-sol = solve(test_problem_ssp_inplace, alg, dt=1.)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-
-
-alg = SSPRK53()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-
-alg = SSPRK53_2N1()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-# for SSPRK53_2N2 to be in asymptotic range
-dts = 1 .//2 .^(9:-1:5)
-alg = SSPRK53_2N2()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-#reverting back to original dts
-dts = 1 .//2 .^(8:-1:4)
-alg = SSPRK63()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-
-alg = SSPRK73()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-
-alg = SSPRK83()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-
-alg = SSPRK432()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  # higher order as pure quadrature
-  @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-# test SSP property of dense output
-sol = solve(test_problem_ssp, alg, dt=8/5, adaptive=false)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-sol = solve(test_problem_ssp_inplace, alg, dt=8/5, adaptive=false)
-@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-
-alg = SSPRKMSVS32()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  # higher order as pure quadrature
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-alg = SSPRKMSVS43()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg) #shows superconvergence to 4th order
-  @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
-end
-
-alg = SSPRK932()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false,maxiters=1e7)
-@test all(sol.u .>= 0)
-
-
-alg = SSPRK54()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  # convergence order seems to be worse for this problem
-  @test abs(sim.𝒪est[:final]+0.25-OrdinaryDiffEq.alg_order(alg)) < testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  # convergence order seems to be better for this problem
-  @test abs(sim.𝒪est[:final]-0.5-OrdinaryDiffEq.alg_order(alg)) < testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-
-alg = SSPRK104()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-# test SSP coefficient
-sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-@test all(sol.u .>= 0)
-
-alg = ORK256()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-alg = LDDRK64()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-# for CFRLDDRK64 to be in asymptotic range
-dts = 1 .//2 .^(7:-1:4)
-alg = CFRLDDRK64()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-# reverting back to the original dts
-dts = 1 .//2 .^(8:-1:4)
-alg = TSLDDRK74()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-# for NDBLSRK124 to be in asymptotic range
-dts = 1 .//2 .^(7:-1:3)
-alg = NDBLSRK124()
-for prob in test_problems_only_time
-	sim = test_convergence(dts, prob, alg)
-	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-	sim = test_convergence(dts, prob, alg)
-	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-	sim = test_convergence(dts, prob, alg)
-	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-#reverting back to original dts
-dts = 1 .//2 .^(8:-1:4)
-
-alg = NDBLSRK134()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-alg = NDBLSRK144()
-for prob in test_problems_only_time
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_linear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-for prob in test_problems_nonlinear
-  sim = test_convergence(dts, prob, alg)
-  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-end
-
-alg = DGLDDRG73_C()
+alg = DGLDDRK73_C()
 for prob in test_problems_only_time
   sim = test_convergence(dts, prob, alg)
   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -418,3 +418,17 @@ for prob in test_problems_nonlinear
   sim = test_convergence(dts, prob, alg)
   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
 end
+
+alg = DGLDDRG73_C()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -27,397 +27,397 @@ test_problems_only_time = [prob_ode_sin, prob_ode_sin_inplace]
 test_problems_linear = [prob_ode_linear, prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear]
 test_problems_nonlinear = [prob_ode_nonlinear, prob_ode_nonlinear_inplace]
 
-# f_ssp = (u,p,t) -> begin
-#   sin(10t) * u * (1-u)
-# end
-# test_problem_ssp = ODEProblem(f_ssp, 0.1, (0., 8.))
-# test_problem_ssp_long = ODEProblem(f_ssp, 0.1, (0., 1.e3))
-#
-# f_ssp_inplace = (du,u,p,t) -> begin
-#   @. du = sin(10t) * u * (1-u)
-# end
-# test_problem_ssp_inplace = ODEProblem(f_ssp_inplace, rand(3,3), (0., 8.))
-#
-#
-# # test SSP coefficient for explicit Euler
-# alg = Euler()
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg)+1.e-3, dense=false)
-# @test any(sol.u .< 0)
-#
-#
-# alg = SSPRK22()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-# # test SSP property of dense output
-# sol = solve(test_problem_ssp, alg, dt=1.)
-# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-# sol = solve(test_problem_ssp_inplace, alg, dt=1.)
-# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-#
-#
-# alg = SSPRK33()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   # This corresponds to Simpson's rule; due to symmetric quadrature nodes,
-#   # it is of degree 4 instead of 3, as would be expected.
-#   @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-# # test SSP property of dense output
-# sol = solve(test_problem_ssp, alg, dt=1.)
-# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-# sol = solve(test_problem_ssp_inplace, alg, dt=1.)
-# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-#
-#
-# alg = SSPRK53()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-#
-# alg = SSPRK53_2N1()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-# # for SSPRK53_2N2 to be in asymptotic range
-# dts = 1 .//2 .^(9:-1:5)
-# alg = SSPRK53_2N2()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-# #reverting back to original dts
-# dts = 1 .//2 .^(8:-1:4)
-# alg = SSPRK63()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-#
-# alg = SSPRK73()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-#
-# alg = SSPRK83()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-#
-# alg = SSPRK432()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   # higher order as pure quadrature
-#   @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-# # test SSP property of dense output
-# sol = solve(test_problem_ssp, alg, dt=8/5, adaptive=false)
-# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-# sol = solve(test_problem_ssp_inplace, alg, dt=8/5, adaptive=false)
-# @test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
-#
-# alg = SSPRKMSVS32()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   # higher order as pure quadrature
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# alg = SSPRKMSVS43()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg) #shows superconvergence to 4th order
-#   @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
-# end
-#
-# alg = SSPRK932()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false,maxiters=1e7)
-# @test all(sol.u .>= 0)
-#
-#
-# alg = SSPRK54()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   # convergence order seems to be worse for this problem
-#   @test abs(sim.𝒪est[:final]+0.25-OrdinaryDiffEq.alg_order(alg)) < testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   # convergence order seems to be better for this problem
-#   @test abs(sim.𝒪est[:final]-0.5-OrdinaryDiffEq.alg_order(alg)) < testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-#
-# alg = SSPRK104()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# # test SSP coefficient
-# sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
-# @test all(sol.u .>= 0)
-#
-# alg = ORK256()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# alg = LDDRK64()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# # for CFRLDDRK64 to be in asymptotic range
-# dts = 1 .//2 .^(7:-1:4)
-# alg = CFRLDDRK64()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# # reverting back to the original dts
-# dts = 1 .//2 .^(8:-1:4)
-# alg = TSLDDRK74()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# # for NDBLSRK124 to be in asymptotic range
-# dts = 1 .//2 .^(7:-1:3)
-# alg = NDBLSRK124()
-# for prob in test_problems_only_time
-# 	sim = test_convergence(dts, prob, alg)
-# 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-# 	sim = test_convergence(dts, prob, alg)
-# 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-# 	sim = test_convergence(dts, prob, alg)
-# 	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# #reverting back to original dts
-# dts = 1 .//2 .^(8:-1:4)
-#
-# alg = NDBLSRK134()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-#
-# alg = NDBLSRK144()
-# for prob in test_problems_only_time
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_linear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
-# for prob in test_problems_nonlinear
-#   sim = test_convergence(dts, prob, alg)
-#   @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
-# end
+f_ssp = (u,p,t) -> begin
+  sin(10t) * u * (1-u)
+end
+test_problem_ssp = ODEProblem(f_ssp, 0.1, (0., 8.))
+test_problem_ssp_long = ODEProblem(f_ssp, 0.1, (0., 1.e3))
+
+f_ssp_inplace = (du,u,p,t) -> begin
+  @. du = sin(10t) * u * (1-u)
+end
+test_problem_ssp_inplace = ODEProblem(f_ssp_inplace, rand(3,3), (0., 8.))
+
+
+# test SSP coefficient for explicit Euler
+alg = Euler()
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg)+1.e-3, dense=false)
+@test any(sol.u .< 0)
+
+
+alg = SSPRK22()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+# test SSP property of dense output
+sol = solve(test_problem_ssp, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+sol = solve(test_problem_ssp_inplace, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+
+
+alg = SSPRK33()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  # This corresponds to Simpson's rule; due to symmetric quadrature nodes,
+  # it is of degree 4 instead of 3, as would be expected.
+  @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+# test SSP property of dense output
+sol = solve(test_problem_ssp, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+sol = solve(test_problem_ssp_inplace, alg, dt=1.)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+
+
+alg = SSPRK53()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+
+alg = SSPRK53_2N1()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+# for SSPRK53_2N2 to be in asymptotic range
+dts = 1 .//2 .^(9:-1:5)
+alg = SSPRK53_2N2()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+#reverting back to original dts
+dts = 1 .//2 .^(8:-1:4)
+alg = SSPRK63()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+
+alg = SSPRK73()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+
+alg = SSPRK83()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+
+alg = SSPRK432()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  # higher order as pure quadrature
+  @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+# test SSP property of dense output
+sol = solve(test_problem_ssp, alg, dt=8/5, adaptive=false)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+sol = solve(test_problem_ssp_inplace, alg, dt=8/5, adaptive=false)
+@test mapreduce(t->all(0 .<= sol(t) .<= 1), (u,v)->u&&v, range(0, stop=8, length=50), init=true)
+
+alg = SSPRKMSVS32()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  # higher order as pure quadrature
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+alg = SSPRKMSVS43()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg) #shows superconvergence to 4th order
+  @test abs(sim.𝒪est[:final]-1-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+
+alg = SSPRK932()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false,maxiters=1e7)
+@test all(sol.u .>= 0)
+
+
+alg = SSPRK54()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  # convergence order seems to be worse for this problem
+  @test abs(sim.𝒪est[:final]+0.25-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  # convergence order seems to be better for this problem
+  @test abs(sim.𝒪est[:final]-0.5-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+
+alg = SSPRK104()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
+alg = ORK256()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+alg = LDDRK64()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test_broken sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+# for CFRLDDRK64 to be in asymptotic range
+dts = 1 .//2 .^(7:-1:4)
+alg = CFRLDDRK64()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+# reverting back to the original dts
+dts = 1 .//2 .^(8:-1:4)
+alg = TSLDDRK74()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+# for NDBLSRK124 to be in asymptotic range
+dts = 1 .//2 .^(7:-1:3)
+alg = NDBLSRK124()
+for prob in test_problems_only_time
+	sim = test_convergence(dts, prob, alg)
+	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+	sim = test_convergence(dts, prob, alg)
+	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+	sim = test_convergence(dts, prob, alg)
+	@test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+#reverting back to original dts
+dts = 1 .//2 .^(8:-1:4)
+
+alg = NDBLSRK134()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+
+alg = NDBLSRK144()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test sim.𝒪est[:final] ≈ OrdinaryDiffEq.alg_order(alg) atol=testTol
+end
 
 alg = DGLDDRK73_C()
 for prob in test_problems_only_time

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,69 +12,69 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
 #Start Test Script
 
 @time begin
-# if group == "All" || group == "Interface"
-#   @time @safetestset "Discrete Algorithm Tests" begin include("discrete_algorithm_test.jl") end
-#   @time @safetestset "Tstops Tests" begin include("ode/ode_tstops_tests.jl") end
-#   @time @safetestset "Backwards Tests" begin include("ode/ode_backwards_test.jl") end
-#   @time @safetestset "Initdt Tests" begin include("ode/ode_initdt_tests.jl") end
-#   @time @safetestset "Mass Matrix Tests" begin include("mass_matrix_tests.jl") end
-#   @time @safetestset "Differentiation Trait Tests" begin include("differentiation_traits_tests.jl") end
-#   @time @safetestset "Inf Tests" begin include("inf_handling.jl") end
-#   @time @safetestset "saveat Tests" begin include("ode/ode_saveat_tests.jl") end
-#   @time @safetestset "save_idxs Tests" begin include("ode/ode_saveidxs_tests.jl") end
-#   @time @safetestset "Static Array Tests" begin include("static_array_tests.jl") end
-#   @time @safetestset "Data Array Tests" begin include("data_array_test.jl") end
-#   @time @safetestset "u_modifed Tests" begin include("umodified_test.jl") end
-#   @time @safetestset "Composite Algorithm Tests" begin include("composite_algorithm_test.jl") end
-#   @time @safetestset "Complex Tests" begin include("complex_tests.jl") end
-#   @time @safetestset "Stiffness Detection Tests" begin include("stiffness_detection_test.jl") end
-#   @time @safetestset "Composite Interpolation Tests" begin include("composite_interpolation.jl") end
-#   @time @safetestset "Export tests" begin include("export_tests.jl") end
-#   @time @safetestset "Derivative Utilities Tests" begin include("utility_tests.jl") end
-#   @time @safetestset "Discrete Callback Dual Tests" begin include("discrete_callback_dual_test.jl") end
-# end
-#
-# if group == "All" || group == "Integrators"
-#   @time @safetestset "Reinit Tests" begin include("reinit_test.jl") end
-#   @time @safetestset "Events Tests" begin include("ode/ode_event_tests.jl") end
-#   @time @safetestset "Cache Tests" begin include("ode/ode_cache_tests.jl") end
-#   @time @safetestset "Iterator Tests" begin include("iterator_tests.jl") end
-#   @time @safetestset "Integrator Interface Tests" begin include("integrator_interface_tests.jl") end
-#   @time @safetestset "Add Steps Tests" begin include("ode/ode_add_steps_tests.jl") end
-#   @time @safetestset "Error Check Tests" begin include("check_error.jl") end
-# end
-#
-# if !is_APPVEYOR && ( group == "All" || group == "Regression" )
-#   @time @safetestset "Linear Tests" begin include("ode/ode_twodimlinear_tests.jl") end
-#   @time @safetestset "Dense Tests" begin include("ode/ode_dense_tests.jl") end
-# end
-#
-if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_I" )
-#   # ~ 250 s
-#   @time @safetestset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
-#   # ~ 400 s
-#   @time @safetestset "Convergence Tests" begin include("ode/ode_convergence_tests.jl") end
-#   # ~ 2 s
-#   @time @safetestset "Adams Variable Coefficients Tests" begin include("ode/adams_tests.jl") end
-#   # ~ 50 s
-#   @time @safetestset "Nordsieck Tests" begin include("ode/nordsieck_tests.jl") end
-#   @time @safetestset "Linear Methods Tests" begin include("linear_method_tests.jl") end
-#   # ~ 170 s
-  @time @safetestset "SSPRK Tests" begin include("ode/ode_ssprk_tests.jl") end
-#   # ~ 25 s
-#   @time @safetestset "OwrenZen Tests" begin include("owrenzen_tests.jl") end
-#   @time @safetestset "Runge-Kutta-Chebyshev Tests" begin include("ode/rkc_tests.jl") end
+if group == "All" || group == "Interface"
+  @time @safetestset "Discrete Algorithm Tests" begin include("discrete_algorithm_test.jl") end
+  @time @safetestset "Tstops Tests" begin include("ode/ode_tstops_tests.jl") end
+  @time @safetestset "Backwards Tests" begin include("ode/ode_backwards_test.jl") end
+  @time @safetestset "Initdt Tests" begin include("ode/ode_initdt_tests.jl") end
+  @time @safetestset "Mass Matrix Tests" begin include("mass_matrix_tests.jl") end
+  @time @safetestset "Differentiation Trait Tests" begin include("differentiation_traits_tests.jl") end
+  @time @safetestset "Inf Tests" begin include("inf_handling.jl") end
+  @time @safetestset "saveat Tests" begin include("ode/ode_saveat_tests.jl") end
+  @time @safetestset "save_idxs Tests" begin include("ode/ode_saveidxs_tests.jl") end
+  @time @safetestset "Static Array Tests" begin include("static_array_tests.jl") end
+  @time @safetestset "Data Array Tests" begin include("data_array_test.jl") end
+  @time @safetestset "u_modifed Tests" begin include("umodified_test.jl") end
+  @time @safetestset "Composite Algorithm Tests" begin include("composite_algorithm_test.jl") end
+  @time @safetestset "Complex Tests" begin include("complex_tests.jl") end
+  @time @safetestset "Stiffness Detection Tests" begin include("stiffness_detection_test.jl") end
+  @time @safetestset "Composite Interpolation Tests" begin include("composite_interpolation.jl") end
+  @time @safetestset "Export tests" begin include("export_tests.jl") end
+  @time @safetestset "Derivative Utilities Tests" begin include("utility_tests.jl") end
+  @time @safetestset "Discrete Callback Dual Tests" begin include("discrete_callback_dual_test.jl") end
 end
-#
-# if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_II" )
-#   # ~ 110 s
-#   @time @safetestset "Split Methods Tests" begin include("split_methods_tests.jl") end
-#   # ~ 550 s
-#   @time @safetestset "Rosenbrock Tests" begin include("ode/ode_rosenbrock_tests.jl") end
-#   @time @safetestset "FIRK Tests" begin include("ode/ode_firk_tests.jl") end
-#   # ~ 40 s
-#   @time @safetestset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
-#   # ~ 140 s
-#   @time @safetestset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
-# end
+
+if group == "All" || group == "Integrators"
+  @time @safetestset "Reinit Tests" begin include("reinit_test.jl") end
+  @time @safetestset "Events Tests" begin include("ode/ode_event_tests.jl") end
+  @time @safetestset "Cache Tests" begin include("ode/ode_cache_tests.jl") end
+  @time @safetestset "Iterator Tests" begin include("iterator_tests.jl") end
+  @time @safetestset "Integrator Interface Tests" begin include("integrator_interface_tests.jl") end
+  @time @safetestset "Add Steps Tests" begin include("ode/ode_add_steps_tests.jl") end
+  @time @safetestset "Error Check Tests" begin include("check_error.jl") end
+end
+
+if !is_APPVEYOR && ( group == "All" || group == "Regression" )
+  @time @safetestset "Linear Tests" begin include("ode/ode_twodimlinear_tests.jl") end
+  @time @safetestset "Dense Tests" begin include("ode/ode_dense_tests.jl") end
+end
+
+if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_I" )
+  # ~ 250 s
+  @time @safetestset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
+  # ~ 400 s
+  @time @safetestset "Convergence Tests" begin include("ode/ode_convergence_tests.jl") end
+  # ~ 2 s
+  @time @safetestset "Adams Variable Coefficients Tests" begin include("ode/adams_tests.jl") end
+  # ~ 50 s
+  @time @safetestset "Nordsieck Tests" begin include("ode/nordsieck_tests.jl") end
+  @time @safetestset "Linear Methods Tests" begin include("linear_method_tests.jl") end
+  # ~ 170 s
+  @time @safetestset "SSPRK Tests" begin include("ode/ode_ssprk_tests.jl") end
+  # ~ 25 s
+  @time @safetestset "OwrenZen Tests" begin include("owrenzen_tests.jl") end
+  @time @safetestset "Runge-Kutta-Chebyshev Tests" begin include("ode/rkc_tests.jl") end
+end
+
+if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_II" )
+  # ~ 110 s
+  @time @safetestset "Split Methods Tests" begin include("split_methods_tests.jl") end
+  # ~ 550 s
+  @time @safetestset "Rosenbrock Tests" begin include("ode/ode_rosenbrock_tests.jl") end
+  @time @safetestset "FIRK Tests" begin include("ode/ode_firk_tests.jl") end
+  # ~ 40 s
+  @time @safetestset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
+  # ~ 140 s
+  @time @safetestset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
+end
 end # @time

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,69 +12,69 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
 #Start Test Script
 
 @time begin
-if group == "All" || group == "Interface"
-  @time @safetestset "Discrete Algorithm Tests" begin include("discrete_algorithm_test.jl") end
-  @time @safetestset "Tstops Tests" begin include("ode/ode_tstops_tests.jl") end
-  @time @safetestset "Backwards Tests" begin include("ode/ode_backwards_test.jl") end
-  @time @safetestset "Initdt Tests" begin include("ode/ode_initdt_tests.jl") end
-  @time @safetestset "Mass Matrix Tests" begin include("mass_matrix_tests.jl") end
-  @time @safetestset "Differentiation Trait Tests" begin include("differentiation_traits_tests.jl") end
-  @time @safetestset "Inf Tests" begin include("inf_handling.jl") end
-  @time @safetestset "saveat Tests" begin include("ode/ode_saveat_tests.jl") end
-  @time @safetestset "save_idxs Tests" begin include("ode/ode_saveidxs_tests.jl") end
-  @time @safetestset "Static Array Tests" begin include("static_array_tests.jl") end
-  @time @safetestset "Data Array Tests" begin include("data_array_test.jl") end
-  @time @safetestset "u_modifed Tests" begin include("umodified_test.jl") end
-  @time @safetestset "Composite Algorithm Tests" begin include("composite_algorithm_test.jl") end
-  @time @safetestset "Complex Tests" begin include("complex_tests.jl") end
-  @time @safetestset "Stiffness Detection Tests" begin include("stiffness_detection_test.jl") end
-  @time @safetestset "Composite Interpolation Tests" begin include("composite_interpolation.jl") end
-  @time @safetestset "Export tests" begin include("export_tests.jl") end
-  @time @safetestset "Derivative Utilities Tests" begin include("utility_tests.jl") end
-  @time @safetestset "Discrete Callback Dual Tests" begin include("discrete_callback_dual_test.jl") end
-end
-
-if group == "All" || group == "Integrators"
-  @time @safetestset "Reinit Tests" begin include("reinit_test.jl") end
-  @time @safetestset "Events Tests" begin include("ode/ode_event_tests.jl") end
-  @time @safetestset "Cache Tests" begin include("ode/ode_cache_tests.jl") end
-  @time @safetestset "Iterator Tests" begin include("iterator_tests.jl") end
-  @time @safetestset "Integrator Interface Tests" begin include("integrator_interface_tests.jl") end
-  @time @safetestset "Add Steps Tests" begin include("ode/ode_add_steps_tests.jl") end
-  @time @safetestset "Error Check Tests" begin include("check_error.jl") end
-end
-
-if !is_APPVEYOR && ( group == "All" || group == "Regression" )
-  @time @safetestset "Linear Tests" begin include("ode/ode_twodimlinear_tests.jl") end
-  @time @safetestset "Dense Tests" begin include("ode/ode_dense_tests.jl") end
-end
-
+# if group == "All" || group == "Interface"
+#   @time @safetestset "Discrete Algorithm Tests" begin include("discrete_algorithm_test.jl") end
+#   @time @safetestset "Tstops Tests" begin include("ode/ode_tstops_tests.jl") end
+#   @time @safetestset "Backwards Tests" begin include("ode/ode_backwards_test.jl") end
+#   @time @safetestset "Initdt Tests" begin include("ode/ode_initdt_tests.jl") end
+#   @time @safetestset "Mass Matrix Tests" begin include("mass_matrix_tests.jl") end
+#   @time @safetestset "Differentiation Trait Tests" begin include("differentiation_traits_tests.jl") end
+#   @time @safetestset "Inf Tests" begin include("inf_handling.jl") end
+#   @time @safetestset "saveat Tests" begin include("ode/ode_saveat_tests.jl") end
+#   @time @safetestset "save_idxs Tests" begin include("ode/ode_saveidxs_tests.jl") end
+#   @time @safetestset "Static Array Tests" begin include("static_array_tests.jl") end
+#   @time @safetestset "Data Array Tests" begin include("data_array_test.jl") end
+#   @time @safetestset "u_modifed Tests" begin include("umodified_test.jl") end
+#   @time @safetestset "Composite Algorithm Tests" begin include("composite_algorithm_test.jl") end
+#   @time @safetestset "Complex Tests" begin include("complex_tests.jl") end
+#   @time @safetestset "Stiffness Detection Tests" begin include("stiffness_detection_test.jl") end
+#   @time @safetestset "Composite Interpolation Tests" begin include("composite_interpolation.jl") end
+#   @time @safetestset "Export tests" begin include("export_tests.jl") end
+#   @time @safetestset "Derivative Utilities Tests" begin include("utility_tests.jl") end
+#   @time @safetestset "Discrete Callback Dual Tests" begin include("discrete_callback_dual_test.jl") end
+# end
+#
+# if group == "All" || group == "Integrators"
+#   @time @safetestset "Reinit Tests" begin include("reinit_test.jl") end
+#   @time @safetestset "Events Tests" begin include("ode/ode_event_tests.jl") end
+#   @time @safetestset "Cache Tests" begin include("ode/ode_cache_tests.jl") end
+#   @time @safetestset "Iterator Tests" begin include("iterator_tests.jl") end
+#   @time @safetestset "Integrator Interface Tests" begin include("integrator_interface_tests.jl") end
+#   @time @safetestset "Add Steps Tests" begin include("ode/ode_add_steps_tests.jl") end
+#   @time @safetestset "Error Check Tests" begin include("check_error.jl") end
+# end
+#
+# if !is_APPVEYOR && ( group == "All" || group == "Regression" )
+#   @time @safetestset "Linear Tests" begin include("ode/ode_twodimlinear_tests.jl") end
+#   @time @safetestset "Dense Tests" begin include("ode/ode_dense_tests.jl") end
+# end
+#
 if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_I" )
-  # ~ 250 s
-  @time @safetestset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
-  # ~ 400 s
-  @time @safetestset "Convergence Tests" begin include("ode/ode_convergence_tests.jl") end
-  # ~ 2 s
-  @time @safetestset "Adams Variable Coefficients Tests" begin include("ode/adams_tests.jl") end
-  # ~ 50 s
-  @time @safetestset "Nordsieck Tests" begin include("ode/nordsieck_tests.jl") end
-  @time @safetestset "Linear Methods Tests" begin include("linear_method_tests.jl") end
-  # ~ 170 s
+#   # ~ 250 s
+#   @time @safetestset "Partitioned Methods Tests" begin include("partitioned_methods_tests.jl") end
+#   # ~ 400 s
+#   @time @safetestset "Convergence Tests" begin include("ode/ode_convergence_tests.jl") end
+#   # ~ 2 s
+#   @time @safetestset "Adams Variable Coefficients Tests" begin include("ode/adams_tests.jl") end
+#   # ~ 50 s
+#   @time @safetestset "Nordsieck Tests" begin include("ode/nordsieck_tests.jl") end
+#   @time @safetestset "Linear Methods Tests" begin include("linear_method_tests.jl") end
+#   # ~ 170 s
   @time @safetestset "SSPRK Tests" begin include("ode/ode_ssprk_tests.jl") end
-  # ~ 25 s
-  @time @safetestset "OwrenZen Tests" begin include("owrenzen_tests.jl") end
-  @time @safetestset "Runge-Kutta-Chebyshev Tests" begin include("ode/rkc_tests.jl") end
+#   # ~ 25 s
+#   @time @safetestset "OwrenZen Tests" begin include("owrenzen_tests.jl") end
+#   @time @safetestset "Runge-Kutta-Chebyshev Tests" begin include("ode/rkc_tests.jl") end
 end
-
-if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_II" )
-  # ~ 110 s
-  @time @safetestset "Split Methods Tests" begin include("split_methods_tests.jl") end
-  # ~ 550 s
-  @time @safetestset "Rosenbrock Tests" begin include("ode/ode_rosenbrock_tests.jl") end
-  @time @safetestset "FIRK Tests" begin include("ode/ode_firk_tests.jl") end
-  # ~ 40 s
-  @time @safetestset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
-  # ~ 140 s
-  @time @safetestset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
-end
+#
+# if !is_APPVEYOR && ( group == "All" || group == "AlgConvergence_II" )
+#   # ~ 110 s
+#   @time @safetestset "Split Methods Tests" begin include("split_methods_tests.jl") end
+#   # ~ 550 s
+#   @time @safetestset "Rosenbrock Tests" begin include("ode/ode_rosenbrock_tests.jl") end
+#   @time @safetestset "FIRK Tests" begin include("ode/ode_firk_tests.jl") end
+#   # ~ 40 s
+#   @time @safetestset "Linear-Nonlinear Methods Tests" begin include("linear_nonlinear_convergence_tests.jl") end
+#   # ~ 140 s
+#   @time @safetestset "Linear-Nonlinear Krylov Methods Tests" begin include("linear_nonlinear_krylov_tests.jl") end
+# end
 end # @time


### PR DESCRIPTION
@ChrisRackauckas @YingboMa Implemented RKC73 as DGLDDRK73_C from [Toulorge, Desmet (2012)](https://www.sciencedirect.com/science/article/pii/S0021999111006796).
**Convergence Test**
```
f = (u,p,t)->sin(u)
(::typeof(f))(::Type{Val{:analytic}},u0,p,t) = 2*acot(exp(-t)*cot(0.5))
prob_ode_nonlinear = ODEProblem(f, 1.,(0.,0.5))
dts = 1 .//2 .^(8:-1:4)
testTol = 0.25
sim = test_convergence(dts, prob_ode_nonlinear, DGLDDRK73_C())
plot(sim)
```
![image](https://user-images.githubusercontent.com/26359940/52217506-9201ce80-28be-11e9-9ae0-b86b06dea565.png)

**Example**
```
f(u,p,t) = 2*t + u
u0 = 1.0
tspan = (0.0,10.0)
prob = ODEProblem(f,u0,tspan)
sol1 = solve(prob, Tsit5())
sol2 = solve(prob, DGLDDRK73_C(), dt = 1/100)
tf(t) = exp(t)*(2*(-t*exp(-t) - exp(-t)) + 3)
plot(sol2.t, tf, title="Solution for f'=2*t + u",label="True")
plot!(sol1, label="Tsit5")
plot!(sol2, label="DGLDDRK73_C")
```
![image](https://user-images.githubusercontent.com/26359940/52228047-558e9c80-28d7-11e9-95f3-2d85c3ce4d40.png)

#493 