### PR TITLE
Fix early stopping condition

### DIFF
--- a/src/perform_step/firk_perform_step.jl
+++ b/src/perform_step/firk_perform_step.jl
@@ -116,7 +116,9 @@ end
     # check early stopping criterion
     if iter != 1
       θ = ndw/ndwprev
-      θ ≥ 1 || ndw * θ^(max_iter - iter) > κtol * (1 - θ) && break
+      if θ ≥ 1 || ndw * θ^(max_iter - iter) > κtol * (1 - θ)
+        break
+      end
     end
 
     w1 = @. w1 + dw1
@@ -303,7 +305,9 @@ end
     # check early stopping criterion
     if iter != 1
       θ = ndw/ndwprev
-      θ ≥ 1 || ndw * θ^(max_iter - iter) > κtol * (1 - θ) && break
+      if θ ≥ 1 || ndw * θ^(max_iter - iter) > κtol * (1 - θ)
+        break
+      end
     end
 
     @. w1 = w1 + dw1


### PR DESCRIPTION
It seems the early stopping condition is incorrect due to [short-circuit evaluation](https://docs.julialang.org/en/v1.1/manual/control-flow/#Short-Circuit-Evaluation-1):
```julia
julia> false || true && println("Hello world")
Hello world

julia> true || false && println("Hello world")
true
```