### PR TITLE
Increase benchmarking time

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,6 @@
 using BenchmarkTools, OrdinaryDiffEq
 BenchmarkTools.DEFAULT_PARAMETERS.gcsample = true
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 20
 f(u,p,t) = u
 prob = ODEProblem(f,1.0,(0.0,1.0))
 


### PR DESCRIPTION
This PR increases the max time limit of running a single benchmarking job. Ref: https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/769#issuecomment-504083787