### PR TITLE
Small fixes

### DIFF
--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -891,7 +891,7 @@ end
   tprev2::tType
 end
 
-@cache mutable struct CNAB2Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,tType,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct CNAB2Cache{uType,rateType,JType,WType,UF,JC,N,tType,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
@@ -905,7 +905,6 @@ end
   dz::uType
   b::uType
   tmp::uType
-  atmp::uNoUnitsType
   J::JType
   W::WType
   uf::UF
@@ -936,9 +935,8 @@ function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   du₁ = zero(rate_prototype)
   uprev3 = similar(u)
   tprev2 = t
-  atmp = similar(u,uEltypeNoUnits)
 
-  CNAB2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
+  CNAB2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
 end
 
 # CNLF2
@@ -966,7 +964,6 @@ end
   dz::uType
   b::uType
   tmp::uType
-  atmp::uNoUnitsType
   J::JType
   W::WType
   uf::UF
@@ -999,7 +996,6 @@ function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev2 = similar(u)
   uprev3 = similar(u)
   tprev2 = t
-  atmp = similar(u,uEltypeNoUnits)
 
-  CNLF2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
+  CNLF2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
 end

--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -933,7 +933,7 @@ function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   k1 = zero(rate_prototype)
   k2 = zero(rate_prototype)
   du₁ = zero(rate_prototype)
-  uprev3 = similar(u)
+  uprev3 = zero(u)
   tprev2 = t
 
   CNAB2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)
@@ -993,8 +993,8 @@ function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   k1 = zero(rate_prototype)
   k2 = zero(rate_prototype)
   du₁ = zero(rate_prototype)
-  uprev2 = similar(u)
-  uprev3 = similar(u)
+  uprev2 = zero(u)
+  uprev3 = zero(u)
   tprev2 = t
 
   CNLF2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolve,uprev3,tprev2)

--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -295,9 +295,9 @@ end
 end
 
 function alg_cache(alg::VCAB3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),3)
-  c = fill(zero(typeof(t)), 3, 3)
-  g = fill(zero(typeof(t)), 3)
+  dts = fill(zero(dt),3)
+  c = fill(zero(t), 3, 3)
+  g = fill(zero(t), 3)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 3)
@@ -306,7 +306,7 @@ function alg_cache(alg::VCAB3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),3)
+  β = fill(zero(t),3)
   order = 3
   tab = BS3ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   VCAB3ConstantCache(dts,c,g,ϕ_n,ϕstar_nm1,ϕstar_n,β,order,tab,1)
@@ -324,9 +324,9 @@ function alg_cache(alg::VCAB3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   bs3cache = BS3Cache(u,uprev,bk1,bk2,bk3,bk4,butilde,btmp,batmp,tab)
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),3)
-  c = fill(zero(typeof(t)), 3, 3)
-  g = fill(zero(typeof(t)), 3)
+  dts = fill(zero(dt),3)
+  c = fill(zero(t), 3, 3)
+  g = fill(zero(t), 3)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 3)
@@ -335,7 +335,7 @@ function alg_cache(alg::VCAB3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = zero(rate_prototype)
     ϕstar_n[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)),3)
+  β = fill(zero(t),3)
   order = 3
   atmp = similar(u,uEltypeNoUnits)
   tmp = similar(u)
@@ -377,9 +377,9 @@ end
 end
 
 function alg_cache(alg::VCAB4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),4)
-  c = fill(zero(typeof(t)), 4, 4)
-  g = fill(zero(typeof(t)), 4)
+  dts = fill(zero(dt),4)
+  c = fill(zero(t), 4, 4)
+  g = fill(zero(t), 4)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 4)
@@ -388,7 +388,7 @@ function alg_cache(alg::VCAB4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),4)
+  β = fill(zero(t),4)
   order = 4
   rk4constcache = RK4ConstantCache()
   VCAB4ConstantCache(ϕstar_nm1,dts,c,g,ϕ_n,ϕstar_n,β,order,rk4constcache,1)
@@ -404,9 +404,9 @@ function alg_cache(alg::VCAB4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   rk4cache = RK4Cache(u,uprev,rk1,rk2,rk3,rk4,rk,rtmp,ratmp)
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),4)
-  c = fill(zero(typeof(t)), 4, 4)
-  g = fill(zero(typeof(t)), 4)
+  dts = fill(zero(dt),4)
+  c = fill(zero(t), 4, 4)
+  g = fill(zero(t), 4)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 4)
@@ -415,7 +415,7 @@ function alg_cache(alg::VCAB4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = zero(rate_prototype)
     ϕstar_n[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)),4)
+  β = fill(zero(t),4)
   order = 4
   atmp = similar(u,uEltypeNoUnits)
   tmp = similar(u)
@@ -459,9 +459,9 @@ end
 end
 
 function alg_cache(alg::VCAB5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),5)
-  c = fill(zero(typeof(t)), 5, 5)
-  g = fill(zero(typeof(t)), 5)
+  dts = fill(zero(dt),5)
+  c = fill(zero(t), 5, 5)
+  g = fill(zero(t), 5)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 5)
@@ -470,7 +470,7 @@ function alg_cache(alg::VCAB5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),5)
+  β = fill(zero(t),5)
   order = 5
   rk4constcache = RK4ConstantCache()
   VCAB5ConstantCache(ϕstar_nm1,dts,c,g,ϕ_n,ϕstar_n,β,order,rk4constcache,1)
@@ -486,9 +486,9 @@ function alg_cache(alg::VCAB5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   rk4cache = RK4Cache(u,uprev,rk1,rk2,rk3,rk4,rk,rtmp,ratmp)
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),5)
-  c = fill(zero(typeof(t)), 5, 5)
-  g = fill(zero(typeof(t)), 5)
+  dts = fill(zero(dt),5)
+  c = fill(zero(t), 5, 5)
+  g = fill(zero(t), 5)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 5)
@@ -497,7 +497,7 @@ function alg_cache(alg::VCAB5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = zero(rate_prototype)
     ϕstar_n[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)),5)
+  β = fill(zero(t),5)
   order = 5
   atmp = similar(u,uEltypeNoUnits)
   tmp = similar(u)
@@ -544,9 +544,9 @@ end
 end
 
 function alg_cache(alg::VCABM3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),3)
-  c = fill(zero(typeof(t)), 4, 4)
-  g = fill(zero(typeof(t)), 4)
+  dts = fill(zero(dt),3)
+  c = fill(zero(t), 4, 4)
+  g = fill(zero(t), 4)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 3)
@@ -556,7 +556,7 @@ function alg_cache(alg::VCABM3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),3)
+  β = fill(zero(t),3)
   order = 3
   tab = BS3ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   VCABM3ConstantCache(dts,c,g,ϕ_n,ϕ_np1,ϕstar_nm1,ϕstar_n,β,order,tab,1)
@@ -574,9 +574,9 @@ function alg_cache(alg::VCABM3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   bs3cache = BS3Cache(u,uprev,bk1,bk2,bk3,bk4,butilde,btmp,batmp,tab)
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),3)
-  c = fill(zero(typeof(t)), 4, 4)
-  g = fill(zero(typeof(t)), 4)
+  dts = fill(zero(dt),3)
+  c = fill(zero(t), 4, 4)
+  g = fill(zero(t), 4)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 3)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 3)
@@ -589,7 +589,7 @@ function alg_cache(alg::VCABM3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   for i in 1:4
     ϕ_np1[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)),3)
+  β = fill(zero(t),3)
   order = 3
   atmp = similar(u,uEltypeNoUnits)
   tmp = similar(u)
@@ -635,9 +635,9 @@ end
 end
 
 function alg_cache(alg::VCABM4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),4)
-  c = fill(zero(typeof(t)), 5, 5)
-  g = fill(zero(typeof(t)), 5)
+  dts = fill(zero(dt),4)
+  c = fill(zero(t), 5, 5)
+  g = fill(zero(t), 5)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 4)
@@ -647,7 +647,7 @@ function alg_cache(alg::VCABM4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),4)
+  β = fill(zero(t),4)
   order = 4
   rk4constcache = RK4ConstantCache()
   VCABM4ConstantCache(ϕstar_nm1,dts,c,g,ϕ_n,ϕ_np1,ϕstar_n,β,order,rk4constcache,1)
@@ -663,9 +663,9 @@ function alg_cache(alg::VCABM4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   rk4cache = RK4Cache(u,uprev,rk1,rk2,rk3,rk4,rk,rtmp,ratmp)
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),4)
-  c = fill(zero(typeof(t)), 5, 5)
-  g = fill(zero(typeof(t)), 5)
+  dts = fill(zero(dt),4)
+  c = fill(zero(t), 5, 5)
+  g = fill(zero(t), 5)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 4)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 4)
@@ -678,7 +678,7 @@ function alg_cache(alg::VCABM4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   for i in 1:5
     ϕ_np1[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)),4)
+  β = fill(zero(t),4)
   order = 4
   atmp = similar(u,uEltypeNoUnits)
   tmp = similar(u)
@@ -724,9 +724,9 @@ end
 end
 
 function alg_cache(alg::VCABM5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),5)
-  c = fill(zero(typeof(t)), 6, 6)
-  g = fill(zero(typeof(t)), 6)
+  dts = fill(zero(t),5)
+  c = fill(zero(t), 6, 6)
+  g = fill(zero(t), 6)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 5)
@@ -736,7 +736,7 @@ function alg_cache(alg::VCABM5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),5)
+  β = fill(zero(t),5)
   order = 5
   rk4constcache = RK4ConstantCache()
   VCABM5ConstantCache(ϕstar_nm1,dts,c,g,ϕ_n,ϕ_np1,ϕstar_n,β,order,rk4constcache,1)
@@ -752,9 +752,9 @@ function alg_cache(alg::VCABM5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   rk4cache = RK4Cache(u,uprev,rk1,rk2,rk3,rk4,rk,rtmp,ratmp)
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),5)
-  c = fill(zero(typeof(t)), 6, 6)
-  g = fill(zero(typeof(t)), 6)
+  dts = fill(zero(dt),5)
+  c = fill(zero(t), 6, 6)
+  g = fill(zero(t), 6)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 5)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 5)
@@ -767,7 +767,7 @@ function alg_cache(alg::VCABM5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   for i in 1:6
     ϕ_np1[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)),5)
+  β = fill(zero(t),5)
   order = 5
   atmp = similar(u,uEltypeNoUnits)
   tmp = similar(u)
@@ -823,9 +823,9 @@ end
 end
 
 function alg_cache(alg::VCABM,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),13)
-  c = fill(zero(typeof(t)), 13, 13)
-  g = fill(zero(typeof(t)), 13)
+  dts = fill(zero(dt),13)
+  c = fill(zero(t), 13, 13)
+  g = fill(zero(t), 13)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 13)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 13)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 13)
@@ -835,7 +835,7 @@ function alg_cache(alg::VCABM,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     ϕstar_nm1[i] = copy(rate_prototype)
     ϕstar_n[i] = copy(rate_prototype)
   end
-  β = fill(zero(typeof(t)),13)
+  β = fill(zero(t),13)
   ξ = zero(dt)
   ξ0 = zero(dt)
   order = 1
@@ -846,9 +846,9 @@ end
 function alg_cache(alg::VCABM,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   fsalfirst = zero(rate_prototype)
   k4 = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),13)
-  c = fill(zero(typeof(t)), 13, 13)
-  g = fill(zero(typeof(t)), 13)
+  dts = fill(zero(dt),13)
+  c = fill(zero(t), 13, 13)
+  g = fill(zero(t), 13)
   ϕ_n = Vector{typeof(rate_prototype)}(undef, 13)
   ϕstar_nm1 = Vector{typeof(rate_prototype)}(undef, 13)
   ϕstar_n = Vector{typeof(rate_prototype)}(undef, 13)
@@ -861,7 +861,7 @@ function alg_cache(alg::VCABM,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   for i in 1:14
     ϕ_np1[i] = zero(rate_prototype)
   end
-  β = fill(zero(typeof(t)), 13)
+  β = fill(zero(t), 13)
   order = 1
   max_order = 12
   atmp = similar(u,uEltypeNoUnits)

--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -950,7 +950,7 @@ end
   tprev2::tType
 end
 
-@cache mutable struct CNLF2Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,tType,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct CNLF2Cache{uType,rateType,JType,WType,UF,JC,N,tType,F} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -50,7 +50,7 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = 1//1, 1
   @iipnlsolve
 
-  fsalfirstprev = similar(rate_prototype)
+  fsalfirstprev = zero(rate_prototype)
   atmp = similar(u,uEltypeNoUnits)
 
   eulercache = ImplicitEulerCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve)
@@ -59,7 +59,7 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   nlsolve.cache.c = 1
 
   dtₙ₋₁ = one(dt)
-  zₙ₋₁ = similar(u)
+  zₙ₋₁ = zero(u)
 
   ABDF2Cache(u,uprev,uprev2,du1,fsalfirst,fsalfirstprev,k,z,zₙ₋₁,dz,b,tmp,atmp,J,
               W,uf,jac_config,linsolve,nlsolve,eulercache,dtₙ₋₁)
@@ -82,7 +82,7 @@ end
   du₂::rateType
 end
 
-@cache mutable struct SBDFCache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct SBDFCache{uType,rateType,JType,WType,UF,JC,N,F} <: OrdinaryDiffEqMutableCache
   cnt::Int
   u::uType
   uprev::uType
@@ -93,7 +93,6 @@ end
   dz::uType
   b::uType
   tmp::uType
-  atmp::uNoUnitsType
   J::JType
   W::WType
   uf::UF
@@ -129,18 +128,17 @@ function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
 
   order = alg.order
 
-  k₁ = similar(rate_prototype)
+  k₁ = zero(rate_prototype)
   k₂ = order >= 3 ? zero(rate_prototype) : k₁
   k₃ = order == 4 ? zero(rate_prototype) : k₁
   du₁ = zero(rate_prototype)
   du₂ = zero(rate_prototype)
 
-  uprev2 = similar(u)
-  uprev3 = order >= 3 ? similar(u) : uprev2
-  uprev4 = order == 4 ? similar(u) : uprev2
-  atmp = similar(u,uEltypeNoUnits)
+  uprev2 = zero(u)
+  uprev3 = order >= 3 ? zero(u) : uprev2
+  uprev4 = order == 4 ? zero(u) : uprev2
 
-  SBDFCache(1,u,uprev,fsalfirst,k,du1,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
+  SBDFCache(1,u,uprev,fsalfirst,k,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolve,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
 # QNDF1
@@ -213,7 +211,7 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   atmp = similar(u,uEltypeNoUnits)
   utilde = similar(u)
-  uprev2 = similar(u)
+  uprev2 = zero(u)
   dtₙ₋₁ = one(dt)
 
   QNDF1Cache(uprev2,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
@@ -296,8 +294,8 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   atmp = similar(u,uEltypeNoUnits)
   utilde = similar(u)
-  uprev2 = similar(u)
-  uprev3 = similar(u)
+  uprev2 = zero(u)
+  uprev3 = zero(u)
   dtₙ₋₁ = zero(dt)
   dtₙ₋₂ = zero(dt)
 
@@ -428,7 +426,7 @@ function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = 1, 1
   @iipnlsolve
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); tmp2 = similar(u)
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); tmp2 = zero(u)
   atmp = similar(u,uEltypeNoUnits)
 
   MEBDF2Cache(u,uprev,uprev2,du1,fsalfirst,k,z,z₁,z₂,tmp2,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolve)

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -185,10 +185,10 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev2 = u
   dtₙ₋₁ = t
 
-  D = fill(zero(typeof(u)), 1, 1)
-  D2 = fill(zero(typeof(u)), 1, 2)
-  R = fill(zero(typeof(t)), 1, 1)
-  U = fill(zero(typeof(t)), 1, 1)
+  D = fill(zero(u), 1, 1)
+  D2 = fill(zero(u), 1, 2)
+  R = fill(zero(t), 1, 1)
+  U = fill(zero(t), 1, 1)
 
   U!(1,U)
 
@@ -201,8 +201,8 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   D = Array{typeof(u)}(undef, 1, 1)
   D2 = Array{typeof(u)}(undef, 1, 2)
-  R = fill(zero(typeof(t)), 1, 1)
-  U = fill(zero(typeof(t)), 1, 1)
+  R = fill(zero(t), 1, 1)
+  U = fill(zero(t), 1, 1)
 
   D[1] = similar(u)
   D2[1] = similar(u); D2[2] = similar(u)
@@ -268,10 +268,10 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   dtₙ₋₁ = zero(t)
   dtₙ₋₂ = zero(t)
 
-  D = fill(zero(typeof(u)), 1, 2)
-  D2 = fill(zero(typeof(u)), 1, 3)
-  R = fill(zero(typeof(t)), 2, 2)
-  U = fill(zero(typeof(t)), 2, 2)
+  D = fill(zero(u), 1, 2)
+  D2 = fill(zero(u), 1, 3)
+  R = fill(zero(t), 2, 2)
+  U = fill(zero(t), 2, 2)
 
   U!(2,U)
 
@@ -284,8 +284,8 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   D = Array{typeof(u)}(undef, 1, 2)
   D2 = Array{typeof(u)}(undef, 1, 3)
-  R = fill(zero(typeof(t)), 2, 2)
-  U = fill(zero(typeof(t)), 2, 2)
+  R = fill(zero(t), 2, 2)
+  U = fill(zero(t), 2, 2)
 
   D[1] = similar(u); D[2] = similar(u)
   D2[1] = similar(u);  D2[2] = similar(u); D2[3] = similar(u)
@@ -351,15 +351,15 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   γ, c = one(inv(alg.kappa)), 1
   @oopnlsolve
 
-  udiff = fill(zero(typeof(u)), 1, 6)
-  dts = fill(zero(typeof(dt)), 1, 6)
+  udiff = fill(zero(u), 1, 6)
+  dts = fill(zero(dt), 1, 6)
   h = zero(dt)
   tmp = zero(u)
 
-  D = fill(zero(typeof(u)), 1, 5)
-  D2 = fill(zero(typeof(u)), 6, 6)
-  R = fill(zero(typeof(t)), 5, 5)
-  U = fill(zero(typeof(t)), 5, 5)
+  D = fill(zero(u), 1, 5)
+  D2 = fill(zero(u), 6, 6)
+  R = fill(zero(t), 5, 5)
+  U = fill(zero(t), 5, 5)
 
   max_order = 5
 
@@ -371,13 +371,13 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   @iipnlsolve
 
   udiff = Array{typeof(u)}(undef, 1, 6)
-  dts = fill(zero(typeof(dt)), 1, 6)
+  dts = fill(zero(dt), 1, 6)
   h = zero(dt)
 
   D = Array{typeof(u)}(undef, 1, 5)
   D2 = Array{typeof(u)}(undef, 6, 6)
-  R = fill(zero(typeof(t)), 5, 5)
-  U = fill(zero(typeof(t)), 5, 5)
+  R = fill(zero(t), 5, 5)
+  U = fill(zero(t), 5, 5)
 
   for i = 1:5
     D[i] = zero(u)

--- a/src/caches/generic_implicit_caches.jl
+++ b/src/caches/generic_implicit_caches.jl
@@ -60,7 +60,7 @@ function alg_cache(alg::GenericTrapezoid,u,rate_prototype,uEltypeNoUnits,uBottom
   dual_cache = DiffCache(u,Val{determine_chunksize(u,get_chunksize(alg.nlsolve))})
   rhs = ImplicitRHS(f,tmp,t,t,t,dual_cache,p)
   nl_rhs = alg.nlsolve(Val{:init},rhs,u)
-  uprev3 = similar(u)
+  uprev3 = zero(u)
   tprev2 = t
   GenericTrapezoidCache{typeof(u),typeof(dual_cache),typeof(atmp),typeof(k),
                         typeof(rhs),typeof(nl_rhs),typeof(t)}(

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -55,7 +55,7 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = z
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = z
   atmp = similar(u,uEltypeNoUnits)
 
   KenCarp3Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,k1,k2,k3,k4,dz,b,tmp,atmp,J,
@@ -73,10 +73,6 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
-
-  uprev3 = u
-  tprev2 = t
-
   Kvaerno4ConstantCache(uf,nlsolve,tab)
 end
 
@@ -110,7 +106,7 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   @iipnlsolve
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = z
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = z
   atmp = similar(u,uEltypeNoUnits)
 
   Kvaerno4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
@@ -128,10 +124,6 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   @oopnlsolve
-
-  uprev3 = u
-  tprev2 = t
-
   KenCarp4ConstantCache(uf,nlsolve,tab)
 end
 
@@ -183,7 +175,7 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = similar(u)
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = zero(u)
   z₆ = z
   atmp = similar(u,uEltypeNoUnits)
 
@@ -239,8 +231,8 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   @iipnlsolve
 
-  z₁ = similar(u); z₂ = similar(u);  z₃ = similar(u); z₄ = similar(u); z₅ = similar(u)
-  z₆ = similar(u);  z₇ = z
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = zero(u)
+  z₆ = zero(u); z₇ = z
   atmp = similar(u,uEltypeNoUnits)
 
   Kvaerno5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,dz,b,tmp,atmp,J,
@@ -316,8 +308,8 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u)
-  z₅ = similar(u); z₆ = similar(u); z₇ = similar(u); z₈ = z
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u)
+  z₅ = zero(u); z₆ = zero(u); z₇ = zero(u); z₈ = z
   atmp = similar(u,uEltypeNoUnits)
 
   KenCarp5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,

--- a/src/caches/nordsieck_caches.jl
+++ b/src/caches/nordsieck_caches.jl
@@ -24,7 +24,7 @@ function alg_cache(alg::AN5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits
   Δ = u
   l = fill(zero(tTypeNoUnits),N+1); m = zero(l)
   c_LTE = c_conv = zero(tTypeNoUnits)
-  dts = fill(zero(typeof(dt)), 6)
+  dts = fill(zero(dt), 6)
   tsit5tab = Tsit5ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   AN5ConstantCache(z,l,m,c_LTE,c_conv,dts,Δ,tsit5tab,1)
 end
@@ -71,7 +71,7 @@ function alg_cache(alg::AN5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits
   Δ = similar(atmp)
   l = fill(zero(tTypeNoUnits),N+1); m = zero(l)
   c_LTE = c_conv = zero(tTypeNoUnits)
-  dts = fill(zero(typeof(dt)), 6)
+  dts = fill(zero(dt), 6)
   fsalfirst = zero(rate_prototype)
   z = [zero(rate_prototype) for i in 1:N+1]
   for i in 1:N+1
@@ -128,7 +128,7 @@ function alg_cache(alg::JVODE,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   Δ = u
   l = fill(zero(tTypeNoUnits), N+1); m = zero(l)
   c_LTE₊₁ = c_LTE = c_LTE₋₁ = c_conv = c_𝒟 = prev_𝒟 = zero(tTypeNoUnits)
-  dts = fill(zero(typeof(dt)),N+1)
+  dts = fill(zero(dt),N+1)
   tsit5tab = Tsit5ConstantCache(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   η = zero(dt/dt)
   JVODEConstantCache(z,l,m,
@@ -198,7 +198,7 @@ function alg_cache(alg::JVODE,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   Δ = similar(u,uEltypeNoUnits)
   l = fill(zero(tTypeNoUnits), N+1); m = zero(l)
   c_LTE₊₁ = c_LTE = c_LTE₋₁ = c_conv = c_𝒟 = prev_𝒟 = zero(tTypeNoUnits)
-  dts = fill(zero(typeof(dt)),N+1)
+  dts = fill(zero(dt),N+1)
   η = zero(dt/dt)
   #################################################
   # Nordsieck Vector

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -123,7 +123,7 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   γ, c = 1//2, 1
   @iipnlsolve
 
-  uprev3 = similar(u)
+  uprev3 = zero(u)
   tprev2 = t
   atmp = similar(u,uEltypeNoUnits)
 

--- a/src/caches/ssprk_caches.jl
+++ b/src/caches/ssprk_caches.jl
@@ -550,8 +550,8 @@ end
 
 function alg_cache(alg::SSPRKMSVS32,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   fsalfirst = zero(rate_prototype)
-  dts = fill(zero(typeof(dt)),3)
-  dtf = fill(zero(typeof(dt)),2)
+  dts = fill(zero(dt),3)
+  dtf = fill(zero(dt),2)
   μ = zero(dt)
   u_2 = similar(u)
   u_1 = similar(u)
@@ -561,8 +561,8 @@ function alg_cache(alg::SSPRKMSVS32,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
 end
 
 function alg_cache(alg::SSPRKMSVS32,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  dts = fill(zero(typeof(dt)),3)
-  dtf = fill(zero(typeof(dt)),2)
+  dts = fill(zero(dt),3)
+  dtf = fill(zero(dt),2)
   μ = zero(dt)
   u_2 = u
   u_1 = u

--- a/src/perform_step/adams_bashforth_moulton_perform_step.jl
+++ b/src/perform_step/adams_bashforth_moulton_perform_step.jl
@@ -1504,7 +1504,7 @@ end
 
 function perform_step!(integrator, cache::CNAB2Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack uf,dz,z,k,k1,k2,du₁,b,J,W,jac_config,tmp,atmp,nlsolve = cache
+  @unpack uf,dz,z,k,k1,k2,du₁,b,J,W,jac_config,tmp,nlsolve = cache
   nlsolve!, nlcache = nlsolve, nlsolve.cache
   cnt = integrator.iter
   f1 = integrator.f.f1
@@ -1605,7 +1605,7 @@ end
 
 function perform_step!(integrator, cache::CNLF2Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack uprev2,uf,dz,z,k,k2,du₁,b,J,W,jac_config,tmp,atmp,nlsolve = cache
+  @unpack uprev2,uf,dz,z,k,k2,du₁,b,J,W,jac_config,tmp,nlsolve = cache
   nlsolve!, nlcache = nlsolve, nlsolve.cache
   cnt = integrator.iter
   f1 = integrator.f.f1

--- a/src/perform_step/high_order_rk_perform_step.jl
+++ b/src/perform_step/high_order_rk_perform_step.jl
@@ -177,7 +177,7 @@ end
     err3 = integrator.opts.internalnorm(atmp) # Order 3
     err52 = err5*err5
     if err5 ≈ 0 && err3 ≈ 0
-      integrator.EEst = zero(typeof(integrator.EEst))
+      integrator.EEst = zero(integrator.EEst)
     else
       integrator.EEst = err52/sqrt(err52 + 0.01*err3*err3)
     end

--- a/test/ode/ode_dense_tests.jl
+++ b/test/ode/ode_dense_tests.jl
@@ -10,7 +10,7 @@ print_results(x) = if PRINT_TESTS; @printf("%s \n", x) end
 
 # points and storage arrays used in the interpolation tests
 const interpolation_points = 0:1//2^(4):1
-const interpolation_results_1d = fill(zero(typeof(prob_ode_linear.u0)), length(interpolation_points))
+const interpolation_results_1d = fill(zero(prob_ode_linear.u0), length(interpolation_points))
 const interpolation_results_2d = Vector{typeof(prob_ode_2Dlinear.u0)}(undef, length(interpolation_points))
 for idx in eachindex(interpolation_results_2d)
   interpolation_results_2d[idx] = zero(prob_ode_2Dlinear.u0)


### PR DESCRIPTION
Addresses comments in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/646 and removes superfluous `typeof` inside of `zero`. However, I'm not completely sure in which cases it is sufficient to use `similar` and in which cases `zero` is required, so I worked only on your remarks and similar occurrences so far.