### PR TITLE
Remove _reshape for vectors

### DIFF
--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -168,7 +168,6 @@ end
 
 _reshape(v, siz) = reshape(v, siz)
 _reshape(v::Number, siz) = v
-_reshape(v::AbstractVector, siz) = v
 
 _vec(v) = vec(v)
 _vec(v::Number) = v


### PR DESCRIPTION
This PR should fix test errors such as https://travis-ci.org/JuliaDiffEq/OrdinaryDiffEq.jl/builds/493054046 due to incorrect shapes.