### PR TITLE
Fix possible AD NaN

### DIFF
--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -102,6 +102,11 @@
     f₁ .= ftmp
   end
 
+  # Constant zone before callback
+  # Just return first guess
+  # Avoids AD issues
+  f₀ == f₁ && return 100dt₀
+
   @. tmp = (f₁-f₀)/sk*oneunit_tType
   d₂ = internalnorm(tmp,t)/dt₀*oneunit_tType
   # Hairer has d₂ = sqrt(sum(abs2,tmp))/dt₀, note the lack of norm correction
@@ -142,6 +147,11 @@ end
 
   u₁ = @. u0 + dt₀_tdir * f₀
   f₁ = f(u₁,p,t+dt₀_tdir)
+
+  # Constant zone before callback
+  # Just return first guess
+  # Avoids AD issues
+  f₀ == f₁ && return 100dt₀
 
   d₂ = internalnorm((f₁ .- f₀) ./ sk .* oneunit_tType,t) / dt₀ * oneunit_tType
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -5,3 +5,4 @@ StaticArrays
 DiffEqCallbacks
 DiffEqOperators
 SafeTestsets
+Calculus

--- a/test/ad_tests.jl
+++ b/test/ad_tests.jl
@@ -1,0 +1,35 @@
+using ParameterizedFunctions, Test
+using OrdinaryDiffEq, Calculus, ForwardDiff
+
+f = @ode_def begin
+    dx = -a
+    dy = b
+end a b
+
+cb = ContinuousCallback((u,t,i) -> u[1], (integrator)->(println("Stopped.");integrator.p[2]=zero(integrator.p[2])))
+function test_f(p)
+  prob = ODEProblem(f,eltype(p).([1.0,0.0]),eltype(p).((0.0,1.0)),copy(p))
+  integrator = init(prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb)
+  step!(integrator)
+  solve!(integrator).u[end]
+end
+p = [2.0, 1.0]
+findiff = Calculus.finite_difference_jacobian(test_f,p)
+fordiff = ForwardDiff.jacobian(test_f,p)
+@test findiff ≈ fordiff
+
+f2 = @ode_def begin
+    dx = -x
+    dy = b
+end a b
+
+function test_f2(p)
+  prob = ODEProblem(f2,eltype(p).([1.0,0.0]),eltype(p).((0.0,1.0)),copy(p))
+  integrator = init(prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb)
+  step!(integrator)
+  solve!(integrator).u[end]
+end
+p = [2.0, 1.0]
+findiff = Calculus.finite_difference_jacobian(test_f2,p)
+fordiff = ForwardDiff.jacobian(test_f2,p)
+@test findiff ≈ fordiff

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ if group == "All" || group == "Interface"
   @time @safetestset "Derivative Utilities Tests" begin include("utility_tests.jl") end
   @time @safetestset "Discrete Callback Dual Tests" begin include("discrete_callback_dual_test.jl") end
   @time @safetestset "DEStats Tests" begin include("destats_tests.jl") end
+  @time @safetestset "AD Tests" begin include("ad_tests.jl") end
 end
 
 if group == "All" || group == "Integrators"


### PR DESCRIPTION
Possible AD NaN would show up if f0==f1 which would be the case if the derivative wasn't dependent on state, and the initial dt routine was used, and if time was a dual number. While extremely rare, this could show up in cases where a callback is used to initiate the problem later in the integration.