### PR TITLE
Fix `destats` when using cached forward difference

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -44,10 +44,13 @@ function jacobian(f, x, integrator)
       tmp = 1
     else
       J = jacobian_finitediff(f, x, alg.diff_type)
+      N = length(x)
       if alg.diff_type==Val{:complex} && eltype(x)<:Real
-        tmp = length(x)
+        tmp = N
+      elseif alg.diff_type==Val{:forward}
+        tmp = N + 1
       else
-        tmp = 2*length(x)
+        tmp = 2N
       end
     end
     integrator.destats.nf += tmp

--- a/test/interface/destats_tests.jl
+++ b/test/interface/destats_tests.jl
@@ -2,8 +2,8 @@
 using OrdinaryDiffEq, Test
 x = Ref(0)
 function f(u,p,t)
-	x[] += 1
-	return 5*u
+  x[] += 1
+  return 5*u
 end
 u0 = [1.0, 1.0]
 tspan = (0.0,1.0)


### PR DESCRIPTION
Ref: https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/769, https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/756#issuecomment-502785908