### PR TITLE
Fix https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/674

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,13 +2,13 @@ julia 1.0
 DiffEqBase 5.3.2
 DiffEqOperators 3.2.0
 Parameters 0.10.0
-ForwardDiff 0.7.0
+ForwardDiff 0.10.3
 GenericSVD 0.0.2
 NLsolve 0.14.1
 RecursiveArrayTools 0.18.6
 DiffEqDiffTools 0.4.0
 Reexport
 MuladdMacro 0.2.1
-StaticArrays
+StaticArrays 0.10.3
 DataStructures 0.15.0
 ExponentialUtilities 1.2.0

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -167,7 +167,6 @@ macro cache(expr)
 end
 
 _reshape(v, siz) = reshape(v, siz)
-_reshape(v::StaticArray, siz) = reshape(v, map(last, siz))
 _reshape(v::Number, siz) = v
 
 _vec(v) = vec(v)

--- a/test/static_array_tests.jl
+++ b/test/static_array_tests.jl
@@ -5,28 +5,30 @@ u0 = fill(zero(MVector{2,Float64}), 2)
 u0[1] = ones(MVector{2,Float64}) .+ 1
 f = (du,u,p,t) -> du .= u
 ode = ODEProblem(f, u0, (0.,1.))
-sol = solve(ode, Euler(), dt=1.e-2)
+sol = solve(ode, Euler(), dt=1e-2)
 sol = solve(ode, Tsit5())
 
 u0 = fill(zero(SVector{2,Float64}), 2) .+ 1
 u0[1] = ones(SVector{2,Float64}) .+ 1
 ode = ODEProblem(f, u0, (0.,1.))
-sol = solve(ode, Euler(), dt=1.e-2)
+sol = solve(ode, Euler(), dt=1e-2)
 sol = solve(ode, Tsit5())
 
-sol = solve(ode, SSPRK22(), dt=1.e-2)
+sol = solve(ode, SSPRK22(), dt=1e-2)
 
 
 u0 = ones(MVector{2,Float64})
 ode = ODEProblem(f, u0, (0.,1.))
-sol = solve(ode, Euler(), dt=1.e-2)
-sol = solve(ode, Tsit5(), dt=1.e-2)
+sol = solve(ode, Euler(), dt=1e-2)
+sol = solve(ode, Tsit5(), dt=1e-2)
 
 
 u0 = ones(SVector{2,Float64})
 f = (u,p,t) -> u
 ode = ODEProblem(f, u0, (0.,1.))
-sol = solve(ode, Euler(), dt=1.e-2)
+sol = solve(ode, Euler(), dt=1e-2)
+integrator = init(ode, ImplicitEuler())
+@test OrdinaryDiffEq.get_W(integrator.cache.nlsolver) isa StaticArrays.LU
 sol = solve(ode, ImplicitEuler())
 sol = solve(ode, ImplicitEuler(nlsolve=NLAnderson()))
-sol = solve(ode, Tsit5(), dt=1.e-2)
+sol = solve(ode, Tsit5(), dt=1e-2)


### PR DESCRIPTION
Additionally I added an explicit test to ensure that for static arrays a static LU decomposition of `W` is created (and hence throughout the integration `W` is of that type). By the way, when adding this test I noticed that finite differencing (i.e., using `sol = solve(ode, ImplicitEuler(autodiff=false))`) does not work because of the assignment in line https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/blob/master/src/jacobians.jl#L147 - is this a regression or just something that should be fixed at some point?