### PR TITLE
Implemented KYKDGSSPRK3S2

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -175,7 +175,8 @@ module OrdinaryDiffEq
          ParsaniKetchesonDeconinck3S32, ParsaniKetchesonDeconinck3S82,
          ParsaniKetchesonDeconinck3S53, ParsaniKetchesonDeconinck3S173,
          ParsaniKetchesonDeconinck3S94, ParsaniKetchesonDeconinck3S184,
-         ParsaniKetchesonDeconinck3S105, ParsaniKetchesonDeconinck3S205
+         ParsaniKetchesonDeconinck3S105, ParsaniKetchesonDeconinck3S205,
+         KYK2014DGSSPRK_3S2
 
   export RadauIIA5
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -408,6 +408,7 @@ ssp_coefficient(alg::SSPRKMSVS43) = 0.33
 ssp_coefficient(alg::SSPRK932) = 6
 ssp_coefficient(alg::SSPRK54) = 1.508
 ssp_coefficient(alg::SSPRK104) = 6
+ssp_coefficient(alg::KYK2014DGSSPRK_3S2) =  0.8417
 
 # We shouldn't do this probably.
 #ssp_coefficient(alg::ImplicitEuler) = Inf

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -206,6 +206,7 @@ alg_order(alg::ParsaniKetchesonDeconinck3S94) = 4
 alg_order(alg::ParsaniKetchesonDeconinck3S184) = 4
 alg_order(alg::ParsaniKetchesonDeconinck3S105) = 5
 alg_order(alg::ParsaniKetchesonDeconinck3S205) = 5
+alg_order(alg::KYK2014DGSSPRK_3S2) = 2
 
 alg_order(alg::SSPRK22) = 2
 alg_order(alg::SSPRKMSVS32) = 2

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -89,6 +89,8 @@ struct ParsaniKetchesonDeconinck3S94 <: OrdinaryDiffEqAlgorithm end
 struct ParsaniKetchesonDeconinck3S184 <: OrdinaryDiffEqAlgorithm end
 struct ParsaniKetchesonDeconinck3S105 <: OrdinaryDiffEqAlgorithm end
 struct ParsaniKetchesonDeconinck3S205 <: OrdinaryDiffEqAlgorithm end
+struct KYK2014DGSSPRK_3S2 <: OrdinaryDiffEqAlgorithm end
+
 
 struct SSPRK22{StageLimiter,StepLimiter} <: OrdinaryDiffEqAlgorithm
   stage_limiter!::StageLimiter

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -868,6 +868,7 @@ function initialize!(integrator,cache::KYK2014DGSSPRK_3S2_Cache)
  integrator.kshortsize = 2
  resize!(integrator.k, integrator.kshortsize)
  integrator.k[1] = integrator.fsalfirst
+ integrator.k[2] = integrator.fsallast
  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
 end
 
@@ -887,7 +888,5 @@ end
   α_30 * uprev + dt*β_30*integrator.fsalfirst +
   α_32 * u_2 + dt*β_32*kk_2
  )
- integrator.k[1] .= integrator.fsalfirst
  f(integrator.k[2], integrator.u, p, t+dt) # For interpolation, then FSAL'd
- integrator.fsallast = integrator.k[2]
 end

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -834,3 +834,60 @@ end
     end
   end
 end
+
+function initialize!(integrator,cache::KYK2014DGSSPRK_3S2_ConstantCache)
+ integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+ integrator.kshortsize = 2
+ integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+
+ # Avoid undefined entries if k is an array of arrays
+ integrator.fsallast = zero(integrator.fsalfirst)
+end
+
+@muladd function perform_step!(integrator,cache::KYK2014DGSSPRK_3S2_ConstantCache,repeat_step=false)
+ @unpack t,dt,uprev,u,f,p = integrator
+ @unpack α_10, α_20, α_21, α_30, α_32, β_10, β_21, β_30, β_32, c_1, c_2 = cache
+ u_1 =  α_10 * uprev + dt*β_10*integrator.fsalfirst
+ u_2 = (
+  α_20 * uprev +
+  α_21 * u_1 + dt*β_21*f(u_1, p, t + c_1*dt)
+ )
+ integrator.u = (
+  α_30 * uprev + dt*β_30*integrator.fsalfirst +
+  α_32 * u_2 + dt*β_32*f(u_2, p, t + c_2*dt)
+ )
+ integrator.k[1] = integrator.fsalfirst
+ integrator.k[2] = f(integrator.u, p, t+dt) # For interpolation, then FSAL'd
+ integrator.fsallast = integrator.k[2]
+end
+
+function initialize!(integrator,cache::KYK2014DGSSPRK_3S2_Cache)
+ @unpack k,fsalfirst = cache
+ integrator.fsalfirst = fsalfirst
+ integrator.fsallast = k
+ integrator.kshortsize = 2
+ resize!(integrator.k, integrator.kshortsize)
+ integrator.k[1] = integrator.fsalfirst
+ integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+end
+
+@muladd function perform_step!(integrator,cache::KYK2014DGSSPRK_3S2_Cache,repeat_step=false)
+ @unpack t,dt,uprev,u,f,p = integrator
+ @unpack k,fsalfirst,u_1,u_2, kk_1, kk_2 = cache
+ @unpack α_10, α_20, α_21, α_30, α_32, β_10, β_21, β_30, β_32, c_1, c_2 = cache.tab
+
+ @. u_1 =  α_10 * uprev + dt*β_10*integrator.fsalfirst
+ f(kk_1, u_1, p, t + c_1*dt)
+ @. u_2 = (
+  α_20 * uprev +
+  α_21 * u_1 + dt*β_21*kk_1
+ )
+ f(kk_2, u_2, p, t + c_2*dt)
+ integrator.u .= (
+  α_30 * uprev + dt*β_30*integrator.fsalfirst +
+  α_32 * u_2 + dt*β_32*kk_2
+ )
+ integrator.k[1] .= integrator.fsalfirst
+ f(integrator.k[2], integrator.u, p, t+dt) # For interpolation, then FSAL'd
+ integrator.fsallast = integrator.k[2]
+end

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -346,6 +346,25 @@ end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
 @test all(sol.u .>= 0)
+
+
+alg = KYK2014DGSSPRK_3S2()
+for prob in test_problems_only_time
+  sim = test_convergence(dts, prob, alg)
+  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+for prob in test_problems_linear
+  sim = test_convergence(dts, prob, alg)
+  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+for prob in test_problems_nonlinear
+  sim = test_convergence(dts, prob, alg)
+  @test abs(sim.𝒪est[:final]-OrdinaryDiffEq.alg_order(alg)) < testTol
+end
+# test SSP coefficient
+sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
+@test all(sol.u .>= 0)
+
 # test storage
 integ = init(prob_ode_large, alg, dt=1.e-2, save_start=false, save_end=false, save_everystep=false)
 @test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 6

--- a/test/ode/ode_ssprk_tests.jl
+++ b/test/ode/ode_ssprk_tests.jl
@@ -347,6 +347,11 @@ end
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
 @test all(sol.u .>= 0)
 
+# test storage
+integ = init(prob_ode_large, alg, dt=1.e-2, save_start=false, save_end=false, save_everystep=false)
+@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 6
+integ = init(prob_ode_large, alg, dt=1.e-2, save_start=false, save_end=false, save_everystep=false, alias_u0=true)
+@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 5
 
 alg = KYK2014DGSSPRK_3S2()
 for prob in test_problems_only_time
@@ -364,9 +369,3 @@ end
 # test SSP coefficient
 sol = solve(test_problem_ssp_long, alg, dt=OrdinaryDiffEq.ssp_coefficient(alg), dense=false)
 @test all(sol.u .>= 0)
-
-# test storage
-integ = init(prob_ode_large, alg, dt=1.e-2, save_start=false, save_end=false, save_everystep=false)
-@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 6
-integ = init(prob_ode_large, alg, dt=1.e-2, save_start=false, save_end=false, save_everystep=false, alias_u0=true)
-@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 5


### PR DESCRIPTION
Implemented the SSPRK(3 Stages, Order 2) scheme given in "Optimal Strong-Stability-Preserving Runge–Kutta Time Discretizations for Discontinuous Galerkin Methods" by Kubatko, Yeager, Ketcheson (2014) as requested here #493. 

```
f = (u,p,t)->sin(u)
(::typeof(f))(::Type{Val{:analytic}},u0,p,t) = 2*acot(exp(-t)*cot(0.5))
prob_ode_nonlinear = ODEProblem(f, 1.,(0.,0.5))
dts = 1 .//2 .^(8:-1:4)
testTol = 0.25
sim = test_convergence(dts, prob_ode_nonlinear, KYK2014DGSSPRK_3S2())
plot(sim)
```
![image](https://user-images.githubusercontent.com/5693983/53287071-8562ee80-3777-11e9-912b-153b0a8f21cd.png)

```
g(u,p,t) = 2*t + u
u0 = 1.0
tspan = (0.0,10.0)
prob = ODEProblem(g,u0,tspan)
sol1 = solve(prob, Tsit5())
sol2 = solve(prob, KYK2014DGSSPRK_3S2(), dt = 1/100)
tf(t) = exp(t)*(2*(-t*exp(-t) - exp(-t)) + 3)
plot(sol2.t, tf, title="Solution for g'=2*t + u",label="True")
plot!(sol1, label="Tsit5")
plot!(sol2, label="KYK2014DGSSPRK_3S2")
```
![image](https://user-images.githubusercontent.com/5693983/53287078-a0cdf980-3777-11e9-9934-d5aab3a00052.png)

I am not sure if I am doing the `perform_step` and `initialize` version using the cache right, since I barely use it.