### PR TITLE
WIP: Full GPU stiff ODE solvers

### DIFF
--- a/src/caches/firk_caches.jl
+++ b/src/caches/firk_caches.jl
@@ -82,7 +82,7 @@ function alg_cache(alg::RadauIIA5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   k = similar(rate_prototype); k2 = similar(rate_prototype); k3 = similar(rate_prototype)
   fw1 = similar(rate_prototype); fw2 = similar(rate_prototype); fw3 = similar(rate_prototype)
 
-  J = fill(zero(uEltypeNoUnits),length(u),length(u))
+  J = false .* rate_prototype .* rate_prototype'
   W1 = similar(J); W2 = similar(J, Complex{eltype(J)})
 
   du1 = similar(rate_prototype)

--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -10,7 +10,7 @@ end
 
 function alg_cache(alg::MidpointSplitting,u,rate_prototype,uEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  W = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+  W = false .* rate_prototype .* rate_prototype' # uEltype?
   k = zero(rate_prototype); fsalfirst = zero(rate_prototype)
   MidpointSplittingCache(u,uprev,uprev2,similar(u),fsalfirst,W,k)
 end

--- a/src/caches/rosenbrock_caches.jl
+++ b/src/caches/rosenbrock_caches.jl
@@ -66,7 +66,7 @@ function alg_cache(alg::Rosenbrock23,u,rate_prototype,uEltypeNoUnits,uBottomElty
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = zero(rate_prototype .* rate_prototype') # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)

--- a/src/caches/rosenbrock_caches.jl
+++ b/src/caches/rosenbrock_caches.jl
@@ -66,7 +66,7 @@ function alg_cache(alg::Rosenbrock23,u,rate_prototype,uEltypeNoUnits,uBottomElty
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = zero(rate_prototype .* rate_prototype') # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -99,7 +99,7 @@ function alg_cache(alg::Rosenbrock32,u,rate_prototype,uEltypeNoUnits,uBottomElty
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -202,7 +202,7 @@ function alg_cache(alg::ROS3P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -264,7 +264,7 @@ function alg_cache(alg::Rodas3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -344,7 +344,7 @@ function alg_cache(alg::RosShamp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -382,7 +382,7 @@ function alg_cache(alg::Veldd4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -420,7 +420,7 @@ function alg_cache(alg::Velds4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -458,7 +458,7 @@ function alg_cache(alg::GRK4T,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -496,7 +496,7 @@ function alg_cache(alg::GRK4A,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -534,7 +534,7 @@ function alg_cache(alg::Ros4LStab,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -615,7 +615,7 @@ function alg_cache(alg::Rodas4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -658,7 +658,7 @@ function alg_cache(alg::Rodas42,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -701,7 +701,7 @@ function alg_cache(alg::Rodas4P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)
@@ -787,7 +787,7 @@ function alg_cache(alg::Rodas5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     W = WOperator(f, dt, true)
     J = nothing # is J = W.J better?
   else
-    J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+    J = false .* rate_prototype .* rate_prototype' # uEltype?
     W = similar(J)
   end
   tmp = zero(rate_prototype)

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -117,7 +117,7 @@ DiffEqBase.@def iipnlsolve begin
         W = WOperator(f, dt, true)
         J = nothing # is J = W.J better?
       else
-        J = zero(u .* u')
+        J = false .* u .* u'
         W = similar(J)
       end
     end

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -117,7 +117,7 @@ DiffEqBase.@def iipnlsolve begin
         W = WOperator(f, dt, true)
         J = nothing # is J = W.J better?
       else
-        J = fill(zero(uEltypeNoUnits),length(u),length(u)) # uEltype?
+        J = zero(u .* u')
         W = similar(J)
       end
     end


### PR DESCRIPTION
With @YingboMa 

```julia
using OrdinaryDiffEq, CuArrays, LinearAlgebra
function lorenz(du,u,p,t)
    mul!(du,A,u)
end
A = cu(-rand(3,3))
u0 = cu([1.0;0.0;0.0])
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
sol = solve(prob,Tsit5())

sol = solve(prob,Rosenbrock23(linsolve=culinsolve))

function culinsolve(x,A,b,update_matrix=false)
    _qr = qr(A)
    _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
    x .= vec(_x)
end
function culinsolve(::Type{Val{:init}},f,u0_prototype)
    culinsolve
end
```

works with this PR. This means we have the following action items:

1) Define dense Jacobians in a generic way. Outer product works fine, but is a little hacky. If someone has a better solution then sure.
2) Linear solvers need to be defined for CuArrays. `qr(A)` works, but surprisingly using `\` on that doesn't. So there needs to be a PR to CuArrays.jl that makes lu or qr works. Default linsolve should be setup to handle this.
3) Do we need to zero out `J`? We can do `fill!(0,r .* r')` or something. What's written here has an alloc.