### PR TITLE
Step_size limitations on SERK Methods and RKC

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -499,7 +499,8 @@ uses_uprev(alg::CKLLSRK85_4FM_4R, adaptive::Bool) = adaptive
 uses_uprev(alg::CKLLSRK75_4M_5R, adaptive::Bool) = adaptive
 
 ispredictive(alg::OrdinaryDiffEqAlgorithm) = false
-ispredictive(alg::Union{RKC,SERK2v2}) = alg.controller === :Predictive
+ispredictive(alg::Union{RKC}) = true
+ispredictive(alg::Union{SERK2v2}) = alg.controller === :Predictive
 ispredictive(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = alg.controller === :Predictive
 isstandard(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = alg.controller === :Standard
 isstandard(alg::Union{GenericImplicitEuler,GenericTrapezoid,VCABM}) = true

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -500,7 +500,7 @@ uses_uprev(alg::CKLLSRK85_4FM_4R, adaptive::Bool) = adaptive
 uses_uprev(alg::CKLLSRK75_4M_5R, adaptive::Bool) = adaptive
 
 ispredictive(alg::OrdinaryDiffEqAlgorithm) = false
-ispredictive(alg::Union{RKC,SERK2v2}) = true
+ispredictive(alg::Union{RKC,SERK2v2,ESERK5}) = alg.controller === :Predictive
 ispredictive(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = alg.controller === :Predictive
 isstandard(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = alg.controller === :Standard
 isstandard(alg::Union{GenericImplicitEuler,GenericTrapezoid,VCABM}) = true

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -388,7 +388,6 @@ beta1_default(alg::ExtrapolationMidpointDeuflhard,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ExtrapolationMidpointHairerWanner,beta2) =  1//(2alg.n_init+1)
 
 gamma_default(alg::OrdinaryDiffEqAlgorithm) = 9//10
-gamma_default(alg::ESERK5) = 8//10
 gamma_default(alg::RKC) = 8//10
 gamma_default(alg::IRKC) = 8//10
 gamma_default(alg::ExtrapolationMidpointDeuflhard) = (1//4)^beta1_default(alg,beta2_default(alg))
@@ -500,7 +499,7 @@ uses_uprev(alg::CKLLSRK85_4FM_4R, adaptive::Bool) = adaptive
 uses_uprev(alg::CKLLSRK75_4M_5R, adaptive::Bool) = adaptive
 
 ispredictive(alg::OrdinaryDiffEqAlgorithm) = false
-ispredictive(alg::Union{RKC,SERK2v2,ESERK5}) = alg.controller === :Predictive
+ispredictive(alg::Union{RKC,SERK2v2}) = alg.controller === :Predictive
 ispredictive(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = alg.controller === :Predictive
 isstandard(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = alg.controller === :Standard
 isstandard(alg::Union{GenericImplicitEuler,GenericTrapezoid,VCABM}) = true

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -489,7 +489,6 @@ ROCK4(;min_stages=0,max_stages=152) = ROCK4(min_stages,max_stages)
 
 # SERK methods
 struct ESERK5 <: OrdinaryDiffEqAdaptiveAlgorithm end
-
 struct SERK2v2 <: OrdinaryDiffEqAdaptiveAlgorithm
   controller::Symbol
 end
@@ -497,7 +496,6 @@ SERK2v2(;controller=:PI) = SERK2v2(controller)
 
 # RKC mehtods
 struct RKC <: OrdinaryDiffEqAdaptiveAlgorithm end
-
 struct IRKC{CS,AD,F,F2,FDT,K,T} <: OrdinaryDiffEqNewtonAdaptiveAlgorithm{CS,AD}
   linsolve::F
   nlsolve::F2

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -488,11 +488,22 @@ end
 ROCK4(;min_stages=0,max_stages=152) = ROCK4(min_stages,max_stages)
 
 # SERK methods
-struct ESERK5 <: OrdinaryDiffEqAdaptiveAlgorithm end
-struct SERK2v2 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct ESERK5 <: OrdinaryDiffEqAdaptiveAlgorithm
+  controller::Symbol
+end
+ESERK5(;controller=:PI) = ESERK5(controller)
+
+struct SERK2v2 <: OrdinaryDiffEqAdaptiveAlgorithm
+  controller::Symbol
+end
+SERK2v2(;controller=:PI) = SERK2v2(controller)
 
 # RKC mehtods
-struct RKC <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RKC <: OrdinaryDiffEqAdaptiveAlgorithm
+  controller::Symbol
+end
+RKC(;controller=:PI) = RKC(controller)
+
 struct IRKC{CS,AD,F,F2,FDT,K,T} <: OrdinaryDiffEqNewtonAdaptiveAlgorithm{CS,AD}
   linsolve::F
   nlsolve::F2

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -488,10 +488,7 @@ end
 ROCK4(;min_stages=0,max_stages=152) = ROCK4(min_stages,max_stages)
 
 # SERK methods
-struct ESERK5 <: OrdinaryDiffEqAdaptiveAlgorithm
-  controller::Symbol
-end
-ESERK5(;controller=:PI) = ESERK5(controller)
+struct ESERK5 <: OrdinaryDiffEqAdaptiveAlgorithm end
 
 struct SERK2v2 <: OrdinaryDiffEqAdaptiveAlgorithm
   controller::Symbol
@@ -499,10 +496,7 @@ end
 SERK2v2(;controller=:PI) = SERK2v2(controller)
 
 # RKC mehtods
-struct RKC <: OrdinaryDiffEqAdaptiveAlgorithm
-  controller::Symbol
-end
-RKC(;controller=:PI) = RKC(controller)
+struct RKC <: OrdinaryDiffEqAdaptiveAlgorithm end
 
 struct IRKC{CS,AD,F,F2,FDT,K,T} <: OrdinaryDiffEqNewtonAdaptiveAlgorithm{CS,AD}
   linsolve::F

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -4,7 +4,7 @@
     q = inv(integrator.opts.qmax)
   else
     gamma = integrator.opts.gamma
-    if typeof(alg) <: Union{RKC,IRKC,SERK2v2}
+    if typeof(alg) <: Union{RKC,IRKC,SERK2v2,ESERK5}
       fac = gamma
     else
       if alg isa RadauIIA5

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -4,7 +4,7 @@
     q = inv(integrator.opts.qmax)
   else
     gamma = integrator.opts.gamma
-    if typeof(alg) <: Union{RKC,IRKC,SERK2v2,ESERK5}
+    if typeof(alg) <: Union{RKC,IRKC,SERK2v2}
       fac = gamma
     else
       if alg isa RadauIIA5

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -302,9 +302,11 @@ function handle_discontinuities!(integrator)
 end
 
 function calc_dt_propose!(integrator,dtnew)
-  if (typeof(integrator.alg) <: Union{ROCK2,ROCK4}) && integrator.opts.adaptive && (integrator.iter >= 1)
+  if (typeof(integrator.alg) <: Union{ROCK2,ROCK4,SERK2v2,ESERK5}) && integrator.opts.adaptive && (integrator.iter >= 1)
     (integrator.alg isa ROCK2) && (dtnew = min(dtnew,typeof(dtnew)((((min(integrator.alg.max_stages,200)^2.0)*.811 - 1.5)/integrator.eigen_est))))
     (integrator.alg isa ROCK4) && (dtnew = min(dtnew,typeof(dtnew)((((min(integrator.alg.max_stages,152)^2.0)*.353 - 3)/integrator.eigen_est))))
+    (integrator.alg isa SERK2v2) && (dtnew = min(dtnew,typeof(dtnew)((0.8*250*250/(integrator.eigen_est+1.0)))))
+    (integrator.alg isa ESERK5) && (dtnew = min(dtnew,typeof(dtnew)((0.98*2000*2000/integrator.eigen_est))))
   end
   dtpropose = integrator.tdir*min(abs(integrator.opts.dtmax),abs(dtnew))
   dtpropose = integrator.tdir*max(abs(dtpropose),abs(integrator.opts.dtmin))

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -803,6 +803,7 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.98))+1)
+  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 2000) ? 2000 : mdeg
   cache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)
@@ -881,6 +882,7 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.98))+1)
+  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 2000) ? 2000 : mdeg
   ccache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)
@@ -960,6 +962,7 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.8))+1)
+  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 250) ? 250 : mdeg
   cache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)
@@ -1022,6 +1025,7 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.8))+1)
+  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 250) ? 250 : mdeg
   ccache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -372,9 +372,8 @@ end
   # The the number of degree for Chebyshev polynomial
   maxm = max(2,Int(floor(sqrt(integrator.opts.internalnorm(integrator.opts.reltol,t)/(10*eps(integrator.opts.internalnorm(uprev,t)))))))
   mdeg = 1 + Int(floor(sqrt(1.54*dt*integrator.eigen_est + 1)))
-  if mdeg >= maxm
-    mdeg = maxm
-  end
+  mdeg = (mdeg > maxm) ? maxm : mdeg
+
 
   w0 = 1 + 2/(13*(mdeg^2))
   temp1 = w0^2 - 1
@@ -457,9 +456,7 @@ end
   # The the number of degree for Chebyshev polynomial
   maxm = max(2,Int(floor(sqrt(integrator.opts.internalnorm(integrator.opts.reltol,t)/(10*eps(integrator.opts.internalnorm(uprev,t)))))))
   mdeg = 1 + Int(floor(sqrt(1.54*dt*integrator.eigen_est + 1)))
-  if mdeg >= maxm
-    mdeg = maxm
-  end
+  mdeg = (mdeg > maxm) ? maxm : mdeg
 
   w0 = 1 + 2/(13*(mdeg^2))
   temp1 = w0^2 - 1
@@ -803,7 +800,6 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.98))+1)
-  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 2000) ? 2000 : mdeg
   cache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)
@@ -882,7 +878,6 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.98))+1)
-  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 2000) ? 2000 : mdeg
   ccache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)
@@ -962,7 +957,6 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.8))+1)
-  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 250) ? 250 : mdeg
   cache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)
@@ -1025,7 +1019,6 @@ end
   maxeig!(integrator, cache)
 
   mdeg = Int(floor(sqrt(abs(dt)*integrator.eigen_est/0.8))+1)
-  # println(integrator.iter,"  ",mdeg,"  ",integrator.eigen_est,"  ",dt)
   mdeg = (mdeg > 250) ? 250 : mdeg
   ccache.mdeg = mdeg
   choosedeg_SERK!(integrator,cache)

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -374,7 +374,6 @@ end
   mdeg = 1 + Int(floor(sqrt(1.54*dt*integrator.eigen_est + 1)))
   mdeg = (mdeg > maxm) ? maxm : mdeg
 
-
   w0 = 1 + 2/(13*(mdeg^2))
   temp1 = w0^2 - 1
   temp2 = sqrt(temp1)

--- a/src/rkc_utils.jl
+++ b/src/rkc_utils.jl
@@ -51,6 +51,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
   for iter in 1:maxiter
     if integrator.alg isa IRKC
       fz = f.f2(z, p, t)
+      integrator.destats.nf2 += 1
       tmp = fz - cache.du₂
     else
       fz = f(z, p, t)
@@ -145,6 +146,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
   for iter in 1:maxiter
     if integrator.alg isa IRKC
       f.f2(fz, z, p, t)
+      integrator.destats.nf2 += 1
       @.. atmp = fz - cache.du₂
     else
       f(fz, z, p, t)


### PR DESCRIPTION
@ChrisRackauckas 
1.  Adds step_size limits for `RKC`, `ESERK5` and `SERK2v2` so that the solver remain stable.
2.  adds 1 missing function evaluation count in `destats`.
3.  Adds functionality to use both `PI` and `Predictive` controls in `SERK2v2`. The default is set to `PI`.
4. `ESERK5` now uses default `gamma`.

Also `RKC` currently uses `Predictive` by default and I ran a few benchmarks I think we should switch to `PI`