### PR TITLE
Explicit extrapolation fix

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -90,7 +90,7 @@ function ExtrapolationMidpointHairerWanner(;min_order=2,init_order=5, max_order=
   # Enforce 2 <=  min_order
   # and min_order + 1 <= init_order <= max_order - 1:
   n_min = max(2, min_order)
-  n_init = max(n_min, init_order)
+  n_init = max(n_min + 1, init_order)
   n_max = max(n_init + 1, max_order)
 
   # Warn user if orders have been changed

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -69,14 +69,14 @@ end
 function create_extrapolation_coefficients(alg::algType) where {algType <: Union{ExtrapolationMidpointDeuflhard, ExtrapolationMidpointHairerWanner}}
   # Compute and return extrapolation_coefficients
 
-  @unpack n_min, n_init, n_max, sequence_symbol = alg
+  @unpack n_min, n_init, n_max, sequence = alg
 
   # Initialize subdividing_sequence:
-  if sequence_symbol == :harmonic
+  if sequence == :harmonic
       subdividing_sequence = [BigInt(n+1) for n = 0:n_max]
-  elseif sequence_symbol == :romberg
+  elseif sequence == :romberg
       subdividing_sequence = [BigInt(2)^n for n = 0:n_max]
-  else # sequence_symbol == :bulirsch
+  else # sequence == :bulirsch
       subdividing_sequence = [n==0 ? BigInt(1) : (isodd(n) ? BigInt(2)^Int64(n/2 + 0.5) : 3BigInt(2^Int64(n/2 - 1))) for n = 0:n_max]
   end
 

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -269,20 +269,20 @@ function step_accept_controller!(integrator,alg::ExtrapolationMidpointHairerWann
 
   # Order selection
   n_new = n_old
-  if n_curr == n_min # Enforce n_min ≦ n_new
-    n_new = n_min
+  if n_curr == n_min # Enforce n_min + 1 ≦ n_new
+    n_new = n_min + 1
   else
     if n_curr <= n_old
       if work[n_curr-1] < sigma * work[n_curr]
-        n_new = max(n_curr-1,n_old-1,n_min) # Enforce n_min ≦ n_new
+        n_new = max(n_curr-1,n_old-1,n_min+1) # Enforce n_min + 1≦ n_new
       elseif work[n_curr] < sigma * work[n_curr-1]
         n_new = min(n_curr+1,n_max-1) # Enforce n_new ≦ n_max - 1
       else
-        n_new = n_curr # n_min ≦ n_curr
+        n_new = n_curr # n_min + 1 ≦ n_curr
       end
     else
       if work[n_old] < sigma *  work[n_old+1]
-        n_new = max(n_old-1,n_min)  # Enforce n_min ≦ n_new
+        n_new = max(n_old-1,n_min+1)  # Enforce n_min + 1 ≦ n_new
       end
       if work[n_curr+1] <  sigma * work[n_new+1]
         n_new = min(n_new+1,n_max-1) # Enforce n_new ≦ n_max - 1
@@ -307,7 +307,7 @@ function step_reject_controller!(integrator, alg::ExtrapolationMidpointHairerWan
   # Order selection
   n_red = n_old
   if n_curr == n_old - 1
-    n_red = max(alg.n_min,n_old-1) # Enforce n_min ≦ n_red
+    n_red = max(alg.n_min+1,n_old-1) # Enforce n_min + 1 ≦ n_red
   end
   integrator.cache.n_curr = n_red
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -420,8 +420,8 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
   if integrator.opts.adaptive
     # Set up the order window
     # integrator.alg.n_min + 1 ≦ n_curr ≦ integrator.alg.n_max - 1 is enforced by step_*_controller!
-    if !(integrator.alg.n_min <= n_curr <= integrator.alg.n_max-1)
-       error("Something went wrong while setting up the order window: $n_curr ∉ [$(integrator.alg.n_min),$(integrator.alg.n_max-1)].
+    if !(integrator.alg.n_min + 1 <= n_curr <= integrator.alg.n_max-1)
+       error("Something went wrong while setting up the order window: $n_curr ∉ [$(integrator.alg.n_min+1),$(integrator.alg.n_max-1)].
        Please report this error  ")
     end
     win_min =  n_curr - 1
@@ -531,8 +531,8 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
   if integrator.opts.adaptive
     # Set up the order window
     # integrator.alg.n_min + 1 ≦ n_curr ≦ integrator.alg.n_max - 1 is enforced by step_*_controller!
-    if !(integrator.alg.n_min <= n_curr <= integrator.alg.n_max-1)
-       error("Something went wrong while setting up the order window: $n_curr ∉ [$(integrator.alg.n_min),$(integrator.alg.n_max-1)].
+    if !(integrator.alg.n_min + 1 <= n_curr <= integrator.alg.n_max-1)
+       error("Something went wrong while setting up the order window: $n_curr ∉ [$(integrator.alg.n_min+1),$(integrator.alg.n_max-1)].
        Please report this error  ")
     end
     win_min =  n_curr - 1


### PR DESCRIPTION
This Pull Request contains two fixes for the methods `ExtrapolationMidpointDeuflhard` and
`ExtrapolationMidpointHairerWanner`.

1) Order Selection process for  `ExtrapolationMidpointHairerWanner`.
  `n_curr` in `perform_step!` must be greater or equal to 3.
  Otherwise, if `n_min` attains its minimum 2,  there will be 0 passed as an index to an array:
  https://github.com/AlthausKonstantin/OrdinaryDiffEq.jl/blob/4ec7bda492b83c3925c9f3afb21618fea2cf4160/src/perform_step/extrapolation_perform_step.jl#L453.

2) Use of `sequence_symbol` in src/caches/extrapolation_caches.jl is deprecated.