### PR TITLE
Refactor non-linear solvers

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -54,6 +54,7 @@ module OrdinaryDiffEq
   include("nlsolve/newton.jl")
   include("nlsolve/functional.jl")
   include("nlsolve/anderson.jl")
+  include("nlsolve/utils.jl")
 
   include("caches/basic_caches.jl")
   include("caches/low_order_rk_caches.jl")

--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -917,28 +917,27 @@ end
 end
 
 function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
+  γ, c = 1//2, 1
+  @oopnlsolve
+
   k2 = rate_prototype
   uprev3 = u
   tprev2 = t
 
-  γ, c = 1//2, 1
-  @oopnlsolve
   CNAB2ConstantCache(k2,uf,nlsolve,uprev3,tprev2)
 end
 
 function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  atmp = similar(u,uEltypeNoUnits)
+  γ, c = 1//2, 1
+  @iipnlsolve
+
   k1 = zero(rate_prototype)
   k2 = zero(rate_prototype)
   du₁ = zero(rate_prototype)
-
   uprev3 = similar(u)
   tprev2 = t
+  atmp = similar(u,uEltypeNoUnits)
 
-  γ, c = 1//2, 1
-  @iipnlsolve
   CNAB2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
 end
 
@@ -979,29 +978,28 @@ end
 end
 
 function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
+  γ, c = 1//1, 1
+  @oopnlsolve
+
   k2 = rate_prototype
   uprev2 = u
   uprev3 = u
   tprev2 = t
 
-  γ, c = 1//1, 1
-  @oopnlsolve
   CNLF2ConstantCache(k2,uf,nlsolve,uprev2,uprev3,tprev2)
 end
 
 function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  atmp = similar(u,uEltypeNoUnits)
+  γ, c = 1//1, 1
+  @iipnlsolve
+
   k1 = zero(rate_prototype)
   k2 = zero(rate_prototype)
   du₁ = zero(rate_prototype)
-
   uprev2 = similar(u)
   uprev3 = similar(u)
   tprev2 = t
+  atmp = similar(u,uEltypeNoUnits)
 
-  γ, c = 1//1, 1
-  @iipnlsolve
   CNLF2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
 end

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -8,14 +8,16 @@ end
 
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
   γ, c = 1//1, 1
   @oopnlsolve
   eulercache = ImplicitEulerConstantCache(uf,nlsolve)
-  dtₙ₋₁ = one(dt)
-  fsalfirstprev = rate_prototype
+
   nlsolve.cache.γ = 2//3
   nlsolve.cache.c = 1
+
+  dtₙ₋₁ = one(dt)
+  fsalfirstprev = rate_prototype
+
   ABDF2ConstantCache(uf, nlsolve, eulercache, dtₙ₋₁, fsalfirstprev)
 end
 
@@ -45,17 +47,20 @@ end
 
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
   γ, c = 1//1, 1
   @iipnlsolve
-  atmp = similar(u,uEltypeNoUnits)
 
   fsalfirstprev = similar(rate_prototype)
+  atmp = similar(u,uEltypeNoUnits)
+
   eulercache = ImplicitEulerCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve)
-  dtₙ₋₁ = one(dt)
-  zₙ₋₁ = similar(u)
+
   nlsolve.cache.γ = 2//3
   nlsolve.cache.c = 1
+
+  dtₙ₋₁ = one(dt)
+  zₙ₋₁ = similar(u)
+
   ABDF2Cache(u,uprev,uprev2,du1,fsalfirst,fsalfirstprev,k,z,zₙ₋₁,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,nlsolve,eulercache,dtₙ₋₁)
 end
@@ -106,37 +111,35 @@ end
 end
 
 function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
-  k2 = rate_prototype
-  uprev2 = u
-  uprev3 = u
-  uprev4 = u
-  k₁ = rate_prototype
-  k₂ = rate_prototype
-  k₃ = rate_prototype
-  du₁ = rate_prototype
-  du₂ = rate_prototype
-
   γ, c = 1//1, 1
   @oopnlsolve
+
+  k2 = rate_prototype
+  k₁ = rate_prototype; k₂ = rate_prototype; k₃ = rate_prototype
+  du₁ = rate_prototype; du₂ = rate_prototype
+
+  uprev2 = u; uprev3 = u; uprev4 = u
+
   SBDFConstantCache(1,k2,uf,nlsolve,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
 function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  atmp = similar(u,uEltypeNoUnits)
+  γ, c = 1//1, 1
+  @iipnlsolve
+
   order = alg.order
-  uprev2 = similar(u)
-  uprev3 = order >= 3 ? similar(u) : uprev2
-  uprev4 = order == 4 ? similar(u) : uprev2
+
   k₁ = similar(rate_prototype)
   k₂ = order >= 3 ? zero(rate_prototype) : k₁
   k₃ = order == 4 ? zero(rate_prototype) : k₁
   du₁ = zero(rate_prototype)
   du₂ = zero(rate_prototype)
 
-  γ, c = 1//1, 1
-  @iipnlsolve
+  uprev2 = similar(u)
+  uprev3 = order >= 3 ? similar(u) : uprev2
+  uprev4 = order == 4 ? similar(u) : uprev2
+  atmp = similar(u,uEltypeNoUnits)
+
   SBDFCache(1,u,uprev,fsalfirst,k,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
@@ -178,7 +181,9 @@ end
 end
 
 function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @oopnlsolve
+
   uprev2 = u
   dtₙ₋₁ = t
 
@@ -188,14 +193,14 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   U = fill(zero(typeof(t)), 1, 1)
 
   U!(1,U)
-  γ, c = zero(inv((1-alg.kappa))), 1
-  @oopnlsolve
 
   QNDF1ConstantCache(uf,nlsolve,D,D2,R,U,uprev2,dtₙ₋₁)
 end
 
 function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @iipnlsolve
+
   D = Array{typeof(u)}(undef, 1, 1)
   D2 = Array{typeof(u)}(undef, 1, 2)
   R = fill(zero(typeof(t)), 1, 1)
@@ -210,8 +215,6 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   utilde = similar(u)
   uprev2 = similar(u)
   dtₙ₋₁ = one(dt)
-  γ, c = zero(inv((1-alg.kappa))), 1
-  @iipnlsolve
 
   QNDF1Cache(uprev2,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
               W,uf,jac_config,linsolve,nlsolve,dtₙ₋₁)
@@ -259,7 +262,9 @@ end
 end
 
 function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @oopnlsolve
+
   uprev2 = u
   uprev3 = u
   dtₙ₋₁ = zero(t)
@@ -272,13 +277,13 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   U!(2,U)
 
-  γ, c = zero(inv((1-alg.kappa))), 1
-  @oopnlsolve
   QNDF2ConstantCache(uf,nlsolve,D,D2,R,U,uprev2,uprev3,dtₙ₋₁,dtₙ₋₂)
 end
 
 function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
+  γ, c = zero(inv((1-alg.kappa))), 1
+  @iipnlsolve
+
   D = Array{typeof(u)}(undef, 1, 2)
   D2 = Array{typeof(u)}(undef, 1, 3)
   R = fill(zero(typeof(t)), 2, 2)
@@ -296,8 +301,6 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   dtₙ₋₁ = zero(dt)
   dtₙ₋₂ = zero(dt)
 
-  γ, c = zero(inv((1-alg.kappa))), 1
-  @iipnlsolve
   QNDF2Cache(uprev2,uprev3,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
              W,uf,jac_config,linsolve,nlsolve,dtₙ₋₁,dtₙ₋₂)
 end
@@ -347,7 +350,9 @@ end
 end
 
 function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
+  γ, c = one(inv(alg.kappa)), 1
+  @oopnlsolve
+
   udiff = fill(zero(typeof(u)), 1, 6)
   dts = fill(zero(typeof(dt)), 1, 6)
   h = zero(dt)
@@ -360,13 +365,13 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
 
   max_order = 5
 
-  γ, c = inv(oneunit(eltype(alg.kappa))), 1
-  @oopnlsolve
   QNDFConstantCache(uf,nlsolve,D,D2,R,U,1,max_order,udiff,dts,tmp,h,0)
 end
 
 function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
+  γ, c = one(alg.kappa), 1
+  @iipnlsolve
+
   udiff = Array{typeof(u)}(undef, 1, 6)
   dts = fill(zero(typeof(dt)), 1, 6)
   h = zero(dt)
@@ -389,8 +394,6 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   max_order = 5
   atmp = similar(u,uEltypeNoUnits)
   utilde = similar(u)
-  γ, c = inv(oneunit(eltype(alg.kappa))), 1
-  @iipnlsolve
 
   QNDFCache(du1,fsalfirst,k,z,dz,b,D,D2,R,U,1,max_order,udiff,dts,tmp,atmp,utilde,J,
             W,uf,jac_config,linsolve,nlsolve,h,0)
@@ -422,11 +425,12 @@ end
 
 function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); tmp2 = similar(u);
-  atmp = similar(u,uEltypeNoUnits)
   γ, c = 1, 1
   @iipnlsolve
+
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); tmp2 = similar(u)
+  atmp = similar(u,uEltypeNoUnits)
+
   MEBDF2Cache(u,uprev,uprev2,du1,fsalfirst,k,z,z₁,z₂,tmp2,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve)
 end
 
@@ -437,7 +441,6 @@ end
 
 function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
   γ, c = 1, 1
   @oopnlsolve
   MEBDF2ConstantCache(uf,nlsolve)

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -6,8 +6,7 @@ end
 
 function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
-  tab = KenCarp3Tableau(uToltype,real(tTypeNoUnits))
+  tab = KenCarp3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
 
@@ -43,10 +42,9 @@ end
 
 function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  z₁ = similar(u); z₂ = similar(u)
-  z₃ = similar(u); z₄ = z
-  atmp = similar(u,uEltypeNoUnits)
+  tab = KenCarp3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   if typeof(f) <: SplitFunction
     k1 = similar(u); k2 = similar(u)
@@ -56,9 +54,9 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     k3 = nothing; k4 = nothing
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
-  tab = KenCarp3Tableau(uToltype,real(tTypeNoUnits))
-  γ, c = tab.γ, tab.c3
-  @iipnlsolve
+
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = z
+  atmp = similar(u,uEltypeNoUnits)
 
   KenCarp3Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,k1,k2,k3,k4,dz,b,tmp,atmp,J,
                 W,uf,jac_config,linsolve,nlsolve,tab)
@@ -70,15 +68,14 @@ end
   tab::Tab
 end
 
-function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
-                   uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
-  uprev3 = u
-  tprev2 = t
-
-  tab = Kvaerno4Tableau(uToltype,real(tTypeNoUnits))
+function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
+                   tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
+  tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
+
+  uprev3 = u
+  tprev2 = t
 
   Kvaerno4ConstantCache(uf,nlsolve,tab)
 end
@@ -109,14 +106,12 @@ end
 
 function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  z₁ = similar(u); z₂ = similar(u);
-  z₃ = similar(u); z₄ = similar(u)
-  z₅ = z
-  atmp = similar(u,uEltypeNoUnits)
-  tab = Kvaerno4Tableau(uToltype,real(tTypeNoUnits))
+  tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @iipnlsolve
+
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = z
+  atmp = similar(u,uEltypeNoUnits)
 
   Kvaerno4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
                 W,uf,jac_config,linsolve,nlsolve,tab)
@@ -130,12 +125,12 @@ end
 
 function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
-  uprev3 = u
-  tprev2 = t
-  tab = KenCarp4Tableau(uToltype,real(tTypeNoUnits))
+  tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
+
+  uprev3 = u
+  tprev2 = t
 
   KenCarp4ConstantCache(uf,nlsolve,tab)
 end
@@ -173,11 +168,9 @@ end
 
 function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  z₁ = similar(u); z₂ = similar(u)
-  z₃ = similar(u); z₄ = similar(u)
-  z₅ = similar(u); z₆ = z
-  atmp = similar(u,uEltypeNoUnits)
+  tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   if typeof(f) <: SplitFunction
     k1 = similar(u); k2 = similar(u)
@@ -190,9 +183,9 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
-  tab = KenCarp4Tableau(uToltype,real(tTypeNoUnits))
-  γ, c = tab.γ, tab.c3
-  @iipnlsolve
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = similar(u)
+  z₆ = z
+  atmp = similar(u,uEltypeNoUnits)
 
   KenCarp4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,k1,k2,k3,k4,k5,k6,
                 dz,b,tmp,atmp,J,
@@ -207,8 +200,7 @@ end
 
 function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
-  tab = Kvaerno5Tableau(uToltype,real(tTypeNoUnits))
+  tab = Kvaerno5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
 
@@ -243,15 +235,13 @@ end
 
 function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  z₁ = similar(u); z₂ = similar(u);
-  z₃ = similar(u); z₄ = similar(u)
-  z₅ = similar(u); z₆ = similar(u);
-  z₇ = z
-  atmp = similar(u,uEltypeNoUnits)
-  tab = Kvaerno5Tableau(uToltype,real(tTypeNoUnits))
+  tab = Kvaerno5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @iipnlsolve
+
+  z₁ = similar(u); z₂ = similar(u);  z₃ = similar(u); z₄ = similar(u); z₅ = similar(u)
+  z₆ = similar(u);  z₇ = z
+  atmp = similar(u,uEltypeNoUnits)
 
   Kvaerno5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,dz,b,tmp,atmp,J,
                 W,uf,jac_config,linsolve,nlsolve,tab)
@@ -265,8 +255,7 @@ end
 
 function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  @oopnlcachefields
-  tab = KenCarp5Tableau(uToltype,real(tTypeNoUnits))
+  tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
 
@@ -310,12 +299,9 @@ end
 
 function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  @iipnlcachefields
-  z₁ = similar(u); z₂ = similar(u);
-  z₃ = similar(u); z₄ = similar(u)
-  z₅ = similar(u); z₆ = similar(u);
-  z₇ = similar(u); z₈ = z
-  atmp = similar(u,uEltypeNoUnits)
+  tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
+  γ, c = tab.γ, tab.c3
+  @iipnlsolve
 
   if typeof(f) <: SplitFunction
     k1 = similar(u); k2 = similar(u)
@@ -330,9 +316,9 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
-  tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
-  γ, c = tab.γ, tab.c3
-  @iipnlsolve
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u)
+  z₅ = similar(u); z₆ = similar(u); z₇ = similar(u); z₈ = z
+  atmp = similar(u,uEltypeNoUnits)
 
   KenCarp5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,
                 k1,k2,k3,k4,k5,k6,k7,k8,

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -489,6 +489,10 @@ function reset_fsal!(integrator)
   # integrator.reeval_fsal = false
 end
 
+nlsolve_f(f, alg) = f isa SplitFunction && alg isa SplitAlgorithms ? f.f1 : f
+nlsolve_f(integrator::ODEIntegrator) =
+  nlsolve_f(integrator.f, unwrap_alg(integrator, true))
+
 function (integrator::ODEIntegrator)(t,deriv::Type=Val{0};idxs=nothing)
   current_interpolant(t,integrator,idxs,deriv)
 end

--- a/src/nlsolve/anderson.jl
+++ b/src/nlsolve/anderson.jl
@@ -1,15 +1,11 @@
 @muladd function (S::NLAnderson{false})(integrator)
   nlcache = S.cache
-  @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,tmp,W,κ,tol,c,γ,max_iter,min_iter,zs,gs = nlcache
+  @unpack t,dt,uprev,u,p = integrator
+  @unpack z,tmp,κ,tol,c,γ,max_iter,min_iter,zs,gs,residuals = nlcache
   mass_matrix = integrator.f.mass_matrix
-  f = integrator.f isa SplitFunction ? integrator.f.f1 : integrator.f
+  f = nlsolve_f(integrator)
   # precalculations
   κtol = κ*tol
-  residuals = Array{eltype(z)}(undef, length(z), S.n + 1)
-  alphas = Array{eltype(z)}(undef, S.n)
-  ztmp = Array{eltype(z)}(undef, z isa Number ? 1 : size(z))
-  vecztmp = vec(ztmp)
 
   # initial step of fixed point iteration with Anderson acceleration
   iter = 1
@@ -18,7 +14,7 @@
   if mass_matrix == I
     z₊ = dt .* f(u, p, tstep)
   else
-    mz = mass_matrix * z
+    mz = _reshape(mass_matrix * _vec(z), axes(z))
     z₊ = dt .* f(u, p, tstep) .- mz .+ z
   end
   zs[1] = z
@@ -51,18 +47,18 @@
     if mass_matrix == I
       z₊ = dt .* f(u, p, tstep)
     else
-      mz = mass_matrix * z
+      mz = _reshape(mass_matrix * _vec(z), axes(z))
       z₊ = dt .* f(u, p, tstep) .- mz .+ z
     end
     gs[1] = z₊
 
     mk = min(S.n, iter-1)
-    @. ztmp = zs[1] - gs[1]
+    ztmp = zs[1] - gs[1]
     for i in 2:(mk + 1)
-      residuals[:, i - 1] .= _vec(gs[i]) .- _vec(zs[i]) .+ vecztmp
+      residuals[:, i - 1] .= _vec(gs[i]) .- _vec(zs[i]) .+ _vec(ztmp)
     end
     resqr = qr!(view(residuals, :, 1:mk), Val(true))
-    ldiv!(view(alphas, 1:mk), resqr, vecztmp)
+    alphas = ztmp isa Number ? resqr \ fill(ztmp, 1, 1) : resqr \ _vec(ztmp)
     for i in 1:mk
         z₊ = @. z₊ + alphas[i] * (gs[i+1] - gs[1])
     end
@@ -98,15 +94,13 @@ end
 
 @muladd function (S::NLAnderson{true})(integrator)
   nlcache = S.cache
-  @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,z₊,dz,b,tmp,κ,tol,k,c,γ,min_iter,max_iter,zs,gs = nlcache
+  @unpack t,dt,uprev,u,p = integrator
+  @unpack z,z₊,dz,ztmp,tmp,κ,tol,k,c,γ,min_iter,max_iter,zs,gs,alphas,residuals = nlcache
   mass_matrix = integrator.f.mass_matrix
-  f = integrator.f isa SplitFunction ? integrator.f.f1 : integrator.f
+  f = nlsolve_f(integrator)
   # precalculations
   κtol = κ*tol
-  residuals = Array{eltype(z)}(undef, length(z), S.n + 1)
-  alphas = Array{eltype(z)}(undef, S.n)
-  vecb = vec(b); vecz = vec(z); vecz₊ = vec(z₊)
+  vecztmp = vec(ztmp); vecz = vec(z); vecz₊ = vec(z₊)
 
   # initial step of fixed point iteration with Anderson acceleration
   iter = 1
@@ -117,8 +111,8 @@ end
     @. z₊ = dt*k
   else
     @. z₊ = dt*k + z
-    mul!(b, mass_matrix, z)
-    @. z₊ -= b
+    mul!(vecztmp, mass_matrix, vecz)
+    @. z₊ -= ztmp
   end
   zs[1] .= vecz
   gs[1] .= vecz₊
@@ -155,18 +149,18 @@ end
       @. z₊ = dt*k
     else
       @. z₊ = dt*k + z
-      mul!(b, mass_matrix, z)
-      @. z₊ -= b
+      mul!(vecztmp, mass_matrix, vecz)
+      @. z₊ -= ztmp
     end
     gs[1] .= vecz₊
 
     mk = min(S.n, iter-1)
-    @. vecb = zs[1] - gs[1]
+    @. vecztmp = zs[1] - gs[1]
     for i in 1:mk
-      @. residuals[:, i] = gs[i + 1] - zs[i + 1] + vecb
+      @. residuals[:, i] = gs[i + 1] - zs[i + 1] + vecztmp
     end
     resqr = qr!(view(residuals, :, 1:mk), Val(true))
-    ldiv!(view(alphas, 1:mk), resqr, vecb)
+    ldiv!(view(alphas, 1:mk), resqr, vecztmp)
     for i in 1:mk
         @. vecz₊ += alphas[i] * (gs[i + 1] - gs[1])
     end

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -1,6 +1,30 @@
-abstract type AbstractNLsolveSolver end
-abstract type AbstractNLsolveCache end
-mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType,zsType} <: AbstractNLsolveCache
+abstract type AbstractNLSolver end
+abstract type AbstractNLSolverCache end
+
+mutable struct NLFunctionalCache{rateType,uType,uToltype,cType,gType} <: AbstractNLSolverCache
+  κ::uToltype
+  tol::uToltype
+  min_iter::Int
+  max_iter::Int
+  nl_iters::Int
+  z::uType
+  γ::gType
+  c::cType
+  ηold::uToltype
+  # The following fields will alias for immutable cache
+  z₊::uType
+  dz::uType
+  tmp::uType
+  ztmp::uType # can be aliased with `k` if no unit
+  k::rateType
+end
+
+NLFunctionalCache(;κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
+  NLFunctionalCache(κ, tol, min_iter, max_iter, 0, nothing, nothing, nothing,
+                    κ === nothing ? κ : zero(κ), nothing, nothing, nothing, nothing,
+                    nothing)
+
+mutable struct NLNewtonCache{rateType,uType,W,uToltype,cType,gType} <: AbstractNLSolverCache
   κ::uToltype
   tol::uToltype
   min_iter::Int
@@ -8,48 +32,73 @@ mutable struct NLSolverCache{rateType,uType,W,uToltype,cType,gType,zsType} <: Ab
   nl_iters::Int
   new_W::Bool
   z::uType
-  W::W # NLNewton -> `W` operator; NLAnderson -> Vectors; NLFunctional -> Nothing
+  W::W
   γ::gType
   c::cType
   ηold::uToltype
   # The following fields will alias for immutable cache
-  z₊::uType # Only used in `NLAnderson` and `NLFunctional`
   dz::uType
   tmp::uType
-  b::uType # can be aliased with `k` if no unit
+  ztmp::uType # can be aliased with `k` if no unit
+  k::rateType
+end
+
+NLNewtonCache(;κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
+  NLNewtonCache(κ, tol, min_iter, max_iter, 0, true, nothing, nothing, nothing, nothing,
+                κ === nothing ? κ : zero(κ), nothing, nothing, nothing, nothing)
+
+mutable struct NLAndersonCache{rateType,uType,uToltype,cType,gType,zsType,aType,rType} <: AbstractNLSolverCache
+  κ::uToltype
+  tol::uToltype
+  min_iter::Int
+  max_iter::Int
+  nl_iters::Int
+  z::uType
+  γ::gType
+  c::cType
+  ηold::uToltype
+  alphas::aType
+  residuals::rType
+  # The following fields will alias for immutable cache
+  z₊::uType
+  dz::uType
+  tmp::uType
+  ztmp::uType # can be aliased with `k` if no unit
   k::rateType
   zs::zsType
   gs::zsType
 end
 
-struct NLFunctional{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
+NLAndersonCache(; κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
+  NLAndersonCache(κ, tol, min_iter, max_iter, 0, nothing, nothing, nothing,
+                  κ === nothing ? κ : zero(κ), ntuple(i->nothing, 9)...)
+
+struct NLFunctional{iip,T<:NLFunctionalCache} <: AbstractNLSolver
   cache::T
 end
-struct NLAnderson{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
+
+struct NLAnderson{iip,T<:NLAndersonCache} <: AbstractNLSolver
   cache::T
   n::Int
-  NLAnderson{iip,T}(nlcache::T, n=5) where {iip, T<:NLSolverCache} = new(nlcache, n)
+  NLAnderson{iip,T}(nlcache::T, n=5) where {iip, T<:NLAndersonCache} = new(nlcache, n)
 end
-struct NLNewton{iip,T<:NLSolverCache} <: AbstractNLsolveSolver
+
+struct NLNewton{iip,T<:NLNewtonCache} <: AbstractNLSolver
   cache::T
 end
 
-NLSolverCache(;κ=nothing, tol=nothing, min_iter=1, max_iter=10) =
-NLSolverCache(κ, tol, min_iter, max_iter, 0, true,
-              ntuple(i->nothing, 4)...,
-              κ === nothing ? κ : zero(κ),
-              ntuple(i->nothing, 7)...)
-
 # Default `iip` to `true`, but the whole type will be reinitialized in `alg_cache`
-function NLFunctional(;kwargs...)
-  nlcache = NLSolverCache(;kwargs...)
+function NLFunctional(; kwargs...)
+  nlcache = NLFunctionalCache(; kwargs...)
   NLFunctional{true, typeof(nlcache)}(nlcache)
 end
+
 function NLAnderson(n=5; kwargs...)
-  nlcache = NLSolverCache(;kwargs...)
+  nlcache = NLAndersonCache(; kwargs...)
   NLAnderson{true, typeof(nlcache)}(nlcache, n)
 end
-function NLNewton(;kwargs...)
-  nlcache = NLSolverCache(;kwargs...)
+
+function NLNewton(; kwargs...)
+  nlcache = NLNewtonCache(; kwargs...)
   NLNewton{true, typeof(nlcache)}(nlcache)
 end

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -1,0 +1,132 @@
+DiffEqBase.@def iipnlsolve begin
+  # unpack cache of non-linear solver
+  _nlcache = alg.nlsolve.cache
+  @unpack max_iter,min_iter = _nlcache
+
+  # define additional fields of cache of non-linear solver
+  z = similar(u); dz = similar(u); tmp = similar(u); b = similar(u)
+  k = zero(rate_prototype)
+
+  # define tolerances
+  uToltype = real(uBottomEltypeNoUnits)
+  κ = _nlcache.κ === nothing ? uToltype(1//100) : uToltype(_nlcache.κ)
+  tol = _nlcache.tol === nothing ? uToltype(min(0.03,first(reltol)^(0.5))) : uToltype(_nlcache.tol)
+  ηold = one(uToltype)
+
+  # create cache of non-linear solver
+  if alg.nlsolve isa NLNewton
+    nf = nlsolve_f(f, alg)
+
+    # check if `nf` is linear
+    islin = f isa Union{ODEFunction,SplitFunction} && islinear(nf.f)
+
+    if islin
+      # get the operator
+      J = nf.f
+      W = WOperator(f.mass_matrix, dt, J, true)
+    else
+      if DiffEqBase.has_jac(f) && !DiffEqBase.has_invW(f) && f.jac_prototype !== nothing
+        W = WOperator(f, dt, true)
+        J = nothing # is J = W.J better?
+      else
+        J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+        W = similar(J)
+      end
+    end
+
+    nlcache = NLNewtonCache(κ,tol,min_iter,max_iter,10000,_nlcache.new_W,z,W,γ,c,ηold,dz,tmp,b,k)
+  elseif alg.nlsolve isa NLFunctional
+    z₊ = similar(z)
+
+    nlcache = NLFunctionalCache(κ,tol,min_iter,max_iter,10000,z,γ,c,ηold,z₊,dz,tmp,b,k)
+  elseif alg.nlsolve isa NLAnderson
+    z₊ = similar(z)
+    zs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+    gs = [zero(vec(z)) for i in 1:alg.nlsolve.n+1]
+    alphas = Array{eltype(z)}(undef, alg.nlsolve.n + 1)
+    residuals = Array{eltype(z)}(undef, length(z), alg.nlsolve.n + 1)
+
+    nlcache = NLAndersonCache(κ,tol,min_iter,max_iter,10000,z,γ,c,ηold,alphas,residuals,z₊,dz,tmp,b,k,zs,gs)
+  end
+
+  # create non-linear solver
+  _nlsolve = typeof(alg.nlsolve).name.wrapper
+  nlsolve = _nlsolve{true, typeof(nlcache)}(nlcache)
+
+  # define additional fields of cache
+  fsalfirst = zero(rate_prototype)
+  if alg.nlsolve isa NLNewton
+    if islin
+      du1 = rate_prototype
+      uf = nothing
+      jac_config = nothing
+      linsolve = alg.linsolve(Val{:init},nf,u)
+    else
+      du1 = zero(rate_prototype)
+      # if the algorithm specializes on split problems the use `nf`
+      uf = DiffEqDiffTools.UJacobianWrapper(nf,t,p)
+      jac_config = build_jac_config(alg,nf,uf,du1,uprev,u,tmp,dz)
+      linsolve = alg.linsolve(Val{:init},uf,u)
+    end
+  else
+    J = nothing
+    W = nothing
+    du1 = rate_prototype
+    uf = nothing
+    jac_config = nothing
+    linsolve = nothing
+  end
+end
+
+DiffEqBase.@def oopnlsolve begin
+  # unpack cache of non-linear solver
+  _nlcache = alg.nlsolve.cache
+  @unpack max_iter,min_iter = _nlcache
+
+  # define additional fields of cache of non-linear solver (all aliased)
+  z = uprev; dz = z; tmp = z; b = z; k = rate_prototype
+
+  # define tolerances
+  uToltype = real(uBottomEltypeNoUnits)
+  κ = _nlcache.κ === nothing ? uToltype(1//100) : uToltype(_nlcache.κ)
+  tol = _nlcache.tol === nothing ? uToltype(min(0.03,first(reltol)^(0.5))) : uToltype(_nlcache.tol)
+  ηold = one(uToltype)
+
+  # create cache of non-linear solver
+  if alg.nlsolve isa NLNewton
+    nf = nlsolve_f(f, alg)
+
+    # only use `nf` if the algorithm specializes on split eqs
+    uf = DiffEqDiffTools.UDerivativeWrapper(nf,t,p)
+
+    islin = f isa Union{ODEFunction,SplitFunction} && islinear(nf.f)
+    if islin || DiffEqBase.has_jac(f)
+      # get the operator
+      J = islin ? nf.f : f.jac(uprev, p, t)
+      if !isa(J, DiffEqBase.AbstractDiffEqLinearOperator)
+        J = DiffEqArrayOperator(J)
+      end
+      W = WOperator(f.mass_matrix, dt, J, false)
+    else
+      W = typeof(u) <: Number ? u : Matrix{uEltypeNoUnits}(undef, 0, 0) # uEltype?
+    end
+
+    nlcache = NLNewtonCache(κ,tol,min_iter,max_iter,10000,_nlcache.new_W,z,W,γ,c,ηold,dz,tmp,b,k)
+  elseif alg.nlsolve isa NLFunctional
+    uf = nothing
+
+    nlcache = NLFunctionalCache(κ,tol,min_iter,max_iter,10000,z,γ,c,ηold,z,dz,tmp,b,k)
+  elseif alg.nlsolve isa NLAnderson
+    uf = nothing
+    zs = fill(_vec(z), alg.nlsolve.n + 1)
+    gs = fill(_vec(z), alg.nlsolve.n + 1)
+    alphas = nothing
+    residuals = Array{eltype(z)}(undef, length(z), alg.nlsolve.n + 1)
+
+    nlcache = NLAndersonCache(κ,tol,min_iter,max_iter,10000,z,γ,c,ηold,alphas,residuals,z,dz,tmp,b,k,zs,gs)
+  end
+
+  # create non-linear solver
+  _nlsolve = typeof(alg.nlsolve).name.wrapper
+  nlsolve = _nlsolve{false, typeof(nlcache)}(nlcache)
+end

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -917,7 +917,7 @@ end
 ### STEP 2
   nlcache.tmp = z₁
   nlcache.c = 2
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
   z,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
   z₂ = z₁ + z
@@ -925,7 +925,7 @@ end
   tmp2 = 0.5uprev + z₁ - 0.5z₂
   nlcache.tmp = tmp2
   nlcache.c = 1
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
   z,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
   u = tmp2 + z
@@ -972,7 +972,7 @@ end
 ### STEP 2
  nlcache.tmp = z₁
  nlcache.c = 2
- nlcache.new_W = false
+ nlsolve! isa NLNewton && (nlcache.new_W = false)
  z,η,iter,fail_convergence = nlsolve!(integrator)
  fail_convergence && return
  @. z₂ = z₁ + z
@@ -981,7 +981,7 @@ end
  @. tmp2 = 0.5uprev + z₁ - 0.5z₂
  nlcache.tmp = tmp2
  nlcache.c = 1
- nlcache.new_W = false
+ nlsolve! isa NLNewton && (nlcache.new_W = false)
  z,η,iter,fail_convergence = nlsolve!(integrator)
  fail_convergence && return
  @. u = tmp2 + z

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -37,7 +37,7 @@ end
   alg = unwrap_alg(integrator, true)
 
   # calculate W
-  typeof(nlsolve!) <: NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
+  nlsolve! isa NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
 
   # FSAL Step 1
   nlcache.z = z₁ = dt*integrator.fsalfirst
@@ -80,8 +80,8 @@ end
 
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
-    if alg.smooth_est # From Shampine
-      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
+    if nlsolve! isa NLNewton && alg.smooth_est # From Shampine
+      est = _reshape(nlcache.W \_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -105,7 +105,7 @@ end
   # precalculations
   γdt = γ*dt
 
-  typeof(nlsolve) <: NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
+  nlsolve! isa NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
 
   # FSAL Step 1
   @. z₁ = dt*integrator.fsalfirst
@@ -120,7 +120,7 @@ end
   nlcache.c = 2γ
   z₂,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
 
   ################################## Solve Step 3
 
@@ -191,7 +191,7 @@ end
   γdt = γ*dt
 
   # calculate W
-  typeof(nlsolve!) <: NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
+  nlsolve! isa NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
 
   if typeof(integrator.f) <: SplitFunction
     # Explicit tableau is not FSAL
@@ -274,7 +274,7 @@ end
     else
       tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     end
-    if alg.smooth_est # From Shampine
+    if nlsolve! isa NLNewton && alg.smooth_est # From Shampine
       est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
@@ -314,7 +314,7 @@ end
   # precalculations
   γdt = γ*dt
 
-  typeof(nlsolve) <: NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
+  nlsolve! isa NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
 
   if typeof(integrator.f) <: SplitFunction
     # Explicit tableau is not FSAL
@@ -345,7 +345,7 @@ end
   nlcache.c = 2γ
   z₂,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
 
   ################################## Solve Step 3
 
@@ -445,7 +445,7 @@ end
   γdt = γ*dt
 
   # calculate W
-  typeof(nlsolve!) <: NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
+  nlsolve! isa NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
 
   ##### Step 1
 
@@ -498,7 +498,7 @@ end
 
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
-    if alg.smooth_est # From Shampine
+    if nlsolve! isa NLNewton && alg.smooth_est # From Shampine
       est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
@@ -525,7 +525,7 @@ end
   # precalculations
   γdt = γ*dt
 
-  typeof(nlsolve) <: NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
+  nlsolve! isa NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
 
   ##### Step 1
 
@@ -541,7 +541,7 @@ end
   nlcache.c = 2γ
   z₂,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
 
   ################################## Solve Step 3
 
@@ -623,7 +623,7 @@ end
   γdt = γ*dt
 
   # calculate W
-  typeof(nlsolve!) <: NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
+  nlsolve! isa NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
 
   if typeof(integrator.f) <: SplitFunction
     # Explicit tableau is not FSAL
@@ -743,7 +743,7 @@ end
     else
       tmp = btilde1*z₁ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆
     end
-    if alg.smooth_est # From Shampine
+    if nlsolve! isa NLNewton && alg.smooth_est # From Shampine
       est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
@@ -787,7 +787,7 @@ end
   # precalculations
   γdt = γ*dt
 
-  typeof(nlsolve) <: NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
+  nlsolve! isa NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
 
   ##### Step 1
 
@@ -820,7 +820,7 @@ end
   nlcache.c = 2γ
   z₂,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
 
   ################################## Solve Step 3
 
@@ -974,7 +974,7 @@ end
   γdt = γ*dt
 
   # calculate W
-  typeof(nlsolve!) <: NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
+  nlsolve! isa NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
 
   ##### Step 1
 
@@ -1045,7 +1045,7 @@ end
 
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆ + btilde7*z₇
-    if alg.smooth_est # From Shampine
+    if nlsolve! isa NLNewton && alg.smooth_est # From Shampine
       est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
@@ -1072,7 +1072,7 @@ end
   # precalculations
   γdt = γ*dt
 
-  typeof(nlsolve) <: NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
+  nlsolve! isa NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
 
   ##### Step 1
 
@@ -1088,7 +1088,7 @@ end
   nlcache.c = 2γ
   z₂,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
 
   ################################## Solve Step 3
 
@@ -1200,7 +1200,7 @@ end
   γdt = γ*dt
 
   # calculate W
-  typeof(nlsolve!) <: NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
+  nlsolve! isa NLNewton && ( nlcache.W = calc_W!(integrator, cache, γ*dt, repeat_step) )
 
   ##### Step 1
 
@@ -1359,7 +1359,7 @@ end
     else
       tmp = btilde1*z₁ + btilde4*z₄ + btilde5*z₅ + btilde6*z₆ + btilde7*z₇ + btilde8*z₈
     end
-    if alg.smooth_est # From Shampine
+    if nlsolve! isa NLNewton && alg.smooth_est # From Shampine
       est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
@@ -1404,7 +1404,7 @@ end
   # precalculations
   γdt = γ*dt
 
-  typeof(nlsolve) <: NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
+  nlsolve! isa NLNewton && calc_W!(integrator, cache, γdt, repeat_step)
 
   ##### Step 1
 
@@ -1438,7 +1438,7 @@ end
   nlcache.c = 2γ
   z₂,η,iter,fail_convergence = nlsolve!(integrator)
   fail_convergence && return
-  nlcache.new_W = false
+  nlsolve! isa NLNewton && (nlcache.new_W = false)
 
   ################################## Solve Step 3
 


### PR DESCRIPTION
This PR creates separate cache types for each non-linear solver which for Anderson acceleration contains now also caches `alphas` (only for in-place version) and `residuals`.