### PR TITLE
Attempt to fix DiffEqBot timings

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,4 +1,5 @@
 using BenchmarkTools, OrdinaryDiffEq
+BenchmarkTools.DEFAULT_PARAMETERS.gcsample = true
 f(u,p,t) = u
 prob = ODEProblem(f,1.0,(0.0,1.0))
 

--- a/benchmark/tune.json
+++ b/benchmark/tune.json
@@ -1,1 +1,0 @@
-[{"Julia":"1.1.0","BenchmarkTools":"0.2.2"},[["BenchmarkGroup",{"data":{"algs":["BenchmarkGroup",{"data":{"Tsit5":["BenchmarkTools.Parameters",{"gctrial":true,"time_tolerance":0.05,"samples":10000,"evals":3,"gcsample":false,"seconds":5.0,"overhead":0.0,"memory_tolerance":0.01}]},"tags":[]}]},"tags":[]}]]]


### PR DESCRIPTION
Expected due to garbage cleanup, I have introduced sample wise garbage cleanup. By default, garbage cleanup is done after each `@benchmark` call which calls the function, say 1000 times, not between these single calls. Not sure if this will fix the timings, but running it for a few times on my computer shows that it probably got fixed.