### PR TITLE
Fix undefined nlsolve_f for DDEIntegrator

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -490,7 +490,7 @@ function reset_fsal!(integrator)
 end
 
 nlsolve_f(f, alg) = f isa SplitFunction && alg isa SplitAlgorithms ? f.f1 : f
-nlsolve_f(integrator::ODEIntegrator) =
+nlsolve_f(integrator) =
   nlsolve_f(integrator.f, unwrap_alg(integrator, true))
 
 function (integrator::ODEIntegrator)(t,deriv::Type=Val{0};idxs=nothing)

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -357,7 +357,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*zprev + btilde2*zᵧ + btilde3*z
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -468,7 +468,7 @@ end
   if integrator.opts.adaptive
     tmp = z₁/2 - z₂/2
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\_vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -727,7 +727,7 @@ end
 
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\_vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end
@@ -906,7 +906,7 @@ end
   if integrator.opts.adaptive
     tmp = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if alg.smooth_est # From Shampine
-      est = reshape(nlcache.W\_vec(tmp), axes(tmp))
+      est = _reshape(nlcache.W\_vec(tmp), axes(tmp))
     else
       est = tmp
     end


### PR DESCRIPTION
Tests (https://travis-ci.org/JuliaDiffEq/DelayDiffEq.jl/jobs/491080882) indicate that DelayDiffEq requires another fix, in addition to https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/656. Currently `nlsolve_f` is not defined for `DDEIntegrator`s.