### PR TITLE
Fix vec in oop SDIRK

### DIFF
--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -468,7 +468,7 @@ end
   if integrator.opts.adaptive
     tmp = z₁/2 - z₂/2
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -727,7 +727,7 @@ end
 
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -906,7 +906,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end


### PR DESCRIPTION
Fix test errors https://travis-ci.org/JuliaDiffEq/DelayDiffEq.jl/jobs/487827113 due to non-existing method `vec(::Float64)`.