### PR TITLE
Do not evaluate Jacobian nor compute LU factorization in oopnlsolve

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -28,7 +28,7 @@ module OrdinaryDiffEq
 
   # Required by temporary fix in not in-place methods with 12+ broadcasts
   # `MVector` is used by Nordsieck forms
-  import StaticArrays: SArray, MVector, SVector, @SVector
+  import StaticArrays: SArray, MVector, SVector, @SVector, StaticArray
 
   # Integrator Interface
   import DiffEqBase: resize!,deleteat!,addat!,full_cache,user_cache,u_cache,du_cache,

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -167,6 +167,7 @@ macro cache(expr)
 end
 
 _reshape(v, siz) = reshape(v, siz)
+_reshape(v::StaticArray, siz) = reshape(v, map(last, siz))
 _reshape(v::Number, siz) = v
 
 _vec(v) = vec(v)

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -108,16 +108,19 @@ DiffEqBase.@def oopnlsolve begin
       end
       W = WOperator(f.mass_matrix, dt, J, false)
     else
-      if DiffEqBase.has_jac(f)
-        J = f.jac(uprev, p, t)
-      else
-        if alg_autodiff(alg)
-          J = jacobian_autodiff(uf, uprev)
-        else
-          J = jacobian_finitediff(uf, uprev, alg.diff_type)
-        end
-      end
-      W = J isa Number ? J : lu(J; check=false)
+      #if DiffEqBase.has_jac(f)
+      #  J = f.jac(uprev, p, t)
+      #else
+      #  if alg_autodiff(alg)
+      #    J = jacobian_autodiff(uf, uprev)
+      #  else
+      #    J = jacobian_finitediff(uf, uprev, alg.diff_type)
+      #  end
+      #end
+      #W = J isa Number ? J : lu(J; check=false)
+      W = u isa Number ? u : LU{LinearAlgebra.lutype(eltype(u))}(Matrix{uEltypeNoUnits}(undef, 0, 0),
+                                                                 zeros(LinearAlgebra.BlasInt, min(size(J)...)),
+                                                                 0)
     end
 
     nlcache = NLNewtonCache(κ,tol,min_iter,max_iter,10000,_nlcache.new_W,z,W,γ,c,ηold,dz,tmp,b,k)

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -118,9 +118,9 @@ DiffEqBase.@def oopnlsolve begin
       #  end
       #end
       #W = J isa Number ? J : lu(J; check=false)
-      W = u isa Number ? u : LU{LinearAlgebra.lutype(eltype(u))}(Matrix{uEltypeNoUnits}(undef, 0, 0),
-                                                                 zeros(LinearAlgebra.BlasInt, min(size(J)...)),
-                                                                 0)
+      W = u isa Number ? u : LU{LinearAlgebra.lutype(uEltypeNoUnits)}(Matrix{uEltypeNoUnits}(undef, 0, 0),
+                                                                      Vector{LinearAlgebra.BlasInt}(undef, 0),
+                                                                      zero(LinearAlgebra.BlasInt))
     end
 
     nlcache = NLNewtonCache(κ,tol,min_iter,max_iter,10000,_nlcache.new_W,z,W,γ,c,ηold,dz,tmp,b,k)

--- a/test/static_array_tests.jl
+++ b/test/static_array_tests.jl
@@ -27,5 +27,6 @@ u0 = ones(SVector{2,Float64})
 f = (u,p,t) -> u
 ode = ODEProblem(f, u0, (0.,1.))
 sol = solve(ode, Euler(), dt=1.e-2)
-sol = solve(ode, ImplicitEuler(nlsolve=NLAnderson()), dt=1.e-2)
+sol = solve(ode, ImplicitEuler())
+sol = solve(ode, ImplicitEuler(nlsolve=NLAnderson()))
 sol = solve(ode, Tsit5(), dt=1.e-2)


### PR DESCRIPTION
This PR will fix the CI errors in https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/103

@devmotion consider that we don't even have unit aware stiff solvers. Trying to handle custom number types with `lu` defined on it seems to be unnecessary.