### PR TITLE
[WIP] Eliminate p

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -65,6 +65,8 @@ end
   end
 end
 
+DiffEqBase.get_params(integrator::ODEIntegrator) = integrator.p
+
 #TODO: Bigger caches for most algorithms
 @inline DiffEqBase.get_tmp_cache(integrator::ODEIntegrator) =
           get_tmp_cache(integrator::ODEIntegrator,integrator.alg,integrator.cache)

--- a/src/perform_step/feagin_rk_perform_step.jl
+++ b/src/perform_step/feagin_rk_perform_step.jl
@@ -1,5 +1,5 @@
 function initialize!(integrator, cache::Feagin10ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -11,26 +11,26 @@ function initialize!(integrator, cache::Feagin10ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Feagin10ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache
   k1  = integrator.fsalfirst
   a = dt*a0100
-  k2  = f(uprev  + a*k1, p, t + c1*dt)
-  k3  = f(uprev + dt*(a0200*k1 + a0201*k2), p, t + c2*dt)
-  k4  = f(uprev  + dt*(a0300*k1              + a0302*k3), p, t + c3*dt)
-  k5  = f(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4), p, t + c4*dt)
-  k6  = f(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5), p, t + c5*dt)
-  k7  = f(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6), p, t + c6*dt)
-  k8  = f(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7), p, t + c7*dt)
-  k9  = f(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8), p, t + c8*dt)
-  k10 = f(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9), p, t + c9*dt)
-  k11 = f(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10), p, t + c10*dt)
-  k12 = f(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11), p, t + c11*dt)
-  k13 = f(uprev + dt*(a1200*k1                           + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12), p, t + c12*dt)
-  k14 = f(uprev + dt*(a1300*k1              + a1302*k3 + a1303*k4              + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13), p, t + c13*dt)
-  k15 = f(uprev + dt*(a1400*k1 + a1401*k2                           + a1404*k5              + a1406*k7 +                                                                     a1412*k13 + a1413*k14), p, t + c14*dt)
-  k16 = f(uprev + dt*(a1500*k1              + a1502*k3                                                                                                                                                     + a1514*k15), p, t + c15*dt)
-  k17 = f(uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3              + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16), p, t + c16*dt)
+  k2  = f(uprev  + a*k1, t + c1*dt, integrator)
+  k3  = f(uprev + dt*(a0200*k1 + a0201*k2), t + c2*dt, integrator)
+  k4  = f(uprev  + dt*(a0300*k1              + a0302*k3), t + c3*dt, integrator)
+  k5  = f(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4), t + c4*dt, integrator)
+  k6  = f(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5), t + c5*dt, integrator)
+  k7  = f(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6), t + c6*dt, integrator)
+  k8  = f(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7), t + c7*dt, integrator)
+  k9  = f(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8), t + c8*dt, integrator)
+  k10 = f(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9), t + c9*dt, integrator)
+  k11 = f(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10), t + c10*dt, integrator)
+  k12 = f(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11), t + c11*dt, integrator)
+  k13 = f(uprev + dt*(a1200*k1                           + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12), t + c12*dt, integrator)
+  k14 = f(uprev + dt*(a1300*k1              + a1302*k3 + a1303*k4              + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13), t + c13*dt, integrator)
+  k15 = f(uprev + dt*(a1400*k1 + a1401*k2                           + a1404*k5              + a1406*k7 +                                                                     a1412*k13 + a1413*k14), t + c14*dt, integrator)
+  k16 = f(uprev + dt*(a1500*k1              + a1502*k3                                                                                                                                                     + a1514*k15), t + c15*dt, integrator)
+  k17 = f(uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3              + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16), t + c16*dt, integrator)
   integrator.destats.nf += 16
   u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
   if integrator.opts.adaptive
@@ -38,7 +38,7 @@ end
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  k = f(u, p, t+dt) # For the interpolation, needs k at the updated point
+  k = f(u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
   integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
@@ -53,61 +53,61 @@ function initialize!(integrator, cache::Feagin10Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 #=
 @muladd function perform_step!(integrator, cache::Feagin10Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
   a =  dt*a0100
   @.. tmp = uprev + a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev + dt*(a0200*k1 + a0201*k2)
-  f(k3, tmp, p, t + c2*dt )
+  f(k3, tmp, t + c2*dt , integrator)
   @.. tmp = uprev + dt*(a0300*k1 + a0302*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @.. tmp = uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @.. tmp = uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @.. tmp = uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @.. tmp = uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @..  tmp = uprev + dt*(a1200*k1 + a1203*k4 + a1204*k5 + a1205*k6 + a1206*k7 + a1207*k8 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @.. tmp = uprev + dt*(a1300*k1 + a1302*k3 + a1303*k4 + a1305*k6 + a1306*k7 + a1307*k8 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @.. tmp = uprev + dt*(a1400*k1 + a1401*k2 + a1404*k5 + a1406*k7 + a1412*k13 + a1413*k14)
-  f(k15, tmp, p, t + c14*dt)
+  f(k15, tmp, t + c14*dt, integrator)
   @.. tmp = uprev + dt*(a1500*k1 + a1502*k3 + a1514*k15)
-  f(k16, tmp, p, t + c15*dt)
+  f(k16, tmp, t + c15*dt, integrator)
   @.. tmp = uprev + dt*(a1600*k1 + a1601*k2 + a1602*k3 + a1604*k5 + a1605*k6 + a1606*k7 + a1607*k8 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)
-  f(k17, tmp, p, t + c16*dt)
+  f(k17, tmp, t + c16*dt, integrator)
   @.. u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b9*k9 + b10*k10 + b11*k11 + b12*k12 + b13*k13 + b14*k14 + b15*k15 + b16*k16 + b17*k17)
   if integrator.opts.adaptive
     @.. tmp = dt*(k2 - k16) * adaptiveConst
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(integrator.fsallast,u,p,t+dt) # For the interpolation, needs k at the updated point
+  f(integrator.fsallast, u, t+dt, integrator) # For the interpolation, needs k at the updated point
 end
 =#
 
 @muladd function perform_step!(integrator, cache::Feagin10Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1203,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1300,a1302,a1303,a1305,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1400,a1401,a1404,a1406,a1412,a1413,a1500,a1502,a1514,a1600,a1601,a1602,a1604,a1605,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,tmp,atmp,uprev,k = cache
@@ -116,67 +116,67 @@ end
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + a*k1[i]
   end
-  f(k2,tmp,p,t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
   end
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
   end
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
   end
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
   end
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
   end
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1200*k1[i] + a1203*k4[i] + a1204*k5[i] + a1205*k6[i] + a1206*k7[i] + a1207*k8[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
   end
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1300*k1[i] + a1302*k3[i] + a1303*k4[i] + a1305*k6[i] + a1306*k7[i] + a1307*k8[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
   end
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1400*k1[i] + a1401*k2[i] + a1404*k5[i] + a1406*k7[i] + a1412*k13[i] + a1413*k14[i])
   end
-  f(k15, tmp, p, t + c14*dt)
+  f(k15, tmp, t + c14*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1500*k1[i] + a1502*k3[i] + a1514*k15[i])
   end
-  f(k16, tmp, p, t + c15*dt)
+  f(k16, tmp, t + c15*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1600*k1[i] + a1601*k2[i] + a1602*k3[i] + a1604*k5[i] + a1605*k6[i] + a1606*k7[i] + a1607*k8[i] + a1608*k9[i] + a1609*k10[i] + a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i] + a1614*k15[i] + a1615*k16[i])
   end
-  f(k17, tmp, p, t + c16*dt)
+  f(k17, tmp, t + c16*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b9*k9[i] + b10*k10[i] + b11*k11[i] + b12*k12[i] + b13*k13[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b17*k17[i])
   end
@@ -188,12 +188,12 @@ end
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(integrator.fsallast,u,p,t+dt) # For the interpolation, needs k at the updated point
+  f(integrator.fsallast, u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
 end
 
 function initialize!(integrator, cache::Feagin12ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -205,37 +205,37 @@ function initialize!(integrator, cache::Feagin12ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Feagin12ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache
   k1   = integrator.fsalfirst
   a =  dt*a0100
-  k2  = f(uprev  + a*k1, p, t + c1*dt)
-  k3  = f(uprev + dt*(a0200*k1 + a0201*k2), p, t + c2*dt)
-  k4  = f(uprev  + dt*(a0300*k1              + a0302*k3), p, t + c3*dt)
-  k5  = f(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4), p, t + c4*dt)
-  k6  = f(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5), p, t + c5*dt)
-  k7  = f(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6), p, t + c6*dt)
-  k8  = f(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7), p, t + c7*dt)
-  k9  = f(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8), p, t + c8*dt)
-  k10 = f(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9), p, t + c9*dt)
-  k11 = f(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10), p, t + c10*dt)
-  k12 = f(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11), p, t + c11*dt)
-  k13 = f(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12), p, t + c12*dt)
-  k14 = f(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13), p, t + c13*dt)
-  k15 = f(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14), p, t + c14*dt)
-  k16 = f(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15), p, t + c15*dt)
-  k17 = f(uprev + dt*((a1600*k1                                                                                            + a1608*k9 + a1609*k10) + (a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14) + (a1614*k15 + a1615*k16)), p, t + c16*dt)
-  k18 = f(uprev + dt*((a1700*k1                                                     + a1705*k6 + a1706*k7) + (a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11) + (a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15) + (a1715*k16 + a1716*k17)), p, t + c17*dt)
-  k19 = f(uprev + dt*((a1800*k1                                                     + a1805*k6 + a1806*k7) + (a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11) + (a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15) + (a1815*k16 + a1816*k17 + a1817*k18)), p, t + c18*dt)
-  k20 = f(uprev + dt*((a1900*k1                                        + a1904*k5 + a1905*k6) + (a1906*k7              + a1908*k9 + a1909*k10 + a1910*k11) + (a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15) + (a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)), p, t + c19*dt)
-  k21 = f(uprev + dt*((a2000*k1                           + a2003*k4 + a2004*k5) + (a2005*k6              + a2007*k8              + a2009*k10 + a2010*k11)                                                                                     + (a2017*k18 + a2018*k19 + a2019*k20)), p, t + c20*dt)
-  k22 = f(uprev + dt*((a2100*k1              + a2102*k3 + a2103*k4)                           + (a2106*k7 + a2107*k8              + a2109*k10 + a2110*k11)                                                                                     + (a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)), p, t + c21*dt)
-  k23 = f(uprev + dt*((a2200*k1 + a2201*k2                           + a2204*k5)              + (a2206*k7                                                                                                                                                                                     + a2220*k21 + a2221*k22)), p, t + c22*dt)
-  k24 = f(uprev + dt*(a2300*k1              + a2302*k3                                                                                                                                                                                                                                                                     + a2322*k23), p, t + c23*dt)
-  k25 = f(uprev + dt*((a2400*k1 + a2401*k2 + a2402*k3)              + (a2404*k5              + a2406*k7 + a2407*k8 + a2408*k9) + (a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13) + (a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17) + (a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21) + (a2421*k22 + a2422*k23 + a2423*k24)), p, t + c24*dt)
+  k2  = f(uprev  + a*k1, t + c1*dt, integrator)
+  k3  = f(uprev + dt*(a0200*k1 + a0201*k2), t + c2*dt, integrator)
+  k4  = f(uprev  + dt*(a0300*k1              + a0302*k3), t + c3*dt, integrator)
+  k5  = f(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4), t + c4*dt, integrator)
+  k6  = f(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5), t + c5*dt, integrator)
+  k7  = f(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6), t + c6*dt, integrator)
+  k8  = f(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7), t + c7*dt, integrator)
+  k9  = f(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8), t + c8*dt, integrator)
+  k10 = f(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9), t + c9*dt, integrator)
+  k11 = f(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10), t + c10*dt, integrator)
+  k12 = f(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11), t + c11*dt, integrator)
+  k13 = f(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12), t + c12*dt, integrator)
+  k14 = f(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13), t + c13*dt, integrator)
+  k15 = f(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14), t + c14*dt, integrator)
+  k16 = f(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15), t + c15*dt, integrator)
+  k17 = f(uprev + dt*((a1600*k1                                                                                            + a1608*k9 + a1609*k10) + (a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14) + (a1614*k15 + a1615*k16)), t + c16*dt, integrator)
+  k18 = f(uprev + dt*((a1700*k1                                                     + a1705*k6 + a1706*k7) + (a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11) + (a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15) + (a1715*k16 + a1716*k17)), t + c17*dt, integrator)
+  k19 = f(uprev + dt*((a1800*k1                                                     + a1805*k6 + a1806*k7) + (a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11) + (a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15) + (a1815*k16 + a1816*k17 + a1817*k18)), t + c18*dt, integrator)
+  k20 = f(uprev + dt*((a1900*k1                                        + a1904*k5 + a1905*k6) + (a1906*k7              + a1908*k9 + a1909*k10 + a1910*k11) + (a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15) + (a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)), t + c19*dt, integrator)
+  k21 = f(uprev + dt*((a2000*k1                           + a2003*k4 + a2004*k5) + (a2005*k6              + a2007*k8              + a2009*k10 + a2010*k11)                                                                                     + (a2017*k18 + a2018*k19 + a2019*k20)), t + c20*dt, integrator)
+  k22 = f(uprev + dt*((a2100*k1              + a2102*k3 + a2103*k4)                           + (a2106*k7 + a2107*k8              + a2109*k10 + a2110*k11)                                                                                     + (a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)), t + c21*dt, integrator)
+  k23 = f(uprev + dt*((a2200*k1 + a2201*k2                           + a2204*k5)              + (a2206*k7                                                                                                                                                                                     + a2220*k21 + a2221*k22)), t + c22*dt, integrator)
+  k24 = f(uprev + dt*(a2300*k1              + a2302*k3                                                                                                                                                                                                                                                                     + a2322*k23), t + c23*dt, integrator)
+  k25 = f(uprev + dt*((a2400*k1 + a2401*k2 + a2402*k3)              + (a2404*k5              + a2406*k7 + a2407*k8 + a2408*k9) + (a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13) + (a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17) + (a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21) + (a2421*k22 + a2422*k23 + a2423*k24)), t + c24*dt, integrator)
   integrator.destats.nf += 24
   u = uprev + dt*((b1*k1 + b2*k2 + b3*k3 + b5*k5) + (b7*k7 + b8*k8 + b10*k10 + b11*k11) + (b13*k13 + b14*k14 + b15*k15 + b16*k16) + (b17*k17 + b18*k18 + b19*k19 + b20*k20) + (b21*k21 + b22*k22 + b23*k23) + (b24*k24 + b25*k25))
-  k = f(u, p, t+dt)
+  k = f(u, t+dt, integrator)
   integrator.destats.nf += 1
   integrator.fsallast = k
   if integrator.opts.adaptive
@@ -255,77 +255,77 @@ function initialize!(integrator, cache::Feagin12Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 #=
 @muladd function perform_step!(integrator, cache::Feagin12Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k18,k19,k20,k21,k22,k23,k24,k25,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
   a = dt*a0100
   @.. tmp = uprev + a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev + dt*(a0200*k1 + a0201*k2)
-  f(k3, tmp, p, t + c2*dt )
+  f(k3, tmp, t + c2*dt , integrator)
   @.. tmp = uprev + dt*(a0300*k1 + a0302*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @.. tmp = uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @.. tmp = uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @.. tmp = uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @.. tmp = uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @.. tmp = uprev + dt*(a1200*k1 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @.. tmp = uprev + dt*(a1300*k1 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @.. tmp = uprev + dt*(a1400*k1 + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)
-  f(k15, tmp, p, t + c14*dt)
+  f(k15, tmp, t + c14*dt, integrator)
   @.. tmp = uprev + dt*(a1500*k1 + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)
-  f(k16, tmp, p, t + c15*dt)
+  f(k16, tmp, t + c15*dt, integrator)
   @.. tmp = uprev + dt*((a1600*k1 + a1608*k9 + a1609*k10) + (a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14) + (a1614*k15 + a1615*k16))
-  f(k17, tmp, p, t + c16*dt)
+  f(k17, tmp, t + c16*dt, integrator)
   @.. tmp = uprev + dt*((a1700*k1 + a1705*k6 + a1706*k7) + (a1707*k8 + a1708*k9 + a1709*k10 + a1710*k11) + (a1711*k12 + a1712*k13 + a1713*k14 + a1714*k15) + (a1715*k16 + a1716*k17))
-  f(k18, tmp, p, t + c17*dt)
+  f(k18, tmp, t + c17*dt, integrator)
   @.. tmp = uprev + dt*((a1800*k1 + a1805*k6 + a1806*k7) + (a1807*k8 + a1808*k9 + a1809*k10 + a1810*k11) + (a1811*k12 + a1812*k13 + a1813*k14 + a1814*k15) + (a1815*k16 + a1816*k17 + a1817*k18))
-  f(k19, tmp, p, t + c18*dt)
+  f(k19, tmp, t + c18*dt, integrator)
   @.. tmp = uprev + dt*((a1900*k1 + a1904*k5 + a1905*k6) + (a1906*k7 + a1908*k9 + a1909*k10 + a1910*k11) + (a1911*k12 + a1912*k13 + a1913*k14 + a1914*k15) + (a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19))
-  f(k20, tmp, p, t + c19*dt)
+  f(k20, tmp, t + c19*dt, integrator)
   @.. tmp = uprev + dt*((a2000*k1 + a2003*k4 + a2004*k5) + (a2005*k6 + a2007*k8 + a2009*k10 + a2010*k11) + (a2017*k18 + a2018*k19 + a2019*k20))
-  f(k21, tmp, p, t + c20*dt)
+  f(k21, tmp, t + c20*dt, integrator)
   @.. tmp = uprev + dt*((a2100*k1 + a2102*k3 + a2103*k4) + (a2106*k7 + a2107*k8 + a2109*k10 + a2110*k11) + (a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21))
-  f(k22, tmp, p, t + c21*dt)
+  f(k22, tmp, t + c21*dt, integrator)
   @.. tmp = uprev + dt*((a2200*k1 + a2201*k2 + a2204*k5) + (a2206*k7 + a2220*k21 + a2221*k22))
-  f(k23, tmp, p, t + c22*dt)
+  f(k23, tmp, t + c22*dt, integrator)
   @.. tmp = uprev + dt*(a2300*k1 + a2302*k3 + a2322*k23)
-  f(k24, tmp, p, t + c23*dt)
+  f(k24, tmp, t + c23*dt, integrator)
   @.. tmp = uprev + dt*((a2400*k1 + a2401*k2 + a2402*k3) + (a2404*k5 + a2406*k7 + a2407*k8 + a2408*k9) + (a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13) + (a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17) + (a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21) + (a2421*k22 + a2422*k23 + a2423*k24))
-  f(k25, tmp, p, t + c24*dt)
+  f(k25, tmp, t + c24*dt, integrator)
   @.. u = uprev + dt*((b1*k1 + b2*k2 + b3*k3 + b5*k5) + (b7*k7 + b8*k8 + b10*k10 + b11*k11) + (b13*k13 + b14*k14 + b15*k15 + b16*k16) + (b17*k17 + b18*k18 + b19*k19 + b20*k20) + (b21*k21 + b22*k22 + b23*k23) + (b24*k24 + b25*k25))
   if integrator.opts.adaptive
     @.. tmp = dt*(k2 - k24) * adaptiveConst
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
 end
 =#
 
 @muladd function perform_step!(integrator, cache::Feagin12Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1705,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,a1716,a1800,a1805,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1904,a1905,a1906,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2003,a2004,a2005,a2007,a2009,a2010,a2017,a2018,a2019,a2100,a2102,a2103,a2106,a2107,a2109,a2110,a2117,a2118,a2119,a2120,a2200,a2201,a2204,a2206,a2220,a2221,a2300,a2302,a2322,a2400,a2401,a2402,a2404,a2406,a2407,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k18,k19,k20,k21,k22,k23,k24,k25,tmp,atmp,uprev,k = cache
@@ -334,99 +334,99 @@ end
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + a*k1[i]
   end
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
   end
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
   end
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
   end
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
   end
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
   end
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1200*k1[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
   end
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1300*k1[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
   end
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1400*k1[i] + a1408*k9[i] + a1409*k10[i] + a1410*k11[i] + a1411*k12[i] + a1412*k13[i] + a1413*k14[i])
   end
-  f(k15, tmp, p, t + c14*dt)
+  f(k15, tmp, t + c14*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1500*k1[i] + a1508*k9[i] + a1509*k10[i] + a1510*k11[i] + a1511*k12[i] + a1512*k13[i] + a1513*k14[i] + a1514*k15[i])
   end
-  f(k16, tmp, p, t + c15*dt)
+  f(k16, tmp, t + c15*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a1600*k1[i] + a1608*k9[i] + a1609*k10[i]) + (a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i]) + (a1614*k15[i] + a1615*k16[i]))
   end
-  f(k17, tmp, p, t + c16*dt)
+  f(k17, tmp, t + c16*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a1700*k1[i] + a1705*k6[i] + a1706*k7[i]) + (a1707*k8[i] + a1708*k9[i] + a1709*k10[i] + a1710*k11[i]) + (a1711*k12[i] + a1712*k13[i] + a1713*k14[i] + a1714*k15[i]) + (a1715*k16[i] + a1716*k17[i]))
   end
-  f(k18, tmp, p, t + c17*dt)
+  f(k18, tmp, t + c17*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a1800*k1[i] + a1805*k6[i] + a1806*k7[i]) + (a1807*k8[i] + a1808*k9[i] + a1809*k10[i] + a1810*k11[i]) + (a1811*k12[i] + a1812*k13[i] + a1813*k14[i] + a1814*k15[i]) + (a1815*k16[i] + a1816*k17[i] + a1817*k18[i]))
   end
-  f(k19, tmp, p, t + c18*dt)
+  f(k19, tmp, t + c18*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a1900*k1[i] + a1904*k5[i] + a1905*k6[i]) + (a1906*k7[i] + a1908*k9[i] + a1909*k10[i] + a1910*k11[i]) + (a1911*k12[i] + a1912*k13[i] + a1913*k14[i] + a1914*k15[i]) + (a1915*k16[i] + a1916*k17[i] + a1917*k18[i] + a1918*k19[i]))
   end
-  f(k20, tmp, p, t + c19*dt)
+  f(k20, tmp, t + c19*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a2000*k1[i] + a2003*k4[i] + a2004*k5[i]) + (a2005*k6[i] + a2007*k8[i] + a2009*k10[i] + a2010*k11[i]) + (a2017*k18[i] + a2018*k19[i] + a2019*k20[i]))
   end
-  f(k21, tmp, p, t + c20*dt)
+  f(k21, tmp, t + c20*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a2100*k1[i] + a2102*k3[i] + a2103*k4[i]) + (a2106*k7[i] + a2107*k8[i] + a2109*k10[i] + a2110*k11[i]) + (a2117*k18[i] + a2118*k19[i] + a2119*k20[i] + a2120*k21[i]))
   end
-  f(k22, tmp, p, t + c21*dt)
+  f(k22, tmp, t + c21*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a2200*k1[i] + a2201*k2[i] + a2204*k5[i]) + (a2206*k7[i] + a2220*k21[i] + a2221*k22[i]))
   end
-  f(k23, tmp, p, t + c22*dt)
+  f(k23, tmp, t + c22*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2300*k1[i] + a2302*k3[i] + a2322*k23[i])
   end
-  f(k24, tmp, p, t + c23*dt)
+  f(k24, tmp, t + c23*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*((a2400*k1[i] + a2401*k2[i] + a2402*k3[i]) + (a2404*k5[i] + a2406*k7[i] + a2407*k8[i] + a2408*k9[i]) + (a2409*k10[i] + a2410*k11[i] + a2411*k12[i] + a2412*k13[i]) + (a2413*k14[i] + a2414*k15[i] + a2415*k16[i] + a2416*k17[i]) + (a2417*k18[i] + a2418*k19[i] + a2419*k20[i] + a2420*k21[i]) + (a2421*k22[i] + a2422*k23[i] + a2423*k24[i]))
   end
-  f(k25, tmp, p, t + c24*dt)
+  f(k25, tmp, t + c24*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i] + dt*((b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i]) + (b7*k7[i] + b8*k8[i] + b10*k10[i] + b11*k11[i]) + (b13*k13[i] + b14*k14[i] + b15*k15[i] + b16*k16[i]) + (b17*k17[i] + b18*k18[i] + b19*k19[i] + b20*k20[i]) + (b21*k21[i] + b22*k22[i] + b23*k23[i]) + (b24*k24[i] + b25*k25[i]))
   end
@@ -438,12 +438,12 @@ end
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 1
 end
 
 function initialize!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
-  integrator.fsalfirst = f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -455,44 +455,44 @@ function initialize!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
 end
 
 @muladd function perform_step!(integrator, cache::Feagin14ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache
   k1  = integrator.fsalfirst
   a = dt*a0100
-  k2  = f(uprev  + a*k1, p, t + c1*dt)
-  k3  = f(uprev + dt*(a0200*k1 + a0201*k2), p, t + c2*dt)
-  k4  = f(uprev  + dt*(a0300*k1              + a0302*k3), p, t + c3*dt)
-  k5  = f(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4), p, t + c4*dt)
-  k6  = f(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5), p, t + c5*dt)
-  k7  = f(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6), p, t + c6*dt)
-  k8  = f(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7), p, t + c7*dt)
-  k9  = f(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8), p, t + c8*dt)
-  k10 = f(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9), p, t + c9*dt)
-  k11 = f(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10), p, t + c10*dt)
-  k12 = f(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11), p, t + c11*dt)
-  k13 = f(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12), p, t + c12*dt)
-  k14 = f(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13), p, t + c13*dt)
-  k15 = f(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14), p, t + c14*dt)
-  k16 = f(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15), p, t + c15*dt)
-  k17 = f(uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16), p, t + c16*dt)
-  k18 = f(uprev + dt*(a1700*k1                                                                                                                                                   + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17), p, t + c17*dt)
-  k19 = f(uprev + dt*(a1800*k1                                                                                                                                                   + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18), p, t + c18*dt)
-  k20 = f(uprev + dt*(a1900*k1                                                                                                                                                   + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19), p, t + c19*dt)
-  k21 = f(uprev + dt*(a2000*k1                                                                                                                                                   + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20), p, t + c20*dt)
-  k22 = f(uprev + dt*(a2100*k1                                                                                                                                                   + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21), p, t + c21*dt)
-  k23 = f(uprev + dt*(a2200*k1                                                                                                                                                   + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22), p, t + c22*dt)
-  k24 = f(uprev + dt*(a2300*k1                                                                                            + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23), p, t + c23*dt)
-  k25 = f(uprev + dt*(a2400*k1                                                                                            + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24), p, t + c24*dt)
-  k26 = f(uprev + dt*(a2500*k1                                                                                            + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25), p, t + c25*dt)
-  k27 = f(uprev + dt*(a2600*k1                                                     + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11               + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26), p, t + c26*dt)
-  k28 = f(uprev + dt*(a2700*k1                                                     + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10               + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27), p, t + c27*dt)
-  k29 = f(uprev + dt*(a2800*k1                                                     + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9               + a2810*k11 + a2811*k12               + a2813*k14 + a2814*k15 + a2815*k16                                                                                                   + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28), p, t + c28*dt)
-  k30 = f(uprev + dt*(a2900*k1                                        + a2904*k5 + a2905*k6 + a2906*k7                           + a2909*k10 + a2910*k11 + a2911*k12               + a2913*k14 + a2914*k15 + a2915*k16                                                                                                   + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29), p, t + c29*dt)
-  k31 = f(uprev + dt*(a3000*k1                           + a3003*k4 + a3004*k5 + a3005*k6              + a3007*k8              + a3009*k10 + a3010*k11                             + a3013*k14 + a3014*k15 + a3015*k16                                                                                                   + a3023*k24 + a3024*k25 + a3025*k26               + a3027*k28 + a3028*k29 + a3029*k30), p, t + c30*dt)
-  k32 = f(uprev + dt*(a3100*k1              + a3102*k3 + a3103*k4                           + a3106*k7 + a3107*k8              + a3109*k10 + a3110*k11                             + a3113*k14 + a3114*k15 + a3115*k16                                                                                                   + a3123*k24 + a3124*k25 + a3125*k26               + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31), p, t + c31*dt)
-  k33 = f(uprev + dt*(a3200*k1 + a3201*k2                           + a3204*k5              + a3206*k7                                                                                                                                                                                                                                                                                                                                 + a3230*k31 + a3231*k32), p, t + c32*dt)
-  k34 = f(uprev + dt*(a3300*k1              + a3302*k3                                                                                                                                                                                                                                                                                                                                                                                                                 + a3332*k33), p, t + c33*dt)
-  k35 = f(uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3              + a3404*k5              + a3406*k7 + a3407*k8              + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34), p, t + c34*dt)
+  k2  = f(uprev  + a*k1, t + c1*dt, integrator)
+  k3  = f(uprev + dt*(a0200*k1 + a0201*k2), t + c2*dt, integrator)
+  k4  = f(uprev  + dt*(a0300*k1              + a0302*k3), t + c3*dt, integrator)
+  k5  = f(uprev  + dt*(a0400*k1              + a0402*k3 + a0403*k4), t + c4*dt, integrator)
+  k6  = f(uprev  + dt*(a0500*k1                           + a0503*k4 + a0504*k5), t + c5*dt, integrator)
+  k7  = f(uprev  + dt*(a0600*k1                           + a0603*k4 + a0604*k5 + a0605*k6), t + c6*dt, integrator)
+  k8  = f(uprev  + dt*(a0700*k1                                        + a0704*k5 + a0705*k6 + a0706*k7), t + c7*dt, integrator)
+  k9  = f(uprev  + dt*(a0800*k1                                                     + a0805*k6 + a0806*k7 + a0807*k8), t + c8*dt, integrator)
+  k10 = f(uprev  + dt*(a0900*k1                                                     + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9), t + c9*dt, integrator)
+  k11 = f(uprev + dt*(a1000*k1                                                     + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10), t + c10*dt, integrator)
+  k12 = f(uprev + dt*(a1100*k1                                                     + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11), t + c11*dt, integrator)
+  k13 = f(uprev + dt*(a1200*k1                                                                                            + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12), t + c12*dt, integrator)
+  k14 = f(uprev + dt*(a1300*k1                                                                                            + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13), t + c13*dt, integrator)
+  k15 = f(uprev + dt*(a1400*k1                                                                                            + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14), t + c14*dt, integrator)
+  k16 = f(uprev + dt*(a1500*k1                                                                                            + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15), t + c15*dt, integrator)
+  k17 = f(uprev + dt*(a1600*k1                                                                                            + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16), t + c16*dt, integrator)
+  k18 = f(uprev + dt*(a1700*k1                                                                                                                                                   + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17), t + c17*dt, integrator)
+  k19 = f(uprev + dt*(a1800*k1                                                                                                                                                   + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18), t + c18*dt, integrator)
+  k20 = f(uprev + dt*(a1900*k1                                                                                                                                                   + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19), t + c19*dt, integrator)
+  k21 = f(uprev + dt*(a2000*k1                                                                                                                                                   + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20), t + c20*dt, integrator)
+  k22 = f(uprev + dt*(a2100*k1                                                                                                                                                   + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21), t + c21*dt, integrator)
+  k23 = f(uprev + dt*(a2200*k1                                                                                                                                                   + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22), t + c22*dt, integrator)
+  k24 = f(uprev + dt*(a2300*k1                                                                                            + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23), t + c23*dt, integrator)
+  k25 = f(uprev + dt*(a2400*k1                                                                                            + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24), t + c24*dt, integrator)
+  k26 = f(uprev + dt*(a2500*k1                                                                                            + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25), t + c25*dt, integrator)
+  k27 = f(uprev + dt*(a2600*k1                                                     + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11               + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26), t + c26*dt, integrator)
+  k28 = f(uprev + dt*(a2700*k1                                                     + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10               + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27), t + c27*dt, integrator)
+  k29 = f(uprev + dt*(a2800*k1                                                     + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9               + a2810*k11 + a2811*k12               + a2813*k14 + a2814*k15 + a2815*k16                                                                                                   + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28), t + c28*dt, integrator)
+  k30 = f(uprev + dt*(a2900*k1                                        + a2904*k5 + a2905*k6 + a2906*k7                           + a2909*k10 + a2910*k11 + a2911*k12               + a2913*k14 + a2914*k15 + a2915*k16                                                                                                   + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29), t + c29*dt, integrator)
+  k31 = f(uprev + dt*(a3000*k1                           + a3003*k4 + a3004*k5 + a3005*k6              + a3007*k8              + a3009*k10 + a3010*k11                             + a3013*k14 + a3014*k15 + a3015*k16                                                                                                   + a3023*k24 + a3024*k25 + a3025*k26               + a3027*k28 + a3028*k29 + a3029*k30), t + c30*dt, integrator)
+  k32 = f(uprev + dt*(a3100*k1              + a3102*k3 + a3103*k4                           + a3106*k7 + a3107*k8              + a3109*k10 + a3110*k11                             + a3113*k14 + a3114*k15 + a3115*k16                                                                                                   + a3123*k24 + a3124*k25 + a3125*k26               + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31), t + c31*dt, integrator)
+  k33 = f(uprev + dt*(a3200*k1 + a3201*k2                           + a3204*k5              + a3206*k7                                                                                                                                                                                                                                                                                                                                 + a3230*k31 + a3231*k32), t + c32*dt, integrator)
+  k34 = f(uprev + dt*(a3300*k1              + a3302*k3                                                                                                                                                                                                                                                                                                                                                                                                                 + a3332*k33), t + c33*dt, integrator)
+  k35 = f(uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3              + a3404*k5              + a3406*k7 + a3407*k8              + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34), t + c34*dt, integrator)
   integrator.destats.nf += 34
   u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
   if integrator.opts.adaptive
@@ -500,7 +500,7 @@ end
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  k = f(u, p, t+dt) # For the interpolation, needs k at the updated point
+  k = f(u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
   integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
@@ -515,240 +515,240 @@ function initialize!(integrator, cache::Feagin14Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 #=
 @muladd function perform_step!(integrator, cache::Feagin14Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k18,k19,k20,k21,k22,k23,k24,k25,k26,k27,k28,k29,k30,k31,k32,k33,k34,k35,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0100
   @.. tmp = uprev + a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev + dt*(a0200*k1 + a0201*k2)
-  f(k3, tmp, p, t + c2*dt )
+  f(k3, tmp, t + c2*dt , integrator)
   @.. tmp = uprev + dt*(a0300*k1 + a0302*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev + dt*(a0400*k1 + a0402*k3 + a0403*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev + dt*(a0500*k1 + a0503*k4 + a0504*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev + dt*(a0600*k1 + a0603*k4 + a0604*k5 + a0605*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev + dt*(a0700*k1 + a0704*k5 + a0705*k6 + a0706*k7)
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @.. tmp = uprev + dt*(a0800*k1 + a0805*k6 + a0806*k7 + a0807*k8)
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @.. tmp = uprev + dt*(a0900*k1 + a0905*k6 + a0906*k7 + a0907*k8 + a0908*k9)
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @.. tmp = uprev + dt*(a1000*k1 + a1005*k6 + a1006*k7 + a1007*k8 + a1008*k9 + a1009*k10)
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @.. tmp = uprev + dt*(a1100*k1 + a1105*k6 + a1106*k7 + a1107*k8 + a1108*k9 + a1109*k10 + a1110*k11)
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @.. tmp = uprev + dt*(a1200*k1 + a1208*k9 + a1209*k10 + a1210*k11 + a1211*k12)
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @.. tmp = uprev + dt*(a1300*k1 + a1308*k9 + a1309*k10 + a1310*k11 + a1311*k12 + a1312*k13)
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @.. tmp = uprev + dt*(a1400*k1 + a1408*k9 + a1409*k10 + a1410*k11 + a1411*k12 + a1412*k13 + a1413*k14)
-  f(k15, tmp, p, t + c14*dt)
+  f(k15, tmp, t + c14*dt, integrator)
   @.. tmp = uprev + dt*(a1500*k1 + a1508*k9 + a1509*k10 + a1510*k11 + a1511*k12 + a1512*k13 + a1513*k14 + a1514*k15)
-  f(k16, tmp, p, t + c15*dt)
+  f(k16, tmp, t + c15*dt, integrator)
   @.. tmp = uprev + dt*(a1600*k1 + a1608*k9 + a1609*k10 + a1610*k11 + a1611*k12 + a1612*k13 + a1613*k14 + a1614*k15 + a1615*k16)
-  f(k17, tmp, p, t + c16*dt)
+  f(k17, tmp, t + c16*dt, integrator)
   @.. tmp = uprev + dt*(a1700*k1 + a1712*k13 + a1713*k14 + a1714*k15 + a1715*k16 + a1716*k17)
-  f(k18, tmp, p, t + c17*dt)
+  f(k18, tmp, t + c17*dt, integrator)
   @.. tmp = uprev + dt*(a1800*k1 + a1812*k13 + a1813*k14 + a1814*k15 + a1815*k16 + a1816*k17 + a1817*k18)
-  f(k19, tmp, p, t + c18*dt)
+  f(k19, tmp, t + c18*dt, integrator)
   @.. tmp = uprev + dt*(a1900*k1 + a1912*k13 + a1913*k14 + a1914*k15 + a1915*k16 + a1916*k17 + a1917*k18 + a1918*k19)
-  f(k20, tmp, p, t + c19*dt)
+  f(k20, tmp, t + c19*dt, integrator)
   @.. tmp = uprev + dt*(a2000*k1 + a2012*k13 + a2013*k14 + a2014*k15 + a2015*k16 + a2016*k17 + a2017*k18 + a2018*k19 + a2019*k20)
-  f(k21, tmp, p, t + c20*dt)
+  f(k21, tmp, t + c20*dt, integrator)
   @.. tmp = uprev + dt*(a2100*k1 + a2112*k13 + a2113*k14 + a2114*k15 + a2115*k16 + a2116*k17 + a2117*k18 + a2118*k19 + a2119*k20 + a2120*k21)
-  f(k22, tmp, p, t + c21*dt)
+  f(k22, tmp, t + c21*dt, integrator)
   @.. tmp = uprev + dt*(a2200*k1 + a2212*k13 + a2213*k14 + a2214*k15 + a2215*k16 + a2216*k17 + a2217*k18 + a2218*k19 + a2219*k20 + a2220*k21 + a2221*k22)
-  f(k23, tmp, p, t + c22*dt)
+  f(k23, tmp, t + c22*dt, integrator)
   @.. tmp = uprev + dt*(a2300*k1 + a2308*k9 + a2309*k10 + a2310*k11 + a2311*k12 + a2312*k13 + a2313*k14 + a2314*k15 + a2315*k16 + a2316*k17 + a2317*k18 + a2318*k19 + a2319*k20 + a2320*k21 + a2321*k22 + a2322*k23)
-  f(k24, tmp, p, t + c23*dt)
+  f(k24, tmp, t + c23*dt, integrator)
   @.. tmp = uprev + dt*(a2400*k1 + a2408*k9 + a2409*k10 + a2410*k11 + a2411*k12 + a2412*k13 + a2413*k14 + a2414*k15 + a2415*k16 + a2416*k17 + a2417*k18 + a2418*k19 + a2419*k20 + a2420*k21 + a2421*k22 + a2422*k23 + a2423*k24)
-  f(k25, tmp, p, t + c24*dt)
+  f(k25, tmp, t + c24*dt, integrator)
   @.. tmp = uprev + dt*(a2500*k1 + a2508*k9 + a2509*k10 + a2510*k11 + a2511*k12 + a2512*k13 + a2513*k14 + a2514*k15 + a2515*k16 + a2516*k17 + a2517*k18 + a2518*k19 + a2519*k20 + a2520*k21 + a2521*k22 + a2522*k23 + a2523*k24 + a2524*k25)
-  f(k26, tmp, p, t + c25*dt)
+  f(k26, tmp, t + c25*dt, integrator)
   @.. tmp = uprev + dt*(a2600*k1 + a2605*k6 + a2606*k7 + a2607*k8 + a2608*k9 + a2609*k10 + a2610*k11 + a2612*k13 + a2613*k14 + a2614*k15 + a2615*k16 + a2616*k17 + a2617*k18 + a2618*k19 + a2619*k20 + a2620*k21 + a2621*k22 + a2622*k23 + a2623*k24 + a2624*k25 + a2625*k26)
-  f(k27, tmp, p, t + c26*dt)
+  f(k27, tmp, t + c26*dt, integrator)
   @.. tmp = uprev + dt*(a2700*k1 + a2705*k6 + a2706*k7 + a2707*k8 + a2708*k9 + a2709*k10 + a2711*k12 + a2712*k13 + a2713*k14 + a2714*k15 + a2715*k16 + a2716*k17 + a2717*k18 + a2718*k19 + a2719*k20 + a2720*k21 + a2721*k22 + a2722*k23 + a2723*k24 + a2724*k25 + a2725*k26 + a2726*k27)
-  f(k28, tmp, p, t + c27*dt)
+  f(k28, tmp, t + c27*dt, integrator)
   @.. tmp = uprev + dt*(a2800*k1 + a2805*k6 + a2806*k7 + a2807*k8 + a2808*k9 + a2810*k11 + a2811*k12 + a2813*k14 + a2814*k15 + a2815*k16 + a2823*k24 + a2824*k25 + a2825*k26 + a2826*k27 + a2827*k28)
-  f(k29, tmp, p, t + c28*dt)
+  f(k29, tmp, t + c28*dt, integrator)
   @.. tmp = uprev + dt*(a2900*k1 + a2904*k5 + a2905*k6 + a2906*k7 + a2909*k10 + a2910*k11 + a2911*k12 + a2913*k14 + a2914*k15 + a2915*k16 + a2923*k24 + a2924*k25 + a2925*k26 + a2926*k27 + a2927*k28 + a2928*k29)
-  f(k30, tmp, p, t + c29*dt)
+  f(k30, tmp, t + c29*dt, integrator)
   @.. tmp = uprev + dt*(a3000*k1 + a3003*k4 + a3004*k5 + a3005*k6 + a3007*k8 + a3009*k10 + a3010*k11 + a3013*k14 + a3014*k15 + a3015*k16 + a3023*k24 + a3024*k25 + a3025*k26 + a3027*k28 + a3028*k29 + a3029*k30)
-  f(k31, tmp, p, t + c30*dt)
+  f(k31, tmp, t + c30*dt, integrator)
   @.. tmp = uprev + dt*(a3100*k1 + a3102*k3 + a3103*k4 + a3106*k7 + a3107*k8 + a3109*k10 + a3110*k11 + a3113*k14 + a3114*k15 + a3115*k16 + a3123*k24 + a3124*k25 + a3125*k26 + a3127*k28 + a3128*k29 + a3129*k30 + a3130*k31)
-  f(k32, tmp, p, t + c31*dt)
+  f(k32, tmp, t + c31*dt, integrator)
   @.. tmp = uprev + dt*(a3200*k1 + a3201*k2 + a3204*k5 + a3206*k7 + a3230*k31 + a3231*k32)
-  f(k33, tmp, p, t + c32*dt)
+  f(k33, tmp, t + c32*dt, integrator)
   @.. tmp = uprev + dt*(a3300*k1 + a3302*k3 + a3332*k33)
-  f(k34, tmp, p, t + c33*dt)
+  f(k34, tmp, t + c33*dt, integrator)
   @.. tmp = uprev + dt*(a3400*k1 + a3401*k2 + a3402*k3 + a3404*k5 + a3406*k7 + a3407*k8 + a3409*k10 + a3410*k11 + a3411*k12 + a3412*k13 + a3413*k14 + a3414*k15 + a3415*k16 + a3416*k17 + a3417*k18 + a3418*k19 + a3419*k20 + a3420*k21 + a3421*k22 + a3422*k23 + a3423*k24 + a3424*k25 + a3425*k26 + a3426*k27 + a3427*k28 + a3428*k29 + a3429*k30 + a3430*k31 + a3431*k32 + a3432*k33 + a3433*k34)
-  f(k35, tmp, p, t + c34*dt)
+  f(k35, tmp, t + c34*dt, integrator)
   @.. u = uprev + dt*(b1*k1 + b2*k2 + b3*k3 + b5*k5 + b7*k7 + b8*k8 + b10*k10 + b11*k11 + b12*k12 + b14*k14 + b15*k15 + b16*k16 + b18*k18 + b19*k19 + b20*k20 + b21*k21 + b22*k22 + b23*k23 + b24*k24 + b25*k25 + b26*k26 + b27*k27 + b28*k28 + b29*k29 + b30*k30 + b31*k31 + b32*k32 + b33*k33 + b34*k34 + b35*k35)
   if integrator.opts.adaptive
     @.. tmp = dt*(k2 - k34) * adaptiveConst
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(integrator.fsallast,u,p,t+dt) # For the interpolation, needs k at the updated point
+  f(integrator.fsallast, u, t+dt, integrator) # For the interpolation, needs k at the updated point
 end
 =#
 
 @muladd function perform_step!(integrator, cache::Feagin14Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack adaptiveConst,a0100,a0200,a0201,a0300,a0302,a0400,a0402,a0403,a0500,a0503,a0504,a0600,a0603,a0604,a0605,a0700,a0704,a0705,a0706,a0800,a0805,a0806,a0807,a0900,a0905,a0906,a0907,a0908,a1000,a1005,a1006,a1007,a1008,a1009,a1100,a1105,a1106,a1107,a1108,a1109,a1110,a1200,a1208,a1209,a1210,a1211,a1300,a1308,a1309,a1310,a1311,a1312,a1400,a1408,a1409,a1410,a1411,a1412,a1413,a1500,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1600,a1608,a1609,a1610,a1611,a1612,a1613,a1614,a1615,a1700,a1712,a1713,a1714,a1715,a1716,a1800,a1812,a1813,a1814,a1815,a1816,a1817,a1900,a1912,a1913,a1914,a1915,a1916,a1917,a1918,a2000,a2012,a2013,a2014,a2015,a2016,a2017,a2018,a2019,a2100,a2112,a2113,a2114,a2115,a2116,a2117,a2118,a2119,a2120,a2200,a2212,a2213,a2214,a2215,a2216,a2217,a2218,a2219,a2220,a2221,a2300,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2316,a2317,a2318,a2319,a2320,a2321,a2322,a2400,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2416,a2417,a2418,a2419,a2420,a2421,a2422,a2423,a2500,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2516,a2517,a2518,a2519,a2520,a2521,a2522,a2523,a2524,a2600,a2605,a2606,a2607,a2608,a2609,a2610,a2612,a2613,a2614,a2615,a2616,a2617,a2618,a2619,a2620,a2621,a2622,a2623,a2624,a2625,a2700,a2705,a2706,a2707,a2708,a2709,a2711,a2712,a2713,a2714,a2715,a2716,a2717,a2718,a2719,a2720,a2721,a2722,a2723,a2724,a2725,a2726,a2800,a2805,a2806,a2807,a2808,a2810,a2811,a2813,a2814,a2815,a2823,a2824,a2825,a2826,a2827,a2900,a2904,a2905,a2906,a2909,a2910,a2911,a2913,a2914,a2915,a2923,a2924,a2925,a2926,a2927,a2928,a3000,a3003,a3004,a3005,a3007,a3009,a3010,a3013,a3014,a3015,a3023,a3024,a3025,a3027,a3028,a3029,a3100,a3102,a3103,a3106,a3107,a3109,a3110,a3113,a3114,a3115,a3123,a3124,a3125,a3127,a3128,a3129,a3130,a3200,a3201,a3204,a3206,a3230,a3231,a3300,a3302,a3332,a3400,a3401,a3402,a3404,a3406,a3407,a3409,a3410,a3411,a3412,a3413,a3414,a3415,a3416,a3417,a3418,a3419,a3420,a3421,a3422,a3423,a3424,a3425,a3426,a3427,a3428,a3429,a3430,a3431,a3432,a3433,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31,b32,b33,b34,b35 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k18,k19,k20,k21,k22,k23,k24,k25,k26,k27,k28,k29,k30,k31,k32,k33,k34,k35,tmp,atmp,uprev,k = cache
   k1 = cache.fsalfirst
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0100
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + a*k1[i]
   end
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0200*k1[i] + a0201*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt )
+  f(k3, tmp, t + c2*dt , integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0300*k1[i] + a0302*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0400*k1[i] + a0402*k3[i] + a0403*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0500*k1[i] + a0503*k4[i] + a0504*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0600*k1[i] + a0603*k4[i] + a0604*k5[i] + a0605*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0700*k1[i] + a0704*k5[i] + a0705*k6[i] + a0706*k7[i])
   end
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0800*k1[i] + a0805*k6[i] + a0806*k7[i] + a0807*k8[i])
   end
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a0900*k1[i] + a0905*k6[i] + a0906*k7[i] + a0907*k8[i] + a0908*k9[i])
   end
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1000*k1[i] + a1005*k6[i] + a1006*k7[i] + a1007*k8[i] + a1008*k9[i] + a1009*k10[i])
   end
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1100*k1[i] + a1105*k6[i] + a1106*k7[i] + a1107*k8[i] + a1108*k9[i] + a1109*k10[i] + a1110*k11[i])
   end
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1200*k1[i] + a1208*k9[i] + a1209*k10[i] + a1210*k11[i] + a1211*k12[i])
   end
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1300*k1[i] + a1308*k9[i] + a1309*k10[i] + a1310*k11[i] + a1311*k12[i] + a1312*k13[i])
   end
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1400*k1[i] + a1408*k9[i] + a1409*k10[i] + a1410*k11[i] + a1411*k12[i] + a1412*k13[i] + a1413*k14[i])
   end
-  f(k15, tmp, p, t + c14*dt)
+  f(k15, tmp, t + c14*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1500*k1[i] + a1508*k9[i] + a1509*k10[i] + a1510*k11[i] + a1511*k12[i] + a1512*k13[i] + a1513*k14[i] + a1514*k15[i])
   end
-  f(k16, tmp, p, t + c15*dt)
+  f(k16, tmp, t + c15*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1600*k1[i] + a1608*k9[i] + a1609*k10[i] + a1610*k11[i] + a1611*k12[i] + a1612*k13[i] + a1613*k14[i] + a1614*k15[i] + a1615*k16[i])
   end
-  f(k17, tmp, p, t + c16*dt)
+  f(k17, tmp, t + c16*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1700*k1[i] + a1712*k13[i] + a1713*k14[i] + a1714*k15[i] + a1715*k16[i] + a1716*k17[i])
   end
-  f(k18, tmp, p, t + c17*dt)
+  f(k18, tmp, t + c17*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1800*k1[i] + a1812*k13[i] + a1813*k14[i] + a1814*k15[i] + a1815*k16[i] + a1816*k17[i] + a1817*k18[i])
   end
-  f(k19, tmp, p, t + c18*dt)
+  f(k19, tmp, t + c18*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a1900*k1[i] + a1912*k13[i] + a1913*k14[i] + a1914*k15[i] + a1915*k16[i] + a1916*k17[i] + a1917*k18[i] + a1918*k19[i])
   end
-  f(k20, tmp, p, t + c19*dt)
+  f(k20, tmp, t + c19*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2000*k1[i] + a2012*k13[i] + a2013*k14[i] + a2014*k15[i] + a2015*k16[i] + a2016*k17[i] + a2017*k18[i] + a2018*k19[i] + a2019*k20[i])
   end
-  f(k21, tmp, p, t + c20*dt)
+  f(k21, tmp, t + c20*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2100*k1[i] + a2112*k13[i] + a2113*k14[i] + a2114*k15[i] + a2115*k16[i] + a2116*k17[i] + a2117*k18[i] + a2118*k19[i] + a2119*k20[i] + a2120*k21[i])
   end
-  f(k22, tmp, p, t + c21*dt)
+  f(k22, tmp, t + c21*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2200*k1[i] + a2212*k13[i] + a2213*k14[i] + a2214*k15[i] + a2215*k16[i] + a2216*k17[i] + a2217*k18[i] + a2218*k19[i] + a2219*k20[i] + a2220*k21[i] + a2221*k22[i])
   end
-  f(k23, tmp, p, t + c22*dt)
+  f(k23, tmp, t + c22*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2300*k1[i] + a2308*k9[i] + a2309*k10[i] + a2310*k11[i] + a2311*k12[i] + a2312*k13[i] + a2313*k14[i] + a2314*k15[i] + a2315*k16[i] + a2316*k17[i] + a2317*k18[i] + a2318*k19[i] + a2319*k20[i] + a2320*k21[i] + a2321*k22[i] + a2322*k23[i])
   end
-  f(k24, tmp, p, t + c23*dt)
+  f(k24, tmp, t + c23*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2400*k1[i] + a2408*k9[i] + a2409*k10[i] + a2410*k11[i] + a2411*k12[i] + a2412*k13[i] + a2413*k14[i] + a2414*k15[i] + a2415*k16[i] + a2416*k17[i] + a2417*k18[i] + a2418*k19[i] + a2419*k20[i] + a2420*k21[i] + a2421*k22[i] + a2422*k23[i] + a2423*k24[i])
   end
-  f(k25, tmp, p, t + c24*dt)
+  f(k25, tmp, t + c24*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2500*k1[i] + a2508*k9[i] + a2509*k10[i] + a2510*k11[i] + a2511*k12[i] + a2512*k13[i] + a2513*k14[i] + a2514*k15[i] + a2515*k16[i] + a2516*k17[i] + a2517*k18[i] + a2518*k19[i] + a2519*k20[i] + a2520*k21[i] + a2521*k22[i] + a2522*k23[i] + a2523*k24[i] + a2524*k25[i])
   end
-  f(k26, tmp, p, t + c25*dt)
+  f(k26, tmp, t + c25*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2600*k1[i] + a2605*k6[i] + a2606*k7[i] + a2607*k8[i] + a2608*k9[i] + a2609*k10[i] + a2610*k11[i] + a2612*k13[i] + a2613*k14[i] + a2614*k15[i] + a2615*k16[i] + a2616*k17[i] + a2617*k18[i] + a2618*k19[i] + a2619*k20[i] + a2620*k21[i] + a2621*k22[i] + a2622*k23[i] + a2623*k24[i] + a2624*k25[i] + a2625*k26[i])
   end
-  f(k27, tmp, p, t + c26*dt)
+  f(k27, tmp, t + c26*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2700*k1[i] + a2705*k6[i] + a2706*k7[i] + a2707*k8[i] + a2708*k9[i] + a2709*k10[i] + a2711*k12[i] + a2712*k13[i] + a2713*k14[i] + a2714*k15[i] + a2715*k16[i] + a2716*k17[i] + a2717*k18[i] + a2718*k19[i] + a2719*k20[i] + a2720*k21[i] + a2721*k22[i] + a2722*k23[i] + a2723*k24[i] + a2724*k25[i] + a2725*k26[i] + a2726*k27[i])
   end
-  f(k28, tmp, p, t + c27*dt)
+  f(k28, tmp, t + c27*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2800*k1[i] + a2805*k6[i] + a2806*k7[i] + a2807*k8[i] + a2808*k9[i] + a2810*k11[i] + a2811*k12[i] + a2813*k14[i] + a2814*k15[i] + a2815*k16[i] + a2823*k24[i] + a2824*k25[i] + a2825*k26[i] + a2826*k27[i] + a2827*k28[i])
   end
-  f(k29, tmp, p, t + c28*dt)
+  f(k29, tmp, t + c28*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a2900*k1[i] + a2904*k5[i] + a2905*k6[i] + a2906*k7[i] + a2909*k10[i] + a2910*k11[i] + a2911*k12[i] + a2913*k14[i] + a2914*k15[i] + a2915*k16[i] + a2923*k24[i] + a2924*k25[i] + a2925*k26[i] + a2926*k27[i] + a2927*k28[i] + a2928*k29[i])
   end
-  f(k30, tmp, p, t + c29*dt)
+  f(k30, tmp, t + c29*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a3000*k1[i] + a3003*k4[i] + a3004*k5[i] + a3005*k6[i] + a3007*k8[i] + a3009*k10[i] + a3010*k11[i] + a3013*k14[i] + a3014*k15[i] + a3015*k16[i] + a3023*k24[i] + a3024*k25[i] + a3025*k26[i] + a3027*k28[i] + a3028*k29[i] + a3029*k30[i])
   end
-  f(k31, tmp, p, t + c30*dt)
+  f(k31, tmp, t + c30*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a3100*k1[i] + a3102*k3[i] + a3103*k4[i] + a3106*k7[i] + a3107*k8[i] + a3109*k10[i] + a3110*k11[i] + a3113*k14[i] + a3114*k15[i] + a3115*k16[i] + a3123*k24[i] + a3124*k25[i] + a3125*k26[i] + a3127*k28[i] + a3128*k29[i] + a3129*k30[i] + a3130*k31[i])
   end
-  f(k32, tmp, p, t + c31*dt)
+  f(k32, tmp, t + c31*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a3200*k1[i] + a3201*k2[i] + a3204*k5[i] + a3206*k7[i] + a3230*k31[i] + a3231*k32[i])
   end
-  f(k33, tmp, p, t + c32*dt)
+  f(k33, tmp, t + c32*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a3300*k1[i] + a3302*k3[i] + a3332*k33[i])
   end
-  f(k34, tmp, p, t + c33*dt)
+  f(k34, tmp, t + c33*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i] + dt*(a3400*k1[i] + a3401*k2[i] + a3402*k3[i] + a3404*k5[i] + a3406*k7[i] + a3407*k8[i] + a3409*k10[i] + a3410*k11[i] + a3411*k12[i] + a3412*k13[i] + a3413*k14[i] + a3414*k15[i] + a3415*k16[i] + a3416*k17[i] + a3417*k18[i] + a3418*k19[i] + a3419*k20[i] + a3420*k21[i] + a3421*k22[i] + a3422*k23[i] + a3423*k24[i] + a3424*k25[i] + a3425*k26[i] + a3426*k27[i] + a3427*k28[i] + a3428*k29[i] + a3429*k30[i] + a3430*k31[i] + a3431*k32[i] + a3432*k33[i] + a3433*k34[i])
   end
-  f(k35, tmp, p, t + c34*dt)
+  f(k35, tmp, t + c34*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i] + dt*(b1*k1[i] + b2*k2[i] + b3*k3[i] + b5*k5[i] + b7*k7[i] + b8*k8[i] + b10*k10[i] + b11*k11[i] + b12*k12[i] + b14*k14[i] + b15*k15[i] + b16*k16[i] + b18*k18[i] + b19*k19[i] + b20*k20[i] + b21*k21[i] + b22*k22[i] + b23*k23[i] + b24*k24[i] + b25*k25[i] + b26*k26[i] + b27*k27[i] + b28*k28[i] + b29*k29[i] + b30*k30[i] + b31*k31[i] + b32*k32[i] + b33*k33[i] + b34*k34[i] + b35*k35[i])
   end
@@ -760,6 +760,6 @@ end
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(integrator.fsallast,u,p,t+dt) # For the interpolation, needs k at the updated point
+  f(integrator.fsallast, u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
 end

--- a/src/perform_step/fixed_timestep_perform_step.jl
+++ b/src/perform_step/fixed_timestep_perform_step.jl
@@ -4,14 +4,14 @@ function initialize!(integrator,cache::FunctionMapConstantCache)
 end
 
 function perform_step!(integrator,cache::FunctionMapConstantCache,repeat_step=false)
-  @unpack uprev,dt,t,f,p = integrator
+  @unpack uprev,dt,t,f = integrator
   if integrator.f != DiffEqBase.DISCRETE_OUTOFPLACE_DEFAULT
     if FunctionMap_scale_by_time(integrator.alg)
-      tmp = f(uprev, p, t + dt)
+      tmp = f(uprev, t + dt, integrator)
       integrator.destats.nf += 1
       @muladd integrator.u = @.. uprev + dt * tmp
     else
-      integrator.u = f(uprev, p, t + dt)
+      integrator.u = f(uprev, t + dt, integrator)
       integrator.destats.nf += 1
     end
   end
@@ -23,14 +23,14 @@ function initialize!(integrator,cache::FunctionMapCache)
 end
 
 function perform_step!(integrator,cache::FunctionMapCache,repeat_step=false)
-  @unpack u,uprev,dt,t,f,p = integrator
+  @unpack u,uprev,dt,t,f = integrator
   @unpack tmp = cache
   if integrator.f != DiffEqBase.DISCRETE_INPLACE_DEFAULT
     if FunctionMap_scale_by_time(integrator.alg)
-      f(tmp, uprev, p, t+dt)
+      f(tmp, uprev, t+dt, integrator)
       @muladd @.. u = uprev + dt*tmp
     else
-      f(u,uprev,p,t)
+      f(u, uprev, t, integrator)
     end
     integrator.destats.nf += 1
     if typeof(u) <: DEDataArray # Needs to get the fields, since updated uprev
@@ -42,7 +42,7 @@ end
 function initialize!(integrator,cache::EulerConstantCache)
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -52,9 +52,9 @@ function initialize!(integrator,cache::EulerConstantCache)
 end
 
 function perform_step!(integrator,cache::EulerConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,f,p = integrator
+  @unpack t,dt,uprev,f = integrator
   @muladd u = @.. uprev + dt*integrator.fsalfirst
-  k = f(u, p, t+dt) # For the interpolation, needs k at the updated point
+  k = f(u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
   integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
@@ -70,21 +70,21 @@ function initialize!(integrator,cache::EulerCache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
 end
 
 function perform_step!(integrator,cache::EulerCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @muladd @.. u = uprev + dt*integrator.fsalfirst
-  f(integrator.fsallast,u,p,t+dt) # For the interpolation, needs k at the updated point
+  f(integrator.fsallast, u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
 end
 
 function initialize!(integrator,cache::Union{HeunConstantCache,RalstonConstantCache})
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -94,7 +94,7 @@ function initialize!(integrator,cache::Union{HeunConstantCache,RalstonConstantCa
 end
 
 @muladd function perform_step!(integrator,cache::Union{HeunConstantCache,RalstonConstantCache},repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,fsalfirst = integrator
+  @unpack t,dt,uprev,u,f,fsalfirst = integrator
 
   # precalculations
   if typeof(cache) <: HeunConstantCache
@@ -107,7 +107,7 @@ end
   end
 
   tmp = @.. uprev + a₁ * fsalfirst
-  k2 = f(tmp, p, t + a₁)
+  k2 = f(tmp, t + a₁, integrator)
   integrator.destats.nf += 1
 
   if typeof(cache) <: HeunConstantCache
@@ -126,7 +126,7 @@ end
       atmp = calculate_residuals(tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
       integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  k = f(u, p, t+dt)
+  k = f(u, t+dt, integrator)
   integrator.destats.nf += 1
   integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
@@ -142,12 +142,12 @@ function initialize!(integrator,cache::Union{HeunCache,RalstonCache})
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # For the interpolation, needs k at the updated point
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::Union{HeunCache,RalstonCache},repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack fsalfirst,k,tmp,atmp = cache
 
   # precalculations
@@ -161,7 +161,7 @@ end
   end
 
   @.. tmp = uprev + a₁ * fsalfirst
-  f(k, tmp, p, t + a₁)
+  f(k, tmp, t + a₁, integrator)
   integrator.destats.nf += 1
 
   if typeof(cache) <: HeunCache
@@ -181,12 +181,12 @@ end
                            integrator.opts.reltol, integrator.opts.internalnorm, t)
       integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(integrator.fsallast,u,p,t+dt) # For the interpolation, needs k at the updated point
+  f(integrator.fsallast, u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
 end
 
 function initialize!(integrator,cache::MidpointConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -198,13 +198,13 @@ function initialize!(integrator,cache::MidpointConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::MidpointConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   halfdt = dt/2
   tmp = @.. uprev + halfdt * integrator.fsalfirst
-  k = f(tmp, p, t+halfdt)
+  k = f(tmp, t+halfdt, integrator)
   integrator.destats.nf += 1
   u = @.. uprev + dt * k
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 1
   if integrator.opts.adaptive
       utilde = @.. dt * (integrator.fsalfirst - k)
@@ -225,16 +225,16 @@ function initialize!(integrator,cache::MidpointCache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::MidpointCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack tmp,k,fsalfirst,atmp = cache
   halfdt = dt/2
   @.. tmp = uprev + halfdt*fsalfirst
-  f(k, tmp, p, t+halfdt)
+  f(k, tmp, t+halfdt, integrator)
   integrator.destats.nf += 1
   @.. u = uprev + dt*k
   if integrator.opts.adaptive
@@ -243,12 +243,12 @@ end
                            integrator.opts.reltol,integrator.opts.internalnorm,t)
       integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 1
 end
 
 function initialize!(integrator,cache::RK4ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -260,15 +260,15 @@ function initialize!(integrator,cache::RK4ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::RK4ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   halfdt = dt/2
   k₁ =integrator.fsalfirst
   ttmp = t+halfdt
-  k₂ = f(uprev + halfdt*k₁, p, ttmp)
-  k₃ = f(uprev + halfdt*k₂, p, ttmp)
-  k₄ = f(uprev + dt*k₃, p, t+dt)
+  k₂ = f(uprev + halfdt*k₁, ttmp, integrator)
+  k₃ = f(uprev + halfdt*k₂, ttmp, integrator)
+  k₄ = f(uprev + dt*k₃, t+dt, integrator)
   u = uprev + (dt/6)*(2*(k₂ + k₃) + (k₁+k₄))
-  integrator.fsallast = f(u, p, t+dt)
+  integrator.fsallast = f(u, t+dt, integrator)
   integrator.destats.nf += 4
   if integrator.opts.adaptive
       # Shampine Solving ODEs and DDEs with Residual Control Estimate
@@ -281,9 +281,9 @@ end
                 σ₁*(3*dt*k₁ + 3*dt*k₅ + 6*uprev - 6*u) + 6*u)/dt
       pprime2 = k₁ + σ₂*(-4*dt*k₁ - 2*dt*k₅ - 6*uprev +
                 σ₂*(3*dt*k₁ + 3*dt*k₅ + 6*uprev - 6*u) + 6*u)/dt
-      e1 = integrator.opts.internalnorm(calculate_residuals(dt*(f(p1,p,t+σ₁*dt) - pprime1), uprev, u, integrator.opts.abstol,
+      e1 = integrator.opts.internalnorm(calculate_residuals(dt*(f(p1, t+σ₁*dt, integrator) - pprime1), uprev, u, integrator.opts.abstol,
       integrator.opts.reltol,integrator.opts.internalnorm,t),t)
-      e2 = integrator.opts.internalnorm(calculate_residuals(dt*(f(p2,p,t+σ₂*dt) - pprime2), uprev, u, integrator.opts.abstol, integrator.opts.reltol,
+      e2 = integrator.opts.internalnorm(calculate_residuals(dt*(f(p2, t+σ₂*dt, integrator) - pprime2), uprev, u, integrator.opts.abstol, integrator.opts.reltol,
       integrator.opts.internalnorm,t),t)
       integrator.destats.nf += 2
       integrator.EEst = 2.1342*max(e1,e2)
@@ -301,24 +301,24 @@ function initialize!(integrator,cache::RK4Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # pre-start FSAL
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # pre-start FSAL
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::RK4Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack tmp,fsalfirst,k₂,k₃,k₄,k,atmp = cache
   k₁ = fsalfirst
   halfdt = dt/2
   ttmp = t+halfdt
   @.. tmp = uprev + halfdt*k₁
-  f(k₂,tmp,p,ttmp)
+  f(k₂, tmp, ttmp, integrator)
   @.. tmp = uprev + halfdt*k₂
-  f(k₃,tmp,p,ttmp)
+  f(k₃, tmp, ttmp, integrator)
   @.. tmp = uprev + dt*k₃
-  f(k₄,tmp,p,t+dt)
+  f(k₄, tmp, t+dt, integrator)
   @.. u = uprev + (dt/6)*(2*(k₂ + k₃) + (k₁ + k₄))
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 4
   if integrator.opts.adaptive
       # Shampine Solving ODEs and DDEs with Residual Control Estimate
@@ -330,7 +330,7 @@ end
           @inbounds pprime[i] = k₁[i] + σ₁*(-4*dt*k₁[i] - 2*dt*k₅[i] - 6*uprev[i] +
                     σ₁*(3*dt*k₁[i] + 3*dt*k₅[i] + 6*uprev[i] - 6*u[i]) + 6*u[i])/dt
       end
-      f(_p,tmp,p,t+σ₁*dt)
+      f(_p, tmp, t+σ₁*dt, integrator)
       calculate_residuals!(atmp, dt*(_p - pprime), uprev, u, integrator.opts.abstol,
                            integrator.opts.reltol,integrator.opts.internalnorm,t)
       e1 = integrator.opts.internalnorm(atmp,t)
@@ -339,7 +339,7 @@ end
         @inbounds pprime[i] = k₁[i] + σ₂*(-4*dt*k₁[i] - 2*dt*k₅[i] - 6*uprev[i] +
                   σ₂*(3*dt*k₁[i] + 3*dt*k₅[i] + 6*uprev[i] - 6*u[i]) + 6*u[i])/dt
       end
-      f(_p,tmp,p,t+σ₂*dt)
+      f(_p, tmp, t+σ₂*dt, integrator)
       calculate_residuals!(atmp, dt*(_p - pprime), uprev, u, integrator.opts.abstol,
                            integrator.opts.reltol,integrator.opts.internalnorm,t)
       e2 = integrator.opts.internalnorm(atmp,t)
@@ -349,7 +349,7 @@ end
 end
 
 function initialize!(integrator,cache::RK46NLConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -360,29 +360,29 @@ function initialize!(integrator,cache::RK46NLConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::RK46NLConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α2,α3,α4,α5,α6,β1,β2,β3,β4,β5,β6,c2,c3,c4,c5,c6 = cache
 
   # u1
   tmp = dt*integrator.fsalfirst
   u   = uprev + β1*tmp
   # u2
-  tmp = α2*tmp + dt*f(u, p, t+c2*dt)
+  tmp = α2*tmp + dt*f(u, t+c2*dt, integrator)
   u   = u + β2*tmp
   # u3
-  tmp = α3*tmp + dt*f(u, p, t+c3*dt)
+  tmp = α3*tmp + dt*f(u, t+c3*dt, integrator)
   u   = u + β3*tmp
   # u4
-  tmp = α4*tmp + dt*f(u, p, t+c4*dt)
+  tmp = α4*tmp + dt*f(u, t+c4*dt, integrator)
   u   = u + β4*tmp
   # u5 = u
-  tmp = α5*tmp + dt*f(u, p, t+c5*dt)
+  tmp = α5*tmp + dt*f(u, t+c5*dt, integrator)
   u   = u + β5*tmp
   # u6
-  tmp = α6*tmp + dt*f(u, p, t+c6*dt)
+  tmp = α6*tmp + dt*f(u, t+c6*dt, integrator)
   u = u + β6*tmp
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 6
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -395,12 +395,12 @@ function initialize!(integrator,cache::RK46NLCache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::RK46NLCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,tmp = cache
   @unpack α2,α3,α4,α5,α6,β1,β2,β3,β4,β5,β6,c2,c3,c4,c5,c6 = cache.tab
 
@@ -408,34 +408,34 @@ end
   @.. tmp = dt*fsalfirst
   @.. u   = uprev + β1*tmp
   # u2
-  f( k,  u, p, t+c2*dt)
+  f( k, u, t+c2*dt, integrator)
   @.. tmp = α2*tmp + dt*k
   @.. u   = u + β2*tmp
   # u3
-  f( k,  u, p, t+c3*dt)
+  f( k, u, t+c3*dt, integrator)
   @.. tmp = α3*tmp + dt*k
   @.. u   = u + β3*tmp
   # u4
-  f( k,  u, p, t+c4*dt)
+  f( k, u, t+c4*dt, integrator)
   @.. tmp = α4*tmp + dt*k
   @.. u   = u + β4*tmp
   # u5 = u
-  f( k,  u, p, t+c5*dt)
+  f( k, u, t+c5*dt, integrator)
   @.. tmp = α5*tmp + dt*k
   @.. u   = u + β5*tmp
 
-  f( k,  u, p, t+c6*dt)
+  f( k, u, t+c6*dt, integrator)
   @.. tmp = α6*tmp + dt*k
   @.. u   = u + β6*tmp
 
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
   integrator.destats.nf += 6
 end
 
 function initialize!(integrator, cache::Anas5ConstantCache)
   integrator.kshortsize = 7
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -448,7 +448,7 @@ function initialize!(integrator, cache::Anas5ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Anas5ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,c2,c3,c4,c5,c6,b1,b3,b4,b5,b6 = cache
   ## Note that c1 and b2 were 0.
   w = integrator.alg.w
@@ -459,13 +459,13 @@ end
   a63 += (189//100)*a65
   a64 += (-459//200)*a65
   k1 = integrator.fsalfirst
-  k2 = f(uprev+dt*a21*k1, p, t+c2*dt)
-  k3 = f(uprev+dt*(a31*k1+a32*k2), p, t+c3*dt)
-  k4 = f(uprev+dt*(a41*k1+a42*k2+2*k3), p, t+c4*dt)
-  k5 = f(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4), p, t+c5*dt)
-  k6 = f(uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5), p, t+c6*dt)
+  k2 = f(uprev+dt*a21*k1, t+c2*dt, integrator)
+  k3 = f(uprev+dt*(a31*k1+a32*k2), t+c3*dt, integrator)
+  k4 = f(uprev+dt*(a41*k1+a42*k2+2*k3), t+c4*dt, integrator)
+  k5 = f(uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4), t+c5*dt, integrator)
+  k6 = f(uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5), t+c6*dt, integrator)
   u = uprev+dt*(b1*k1+b3*k3+b4*k4+b5*k5+b6*k6)
-  k7 = f(u, p, t+dt); integrator.fsallast = k7
+  k7 = f(u, t+dt, integrator); integrator.fsallast = k7
   integrator.destats.nf += 6
   integrator.k[1]=k1; integrator.k[2]=k2; integrator.k[3]=k3; integrator.k[4]=k4
   integrator.k[5]=k5; integrator.k[6]=k6; integrator.k[7]=k7;
@@ -480,12 +480,12 @@ function initialize!(integrator, cache::Anas5Cache)
   integrator.k[5]=cache.k5; integrator.k[6]=cache.k6;
   integrator.k[7]=cache.k7;
   integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k7  # setup pointers
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::Anas5Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,c2,c3,c4,c5,c6,b1,b3,b4,b5,b6 = cache.tab
@@ -499,26 +499,26 @@ end
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a21*k1[i]
   end
-  f(k2, tmp, p, t+c2*dt)
+  f(k2, tmp, t+c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(k3, tmp, p, t+c3*dt)
+  f(k3, tmp, t+c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a42*k2[i]+2*k3[i])
   end
-  f(k4, tmp, p, t+c4*dt)
+  f(k4, tmp, t+c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
   end
-  f(k5, tmp, p, t+c5*dt)
+  f(k5, tmp, t+c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
-  f(k6, tmp, p, t+c6*dt)
+  f(k6, tmp, t+c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i]+dt*(b1*k1[i]+b3*k3[i]+b4*k4[i]+b5*k5[i]+b6*k6[i])
   end
-  f(k7, u, p, t+dt)
+  f(k7, u, t+dt, integrator)
   integrator.destats.nf += 6
 end

--- a/src/perform_step/high_order_rk_perform_step.jl
+++ b/src/perform_step/high_order_rk_perform_step.jl
@@ -1,5 +1,5 @@
 function initialize!(integrator,cache::TanYam7ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -11,19 +11,19 @@ function initialize!(integrator,cache::TanYam7ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::TanYam7ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a93,a94,a95,a96,a97,a98,a101,a103,a104,a105,a106,a107,a108,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(uprev+a*k1, p, t + c1*dt)
-  k3 = f(uprev+dt*(a31*k1+a32*k2), p, t + c2*dt)
-  k4 = f(uprev+dt*(a41*k1       +a43*k3), p, t + c3*dt)
-  k5 = f(uprev+dt*(a51*k1       +a53*k3+a54*k4), p, t + c4*dt)
-  k6 = f(uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5), p, t + c5*dt)
-  k7 = f(uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6), p, t + c6*dt)
-  k8 = f(uprev+dt*(a81*k1       +a83*k3+a84*k4+a85*k5+a86*k6+a87*k7), p, t + c7*dt)
-  k9 = f(uprev+dt*(a91*k1       +a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8), p, t+dt)
-  k10= f(uprev+dt*(a101*k1      +a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8), p, t+dt)
+  k2 = f(uprev+a*k1, t + c1*dt, integrator)
+  k3 = f(uprev+dt*(a31*k1+a32*k2), t + c2*dt, integrator)
+  k4 = f(uprev+dt*(a41*k1       +a43*k3), t + c3*dt, integrator)
+  k5 = f(uprev+dt*(a51*k1       +a53*k3+a54*k4), t + c4*dt, integrator)
+  k6 = f(uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5), t + c5*dt, integrator)
+  k7 = f(uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6), t + c6*dt, integrator)
+  k8 = f(uprev+dt*(a81*k1       +a83*k3+a84*k4+a85*k5+a86*k6+a87*k7), t + c7*dt, integrator)
+  k9 = f(uprev+dt*(a91*k1       +a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8), t+dt, integrator)
+  k10= f(uprev+dt*(a101*k1      +a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8), t+dt, integrator)
   integrator.destats.nf += 9
   u = uprev + dt*(b1*k1+b4*k4+b5*k5+b6*k6+b7*k7+b8*k8+b9*k9)
   if integrator.opts.adaptive
@@ -31,7 +31,7 @@ end
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  integrator.fsallast = f(u, p, t+dt) # For the interpolation, needs k at the updated point
+  integrator.fsallast = f(u, t+dt, integrator) # For the interpolation, needs k at the updated point
   integrator.destats.nf += 1
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -45,35 +45,35 @@ function initialize!(integrator, cache::TanYam7Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::TanYam7Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack fsalfirst,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp,k = cache
   @unpack c1,c2,c3,c4,c5,c6,c7,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a93,a94,a95,a96,a97,a98,a101,a103,a104,a105,a106,a107,a108,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10 = cache.tab
   k1 = fsalfirst
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a21
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev+dt*(a31*k1+a32*k2)
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a41*k1+a43*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a51*k1+a53*k3+a54*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a61*k1+a63*k3+a64*k4+a65*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a71*k1+a73*k3+a74*k4+a75*k5+a76*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @.. tmp = uprev+dt*(a91*k1+a93*k3+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8)
-  f(k9, tmp, p, t+dt)
+  f(k9, tmp, t+dt, integrator)
   @.. tmp = uprev+dt*(a101*k1+a103*k3+a104*k4+a105*k5+a106*k6+a107*k7+a108*k8)
-  f(k10, tmp, p, t+dt)
+  f(k10, tmp, t+dt, integrator)
   @.. u = uprev + dt*(b1*k1+b4*k4+b5*k5+b6*k6+b7*k7+b8*k8+b9*k9)
   integrator.destats.nf += 10
   if integrator.opts.adaptive
@@ -81,56 +81,56 @@ end
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 1
   return nothing
 end
 
 #=
 @muladd function perform_step!(integrator, cache::TanYam7Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack fsalfirst,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp,k = cache
   @unpack c1,c2,c3,c4,c5,c6,c7,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a93,a94,a95,a96,a97,a98,a101,a103,a104,a105,a106,a107,a108,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10 = cache.tab
   k1 = fsalfirst
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a21
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a43*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a53*k3[i]+a54*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
   end
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a91*k1[i]+a93*k3[i]+a94*k4[i]+a95*k5[i]+a96*k6[i]+a97*k7[i]+a98*k8[i])
   end
-  f(k9, tmp, p, t+dt)
+  f(k9, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a101*k1[i]+a103*k3[i]+a104*k4[i]+a105*k5[i]+a106*k6[i]+a107*k7[i]+a108*k8[i])
   end
-  f(k10, tmp, p, t+dt)
+  f(k10, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i] + dt*(b1*k1[i]+b4*k4[i]+b5*k5[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i])
   end
@@ -142,7 +142,7 @@ end
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 1
 end
 =#
@@ -150,7 +150,7 @@ end
 function initialize!(integrator, cache::DP8ConstantCache)
   integrator.kshortsize = 7
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -161,21 +161,21 @@ function initialize!(integrator, cache::DP8ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::DP8ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache
   k1 = integrator.fsalfirst
   a = dt*a0201
-  k2 = f(uprev+a*k1, p, t + c2*dt)
-  k3 = f(uprev+dt*(a0301*k1+a0302*k2), p, t + c3*dt)
-  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), p, t + c4*dt)
-  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), p, t + c5*dt)
-  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), p, t + c6*dt)
-  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), p, t + c7*dt)
-  k8 = f(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7), p, t + c8*dt)
-  k9 = f(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8), p, t + c9*dt)
-  k10 =f(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9), p, t + c10*dt)
-  k11= f(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), p, t + c11*dt)
-  k12= f(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11), p, t+dt)
+  k2 = f(uprev+a*k1, t + c2*dt, integrator)
+  k3 = f(uprev+dt*(a0301*k1+a0302*k2), t + c3*dt, integrator)
+  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), t + c4*dt, integrator)
+  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), t + c5*dt, integrator)
+  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), t + c6*dt, integrator)
+  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), t + c7*dt, integrator)
+  k8 = f(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7), t + c8*dt, integrator)
+  k9 = f(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8), t + c9*dt, integrator)
+  k10 =f(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9), t + c10*dt, integrator)
+  k11= f(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), t + c11*dt, integrator)
+  k12= f(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11), t+dt, integrator)
   integrator.destats.nf += 11
   kupdate= b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
   u = uprev + dt*kupdate
@@ -193,15 +193,15 @@ end
       integrator.EEst = err52/sqrt(err52 + 0.01*err3*err3)
     end
   end
-  k13 = f(u, p, t+dt)
+  k13 = f(u, t+dt, integrator)
   integrator.destats.nf += 1
   integrator.fsallast = k13
   if integrator.opts.calck
     @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache
     @unpack d401,d406,d407,d408,d409,d410,d411,d412,d413,d414,d415,d416,d501,d506,d507,d508,d509,d510,d511,d512,d513,d514,d515,d516,d601,d606,d607,d608,d609,d610,d611,d612,d613,d614,d615,d616,d701,d706,d707,d708,d709,d710,d711,d712,d713,d714,d715,d716 = cache
-    k14 = f(uprev+dt*(a1401*k1         +a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13), p, t + c14*dt)
-    k15 = f(uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8                   +a1511*k11+a1512*k12+a1513*k13+a1514*k14), p, t + c15*dt)
-    k16 = f(uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9                              +a1613*k13+a1614*k14+a1615*k15), p, t + c16*dt)
+    k14 = f(uprev+dt*(a1401*k1         +a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13), t + c14*dt, integrator)
+    k15 = f(uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8                   +a1511*k11+a1512*k12+a1513*k13+a1514*k14), t + c15*dt, integrator)
+    k16 = f(uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9                              +a1613*k13+a1614*k14+a1615*k15), t + c16*dt, integrator)
     integrator.destats.nf += 3
     udiff = kupdate
     integrator.k[1] = udiff
@@ -222,39 +222,39 @@ function initialize!(integrator, cache::DP8Cache)
   integrator.k .= [cache.udiff,cache.bspl,cache.dense_tmp3,cache.dense_tmp4,cache.dense_tmp5,cache.dense_tmp6,cache.dense_tmp7]
   integrator.fsalfirst = cache.k1
   integrator.fsallast = cache.k13
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::DP8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,udiff,bspl,dense_tmp3,dense_tmp4,dense_tmp5,dense_tmp6,dense_tmp7,kupdate,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c2*dt)
+  f(k2, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a0301*k1+a0302*k2)
-  f(k3, tmp, p, t + c3*dt)
+  f(k3, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a0401*k1+a0403*k3)
-  f(k4, tmp, p, t + c4*dt)
+  f(k4, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
-  f(k5, tmp, p, t + c5*dt)
+  f(k5, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
-  f(k6, tmp, p, t + c6*dt)
+  f(k6, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
-  f(k7, tmp, p, t + c7*dt)
+  f(k7, tmp, t + c7*dt, integrator)
   @.. tmp = uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
-  f(k8, tmp, p, t + c8*dt)
+  f(k8, tmp, t + c8*dt, integrator)
   @.. tmp = uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
-  f(k9, tmp, p, t + c9*dt)
+  f(k9, tmp, t + c9*dt, integrator)
   @.. tmp = uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
-  f(k10, tmp, p, t + c10*dt)
+  f(k10, tmp, t + c10*dt, integrator)
   @.. tmp = uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
-  f(k11, tmp, p, t + c11*dt)
+  f(k11, tmp, t + c11*dt, integrator)
   @.. tmp = uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
-  f(k12, tmp, p, t+dt)
+  f(k12, tmp, t+dt, integrator)
   @.. kupdate = b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12
   @.. u = uprev + dt*kupdate
   integrator.destats.nf += 12
@@ -272,17 +272,17 @@ end
       integrator.EEst = err52/sqrt(err52 + 0.01*err3*err3)
     end
   end
-  f(k13, u, p, t+dt)
+  f(k13, u, t+dt, integrator)
   integrator.destats.nf += 1
   if integrator.opts.calck
     @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache.tab
     @unpack d401,d406,d407,d408,d409,d410,d411,d412,d413,d414,d415,d416,d501,d506,d507,d508,d509,d510,d511,d512,d513,d514,d515,d516,d601,d606,d607,d608,d609,d610,d611,d612,d613,d614,d615,d616,d701,d706,d707,d708,d709,d710,d711,d712,d713,d714,d715,d716 = cache.tab
     @.. tmp = uprev+dt*(a1401*k1+a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13)
-    f(k14, tmp, p, t + c14*dt)
+    f(k14, tmp, t + c14*dt, integrator)
     @.. tmp = uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8+a1511*k11+a1512*k12+a1513*k13+a1514*k14)
-    f(k15, tmp, p, t + c15*dt)
+    f(k15, tmp, t + c15*dt, integrator)
     @.. tmp = uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9+a1613*k13+a1614*k14+a1615*k15)
-    f(k16, tmp, p, t + c16*dt)
+    f(k16, tmp, t + c16*dt, integrator)
     integrator.destats.nf += 3
     @.. udiff= kupdate
     @.. bspl = k1 - udiff
@@ -296,56 +296,56 @@ end
 
 #=
 @muladd function perform_step!(integrator, cache::DP8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c7,c8,c9,c10,c11,c6,c5,c4,c3,c2,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,er1,er6,er7,er8,er9,er10,er11,er12,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,udiff,bspl,dense_tmp3,dense_tmp4,dense_tmp5,dense_tmp6,dense_tmp7,kupdate,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c2*dt)
+  f(k2, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
   end
-  f(k3, tmp, p, t + c3*dt)
+  f(k3, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
   end
-  f(k4, tmp, p, t + c4*dt)
+  f(k4, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
   end
-  f(k5, tmp, p, t + c5*dt)
+  f(k5, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
   end
-  f(k6, tmp, p, t + c6*dt)
+  f(k6, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
   end
-  f(k7, tmp, p, t + c7*dt)
+  f(k7, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
   end
-  f(k8, tmp, p, t + c8*dt)
+  f(k8, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
   end
-  f(k9, tmp, p, t + c9*dt)
+  f(k9, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
   end
-  f(k10, tmp, p, t + c10*dt)
+  f(k10, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
   end
-  f(k11, tmp, p, t + c11*dt)
+  f(k11, tmp, t + c11*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
   end
-  f(k12, tmp, p, t+dt)
+  f(k12, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds kupdate[i] = b1*k1[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i]
     @inbounds u[i] = uprev[i] + dt*kupdate[i]
@@ -369,7 +369,7 @@ end
       integrator.EEst = err52/sqrt(err52 + 0.01*err3*err3)
     end
   end
-  f(k13, u, p, t+dt)
+  f(k13, u, t+dt, integrator)
   integrator.destats.nf += 1
   if integrator.opts.calck
     @unpack c14,c15,c16,a1401,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1613,a1614,a1615 = cache.tab
@@ -377,15 +377,15 @@ end
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1401*k1[i]+a1407*k7[i]+a1408*k8[i]+a1409*k9[i]+a1410*k10[i]+a1411*k11[i]+a1412*k12[i]+a1413*k13[i])
     end
-    f(k14, tmp, p, t + c14*dt)
+    f(k14, tmp, t + c14*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1501*k1[i]+a1506*k6[i]+a1507*k7[i]+a1508*k8[i]+a1511*k11[i]+a1512*k12[i]+a1513*k13[i]+a1514*k14[i])
     end
-    f(k15, tmp, p, t + c15*dt)
+    f(k15, tmp, t + c15*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1601*k1[i]+a1606*k6[i]+a1607*k7[i]+a1608*k8[i]+a1609*k9[i]+a1613*k13[i]+a1614*k14[i]+a1615*k15[i])
     end
-    f(k16, tmp, p, t + c16*dt)
+    f(k16, tmp, t + c16*dt, integrator)
     integrator.destats.nf += 3
     @tight_loop_macros for i in uidx
       @inbounds udiff[i]= kupdate[i]
@@ -401,7 +401,7 @@ end
 =#
 
 function initialize!(integrator, cache::TsitPap8ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -414,7 +414,7 @@ end
 
 #=
 @muladd function perform_step!(integrator, cache::TsitPap8ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache
   k1 = integrator.fsalfirst
   a = dt*a0201
@@ -436,7 +436,7 @@ end
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  integrator.fsallast = f(u, p, t+dt)
+  integrator.fsallast = f(u, t+dt, integrator)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.u = u
@@ -444,22 +444,22 @@ end
 =#
 
 @muladd function perform_step!(integrator, cache::TsitPap8ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache
   k1 = integrator.fsalfirst
   a = dt*a0201
-  k2 = f(uprev+a*k1, p, t + c1*dt)
-  k3 = f(uprev+dt*(a0301*k1+a0302*k2), p, t + c2*dt)
-  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), p, t + c3*dt)
-  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), p, t + c4*dt)
-  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), p, t + c5*dt)
-  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), p, t + c6*dt)
-  k8 = f(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7), p, t + c7*dt)
-  k9 = f(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8), p, t + c8*dt)
-  k10 =f(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9), p, t + c9*dt)
-  k11= f(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), p, t + c10*dt)
-  k12= f(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11), p, t+dt)
-  k13= f(uprev+dt*(a1301*k1                +a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10), p, t+dt)
+  k2 = f(uprev+a*k1, t + c1*dt, integrator)
+  k3 = f(uprev+dt*(a0301*k1+a0302*k2), t + c2*dt, integrator)
+  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), t + c3*dt, integrator)
+  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), t + c4*dt, integrator)
+  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), t + c5*dt, integrator)
+  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), t + c6*dt, integrator)
+  k8 = f(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7), t + c7*dt, integrator)
+  k9 = f(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8), t + c8*dt, integrator)
+  k10 =f(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9), t + c9*dt, integrator)
+  k11= f(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), t + c10*dt, integrator)
+  k12= f(uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11), t+dt, integrator)
+  k13= f(uprev+dt*(a1301*k1                +a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10), t+dt, integrator)
   integrator.destats.nf += 12
   u = uprev + dt*(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12)
   if integrator.opts.adaptive
@@ -467,7 +467,7 @@ end
     atmp = calculate_residuals(utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  integrator.fsallast = f(u, p, t+dt)
+  integrator.fsallast = f(u, t+dt, integrator)
   integrator.destats.nf += 1
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -482,41 +482,41 @@ function initialize!(integrator, cache::TsitPap8Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::TsitPap8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,utilde,tmp,atmp,k = cache
   k1 = cache.fsalfirst
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev+dt*(a0301*k1+a0302*k2)
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a0401*k1+a0403*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @.. tmp = uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @.. tmp = uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @.. tmp = uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @.. tmp = uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
-  f(k12, tmp, p, t+dt)
+  f(k12, tmp, t+dt, integrator)
   @.. tmp = uprev+dt*(a1301*k1+a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10)
-  f(k13, tmp, p, t+dt)
+  f(k13, tmp, t+dt, integrator)
   @.. u = uprev + dt*(b1*k1+b6*k6+b7*k7+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12)
   integrator.destats.nf += 13
   if integrator.opts.adaptive
@@ -524,68 +524,68 @@ end
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 1
   return nothing
 end
 
 #=
 @muladd function perform_step!(integrator, cache::TsitPap8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,utilde,tmp,atmp,k = cache
   k1 = cache.fsalfirst
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
   end
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
   end
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
   end
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
   end
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
   end
-  f(k12, tmp, p, t+dt)
+  f(k12, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1301*k1[i]+a1304*k4[i]+a1305*k5[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i])
   end
-  f(k13, tmp, p, t+dt)
+  f(k13, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i] + dt*(b1*k1[i]+b6*k6[i]+b7*k7[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i])
   end
@@ -597,7 +597,7 @@ end
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
   integrator.destats.nf += 1
 end
 =#

--- a/src/perform_step/nordsieck_perform_step.jl
+++ b/src/perform_step/nordsieck_perform_step.jl
@@ -1,7 +1,7 @@
 function initialize!(integrator,cache::AN5ConstantCache)
   integrator.kshortsize = 7
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -14,7 +14,7 @@ function initialize!(integrator,cache::AN5ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::AN5ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack z,l,m,c_LTE,dts,tsit5tab = cache
   # handle callbacks, rewind back to order one.
   if integrator.u_modified
@@ -94,12 +94,12 @@ function initialize!(integrator, cache::AN5Cache)
   integrator.k[5] = cache.tsit5cache.k5
   integrator.k[6] = cache.tsit5cache.k6
   integrator.k[7] = cache.tsit5cache.k7
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::AN5Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,uprev2 = integrator
+  @unpack t,dt,uprev,u,f,uprev2 = integrator
   @unpack z,l,m,c_LTE,dts,tmp,ratetmp,atmp,tsit5cache = cache
   # handle callbacks, rewind back to order one.
   if integrator.u_modified
@@ -175,7 +175,7 @@ end
 function initialize!(integrator,cache::JVODEConstantCache)
   integrator.kshortsize = 7
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -188,13 +188,13 @@ function initialize!(integrator,cache::JVODEConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::JVODEConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack z,l,m,c_LTE,dts,tsit5tab = cache
   # handle callbacks, rewind back to order one.
   if integrator.u_modified || integrator.iter == 1
     cache.order = 1
     z[1] = integrator.uprev
-    z[2] = f(uprev, p, t)*dt
+    z[2] = f(uprev, t, integrator)*dt
     integrator.destats.nf += 1
     dts[1] = dt
   end
@@ -248,18 +248,18 @@ function initialize!(integrator, cache::JVODECache)
   integrator.k[5] = cache.tsit5cache.k5
   integrator.k[6] = cache.tsit5cache.k6
   integrator.k[7] = cache.tsit5cache.k7
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::JVODECache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,uprev2 = integrator
+  @unpack t,dt,uprev,u,f,uprev2 = integrator
   @unpack z,l,m,c_LTE,dts,tmp,ratetmp,atmp,tsit5cache = cache
   # handle callbacks, rewind back to order one.
   if integrator.u_modified || integrator.iter == 1
     cache.order = 1
     @.. z[1] = integrator.uprev
-    f(z[2], uprev, p, t)
+    f(z[2], uprev, t, integrator)
     integrator.destats.nf += 1
     @.. z[2] = z[2]*dt
     dts[1] = dt

--- a/src/perform_step/prk_perform_step.jl
+++ b/src/perform_step/prk_perform_step.jl
@@ -1,5 +1,5 @@
 function initialize!(integrator,cache::KuttaPRK2p5ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
@@ -10,30 +10,30 @@ function initialize!(integrator,cache::KuttaPRK2p5ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::KuttaPRK2p5ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α21,α31,α32,α41,α42,α43,α5_6 = cache
   @unpack β1,β3,β5,β6,c2,c3,c4,c5_6 = cache
 
-  k1 = f(uprev, p, t)
-  k2 = f(uprev + dt*α21*k1, p, t + c2*dt)
-  k3 = f(uprev + dt*(α31*k1 + α32*k2), p, t + c3*dt)
-  k4 = f(uprev + dt*(α41*k1 + α42*k2 + α43*k3), p, t + c4*dt)
+  k1 = f(uprev, t, integrator)
+  k2 = f(uprev + dt*α21*k1, t + c2*dt, integrator)
+  k3 = f(uprev + dt*(α31*k1 + α32*k2), t + c3*dt, integrator)
+  k4 = f(uprev + dt*(α41*k1 + α42*k2 + α43*k3), t + c4*dt, integrator)
 
   k5_6 = Array{typeof(k1)}(undef, 2)
 
   if integrator.alg.threading == false
-    k5_6[1] = f(uprev + dt*(α5_6[1,1]*k1 + α5_6[1,2]*k2 + α5_6[1,3]*k3 + α5_6[1,4]*k4), p, t + c5_6[1]*dt)
-    k5_6[2] = f(uprev + dt*(α5_6[2,1]*k1 + α5_6[2,2]*k2 + α5_6[2,3]*k3 + α5_6[2,4]*k4), p, t + c5_6[2]*dt)  
+    k5_6[1] = f(uprev + dt*(α5_6[1,1]*k1 + α5_6[1,2]*k2 + α5_6[1,3]*k3 + α5_6[1,4]*k4), t + c5_6[1]*dt, integrator)
+    k5_6[2] = f(uprev + dt*(α5_6[2,1]*k1 + α5_6[2,2]*k2 + α5_6[2,3]*k3 + α5_6[2,4]*k4), t + c5_6[2]*dt, integrator)
   else
     let
       Threads.@threads for i in [1,2]
-        k5_6[i] = f(uprev + dt*(α5_6[i,1]*k1 + α5_6[i,2]*k2 + α5_6[i,3]*k3 + α5_6[i,4]*k4), p, t + c5_6[i]*dt)
+        k5_6[i] = f(uprev + dt*(α5_6[i,1]*k1 + α5_6[i,2]*k2 + α5_6[i,3]*k3 + α5_6[i,4]*k4), t + c5_6[i]*dt, integrator)
       end
     end
   end
 
   u = uprev + dt*(β1*k1 + β3*k3 + β5*k5_6[1] + β6*k5_6[2])
-  k = f(u, p, t+dt)
+  k = f(u, t+dt, integrator)
 
   integrator.fsallast = k # For interpolation, then FSAL'd
   integrator.k[1] = integrator.fsalfirst
@@ -47,44 +47,44 @@ function initialize!(integrator,cache::KuttaPRK2p5Cache)
   integrator.fsallast = k
   integrator.kshortsize = 2
   resize!(integrator.k, integrator.kshortsize)
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
 end
 
 @muladd function perform_step!(integrator,cache::KuttaPRK2p5Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,k1,k2,k3,k4,k5_6,fsalfirst,tmp = cache
   @unpack α21,α31,α32,α41,α42,α43,α5_6 = cache.tab
   @unpack β1,β3,β5,β6,c2,c3,c4,c5_6 = cache.tab
 
-  f( k1, uprev, p, t)
+  f( k1, uprev, t, integrator)
 
   @.. u = uprev + dt*α21*k1
-  f( k2, u, p, t + c2*dt)
+  f( k2, u, t + c2*dt, integrator)
 
   @.. u = uprev + dt*(α31*k1 + α32*k2)
-  f( k3, u, p, t + c3*dt)
+  f( k3, u, t + c3*dt, integrator)
 
   @.. u = uprev + dt*(α41*k1 + α42*k2 + α43*k3)
-  f( k4, u, p, t + c4*dt)
+  f( k4, u, t + c4*dt, integrator)
 
   if integrator.alg.threading == false
     @.. u = uprev + dt*(α5_6[1,1]*k1 + α5_6[1,2]*k2 + α5_6[1,3]*k3 + α5_6[1,4]*k4)
-    f( k5_6[1], u, p, t + c5_6[1]*dt)
+    f( k5_6[1], u, t + c5_6[1]*dt, integrator)
 
     @.. u = uprev + dt*(α5_6[2,1]*k1 + α5_6[2,2]*k2 + α5_6[2,3]*k3 + α5_6[2,4]*k4)
-    f( k5_6[2], u, p, t + c5_6[2]*dt)
+    f( k5_6[2], u, t + c5_6[2]*dt, integrator)
   else
     tmps = (u, tmp)
     let
       Threads.@threads for i in [1,2]
         @.. tmps[i] = uprev + dt*(α5_6[i,1]*k1 + α5_6[i,2]*k2 + α5_6[i,3]*k3 + α5_6[i,4]*k4)
-        f( k5_6[i], tmps[i], p, t + c5_6[i]*dt)
+        f( k5_6[i], tmps[i], t + c5_6[i]*dt, integrator)
       end
     end
   end
 
   @.. u = uprev + dt*(β1*k1 + β3*k3 + β5*k5_6[1] + β6*k5_6[2])
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end

--- a/src/perform_step/rkn_perform_step.jl
+++ b/src/perform_step/rkn_perform_step.jl
@@ -17,8 +17,8 @@ function initialize!(integrator,cache::NystromCCDefaultInitialization)
  integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
  duprev,uprev = integrator.uprev.x
- kdu = integrator.f.f1(duprev,uprev,integrator.p,integrator.t)
- ku  = integrator.f.f2(duprev,uprev,integrator.p,integrator.t)
+ kdu = integrator.f.f1(duprev, uprev, integrator.t, integrator)
+ ku  = integrator.f.f2(duprev, uprev, integrator.t, integrator)
  integrator.destats.nf += 1
 integrator.destats.nf2 += 1
  integrator.fsalfirst = ArrayPartition((kdu,ku))
@@ -41,14 +41,14 @@ function initialize!(integrator,cache::NystromDefaultInitialization)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f.f1(integrator.k[1].x[1],duprev,uprev,integrator.p,integrator.t)
-  integrator.f.f2(integrator.k[1].x[2],duprev,uprev,integrator.p,integrator.t)
+  integrator.f.f1(integrator.k[1].x[1], duprev, uprev, integrator.t, integrator)
+  integrator.f.f2(integrator.k[1].x[2], duprev, uprev, integrator.t, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 1
 end
 
 @muladd function perform_step!(integrator,cache::Nystrom4ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   k₁ = integrator.fsalfirst.x[1]
   halfdt = dt/2
@@ -62,20 +62,20 @@ end
   ## y'₁ = y'₀ + h∑bᵢk'ᵢ
   kdu = duprev + halfdt*k₁
 
-  k₂ = f.f1(kdu,ku,p,ttmp)
+  k₂ = f.f1(kdu, ku, ttmp, integrator)
   ku = uprev + halfdt*duprev + eighth_dtsq*k₁
   kdu = duprev + halfdt*k₂
 
-  k₃ = f.f1(kdu,ku,p,ttmp)
+  k₃ = f.f1(kdu, ku, ttmp, integrator)
   ku = uprev + dt*duprev + half_dtsq*k₃
   kdu = duprev + dt*k₃
 
-  k₄ = f.f1(kdu,ku,p,t+dt)
+  k₄ = f.f1(kdu, ku, t+dt, integrator)
   u = uprev + (dtsq/6)*(k₁ + k₂ + k₃) + dt*duprev
   du = duprev + (dt/6)*(k₁ + k₄ + 2*(k₂ + k₃))
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -83,7 +83,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Nystrom4Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,fsalfirst,k₂,k₃,k₄,k = cache
@@ -100,26 +100,26 @@ end
   ## y'₁ = y'₀ + h∑bᵢk'ᵢ
   @.. kdu = duprev + halfdt*k₁
 
-  f.f1(k₂,kdu,ku,p,ttmp)
+  f.f1(k₂, kdu, ku, ttmp, integrator)
   @.. ku = uprev + halfdt*duprev + eighth_dtsq*k₁
   @.. kdu = duprev + halfdt*k₂
 
-  f.f1(k₃,kdu,ku,p,ttmp)
+  f.f1(k₃, kdu, ku, ttmp, integrator)
   @.. ku = uprev + dt*duprev + half_dtsq*k₃
   @.. kdu = duprev + dt*k₃
 
-  f.f1(k₄,kdu,ku,p,t+dt)
+  f.f1(k₄, kdu, ku, t+dt, integrator)
   @.. u = uprev + (dtsq/6)*(k₁ + k₂ + k₃) + dt*duprev
   @.. du = duprev + (dt/6)*(k₁ + k₄ + 2*(k₂ + k₃))
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 1
 end
 
 @muladd function perform_step!(integrator,cache::Nystrom4VelocityIndependentConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   k₁ = integrator.fsalfirst.x[1]
   halfdt = dt/2
@@ -131,15 +131,15 @@ end
   ## y₁ = y₀ + hy'₀ + h²∑b̄ᵢk'ᵢ
   ku = uprev + halfdt*duprev + eighth_dtsq*k₁
 
-  k₂ = f.f1(duprev,ku,p,ttmp)
+  k₂ = f.f1(duprev, ku, ttmp, integrator)
   ku = uprev + dt*duprev + half_dtsq*k₂
 
-  k₃ = f.f1(duprev,ku,p,t+dt)
+  k₃ = f.f1(duprev, ku, t+dt, integrator)
   u = uprev + (dtsq/6)*(k₁ + 2*k₂) + dt*duprev
   du = duprev + (dt/6)*(k₁ + k₃ + 4*k₂)
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 3
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -147,7 +147,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Nystrom4VelocityIndependentCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,fsalfirst,k₂,k₃,k = cache
@@ -162,21 +162,21 @@ end
   ## y₁ = y₀ + hy'₀ + h²∑b̄ᵢk'ᵢ
   @.. ku = uprev + halfdt*duprev + eighth_dtsq*k₁
 
-  f.f1(k₂,duprev,ku,p,ttmp)
+  f.f1(k₂, duprev, ku, ttmp, integrator)
   @.. ku = uprev + dt*duprev + half_dtsq*k₂
 
-  f.f1(k₃,duprev,ku,p,t+dt)
+  f.f1(k₃, duprev, ku, t+dt, integrator)
   @.. u = uprev + (dtsq/6)*(k₁ + 2*k₂) + dt*duprev
   @.. du = duprev + (dt/6)*(k₁ + k₃ + 4*k₂)
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 3
   integrator.destats.nf2 += 1
 end
 
 @muladd function perform_step!(integrator,cache::IRKN3ConstantCache,repeat_step=false)
-  @unpack t,dt,k,tprev,f,p = integrator
+  @unpack t,dt,k,tprev,f = integrator
   duprev, uprev   = integrator.uprev.x
   duprev2,uprev2 = integrator.uprev2.x
   @unpack bconst1,bconst2,c1,a21,b1,b2,bbar1,bbar2 = cache
@@ -185,20 +185,20 @@ end
   if integrator.iter < 2 && !integrator.u_modified
     perform_step!(integrator,Nystrom4VelocityIndependentConstantCache())
     k = integrator.fsallast
-    k1cache = ArrayParition((k.x[1],f.f1(duprev,uprev,p,t+c1*dt)))
+    k1cache = ArrayParition((k.x[1], f.f1(duprev, uprev, t+c1*dt, integrator)))
     kdu = uprev + dt*(c1*duprev + dt*a21*k1cache.x[1])
-    k₂.x[1] = f.f1(duprev,kdu,p,t+c1*dt)
+    k₂.x[1] = f.f1(duprev, kdu, t+c1*dt, integrator)
     integrator.destats.nf += 2
   else
     kdu = uprev2 + dt*(c1*duprev2 + dt*a21*k1cache.x[1])
     ku  = uprev  + dt*(c1*duprev  + dt*a21*k1cache.x[2])
 
 
-    k₂x1 = f.f1(duprev, ku, p, t+c1*dt)
+    k₂x1 = f.f1(duprev, ku, t+c1*dt, integrator)
     du = duprev + dt*(b1*k1cache.x[1] + bbar1*k1cache.x[1] + b2*(k₂x1-k₂.x[1]))
     u  = uprev + bconst1*dt*duprev + dt*(bconst2*duprev2 + dt*bbar2*(k₂x1-k₂.x[1]))
 
-    integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+    integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
     integrator.destats.nf += 3
     integrator.destats.nf2 += 1
     copyto!(k₂.x[1],k₂.x[2])
@@ -207,7 +207,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::IRKN3Cache,repeat_step=false)
-  @unpack t,dt,k,tprev,f,p = integrator
+  @unpack t,dt,k,tprev,f = integrator
   du,u = integrator.u.x
   duprev, uprev   = integrator.uprev.x
   duprev2,uprev2 = integrator.uprev2.x
@@ -221,21 +221,21 @@ end
   if integrator.iter < 2 && !integrator.u_modified
     perform_step!(integrator,integrator.cache.onestep_cache)
     copyto!(k1cache.x[1], k.x[1])
-    f.f1(k1cache.x[2],duprev,uprev,p,t+c1*dt)
+    f.f1(k1cache.x[2], duprev, uprev, t+c1*dt, integrator)
     @.. kdu= uprev + dt*(c1*duprev + dt*a21*k1cache.x[2])
-    f.f1(k₂.x[1],duprev,kdu,p,t+c1*dt)
+    f.f1(k₂.x[1], duprev, kdu, t+c1*dt, integrator)
     integrator.destats.nf += 2
   else
     @.. kdu = uprev2 + dt*(c1*duprev2 + dt*a21*k1cache.x[1])
     @.. ku  = uprev  + dt*(c1*duprev  + dt*a21*k1cache.x[2])
 
-    f.f1(k₂.x[2], duprev, ku, p, t+c1*dt)
+    f.f1(k₂.x[2], duprev, ku, t+c1*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds u[i]  = uprev[i] + bconst1*dt*duprev[i] + dt*(bconst2*duprev2[i] + dt*bbar2*(k₂.x[2][i]-k₂.x[1][i]))
       @inbounds du[i] = duprev[i] + dt*(b1*k1cache.x[1][i] + bbar1*k1cache.x[2][i] + b2*(k₂.x[2][i]-k₂.x[1][i]))
     end
-    f.f1(k.x[1],du,u,p,t+dt)
-    f.f2(k.x[2],du,u,p,t+dt)
+    f.f1(k.x[1], du, u, t+dt, integrator)
+    f.f2(k.x[2], du, u, t+dt, integrator)
     integrator.destats.nf += 3
     integrator.destats.nf2 += 1
     copyto!(k₂.x[1],k₂.x[2])
@@ -245,7 +245,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::IRKN4Cache,repeat_step=false)
-  @unpack t,dt,k,tprev,f,p = integrator
+  @unpack t,dt,k,tprev,f = integrator
   du,u = integrator.u.x
   duprev, uprev   = integrator.uprev.x
   duprev2,uprev2 = integrator.uprev2.x
@@ -259,27 +259,27 @@ end
   if integrator.iter < 2 && !integrator.u_modified
     perform_step!(integrator,integrator.cache.onestep_cache)
     copyto!(k1cache.x[1], k.x[1])
-    f.f1(k1cache.x[2],duprev,uprev,p,t+c1*dt)
+    f.f1(k1cache.x[2], duprev, uprev, t+c1*dt, integrator)
     @.. kdu= uprev + dt*(c1*duprev + dt*a21*k1cache.x[1])
-    f.f1(k₂.x[1],duprev,kdu,p,t+c1*dt)
+    f.f1(k₂.x[1], duprev, kdu, t+c1*dt, integrator)
     @.. kdu= uprev + dt*(c2*duprev + dt*a32*k1cache.x[2])
-    f.f1(k₃.x[1],duprev,kdu,p,t+c1*dt)
+    f.f1(k₃.x[1], duprev, kdu, t+c1*dt, integrator)
     integrator.destats.nf += 3
   else
     @.. ku  = uprev  + dt*(c1*duprev  + dt*a21*k1cache.x[1])
     @.. kdu = uprev2+ dt*(c1*duprev2 + dt*a21*k1cache.x[2])
 
-    f.f1(k₂.x[2], duprev, ku, p, t+c1*dt)
+    f.f1(k₂.x[2], duprev, ku, t+c1*dt, integrator)
     @.. ku  = uprev  + dt*(c2*duprev  + dt*a32*k₂.x[2])
     @.. kdu = uprev2 + dt*(c2*duprev2 + dt*a32*k₂.x[1])
 
-    f.f1(k₃.x[2], duprev, ku, p, t+c2*dt)
+    f.f1(k₃.x[2], duprev, ku, t+c2*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds u[i]  = uprev[i] + dt*bconst1*duprev[i] + dt*(bconst2*duprev2[i] + dt*(bbar2*(k₂.x[2][i]-k₂.x[1][i]) + bbar3*(k₃.x[2][i]-k₃.x[1][i])))
       @inbounds du[i] = duprev[i] + dt*(b1*k1cache.x[1][i] + bbar1*k1cache.x[2][i] + b2*(k₂.x[2][i]-k₂.x[1][i]) + b3*(k₃.x[2][i]-k₃.x[1][i]))
     end
-    f.f1(k.x[1],du,u,p,t+dt)
-    f.f2(k.x[2],du,u,p,t+dt)
+    f.f1(k.x[1], du, u, t+dt, integrator)
+    f.f2(k.x[2], du, u, t+dt, integrator)
     integrator.destats.nf += 4
     integrator.destats.nf2 += 1
     copyto!(k₂.x[1],k₂.x[2])
@@ -290,25 +290,25 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Nystrom5VelocityIndependentConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   @unpack c1, c2, a21, a31, a32, a41, a42, a43, bbar1, bbar2, bbar3, b1, b2, b3, b4 = cache
   k₁ = integrator.fsalfirst.x[1]
 
   ku = uprev + dt*(c1*duprev + dt*a21*k₁)
 
-  k₂ = f.f1(duprev,ku,p,t+c1*dt)
+  k₂ = f.f1(duprev, ku, t+c1*dt, integrator)
   ku = uprev + dt*(c2*duprev + dt*(a31*k₁ + a32*k₂))
 
-  k₃ = f.f1(duprev,ku,p,t+c2*dt)
+  k₃ = f.f1(duprev, ku, t+c2*dt, integrator)
   ku = uprev + dt*(duprev + dt*(a41*k₁ + a42*k₂ + a43*k₃))
 
-  k₄ = f.f1(duprev,ku,p,t+dt)
+  k₄ = f.f1(duprev, ku, t+dt, integrator)
   u  = uprev + dt*(duprev + dt*(bbar1*k₁ + bbar2*k₂ + bbar3*k₃))
   du = duprev + dt*(b1*k₁ + b2*k₂ + b3*k₃ + b4*k₄)
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -316,7 +316,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Nystrom5VelocityIndependentCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   uidx = eachindex(integrator.uprev.x[1])
@@ -327,24 +327,24 @@ end
 
   @.. ku = uprev + dt*(c1*duprev + dt*a21*k₁)
 
-  f.f1(k₂,du,ku,p,t+c1*dt)
+  f.f1(k₂, du, ku, t+c1*dt, integrator)
   @.. ku = uprev + dt*(c2*duprev + dt*(a31*k₁ + a32*k₂))
 
-  f.f1(k₃,du,ku,p,t+c2*dt)
+  f.f1(k₃, du, ku, t+c2*dt, integrator)
   #@tight_loop_macros for i in uidx
   #  @inbounds ku[i] = uprev[i] + dt*(duprev[i] + dt*(a41*k₁[i] + a42*k₂[i] + a43*k₃[i]))
   #end
   @.. ku = uprev + dt*(duprev + dt*(a41*k₁ + a42*k₂ + a43*k₃))
 
-  f.f1(k₄,duprev,ku,p,t+dt)
+  f.f1(k₄, duprev, ku, t+dt, integrator)
   #@tight_loop_macros for i in uidx
   #  @inbounds u[i]  = uprev[i] + dt*(duprev[i] + dt*(bbar1*k₁[i] + bbar2*k₂[i] + bbar3*k₃[i]))
   #  @inbounds du[i] = duprev[i] + dt*(b1*k₁[i] + b2*k₂[i] + b3*k₃[i] + b4*k₄[i])
   #end
   @.. u  = uprev + dt*(duprev + dt*(bbar1*k₁ + bbar2*k₂ + bbar3*k₃))
   @.. du = duprev + dt*(b1*k₁ + b2*k₂ + b3*k₃ + b4*k₄)
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   return nothing
@@ -355,8 +355,8 @@ function initialize!(integrator, cache::DPRKN6ConstantCache)
   integrator.kshortsize = 3
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
-  kdu  = integrator.f.f1(duprev,uprev,integrator.p,integrator.t)
-  ku = integrator.f.f2(duprev,uprev,integrator.p,integrator.t)
+  kdu  = integrator.f.f1(duprev, uprev, integrator.t, integrator)
+  ku = integrator.f.f2(duprev, uprev, integrator.t, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 1
   integrator.fsalfirst = ArrayPartition((kdu,ku))
@@ -371,26 +371,26 @@ function initialize!(integrator, cache::DPRKN6ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::DPRKN6ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   @unpack c1, c2, c3, c4, c5, a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, a61, a63, a64, a65, b1, b3, b4, b5, bp1, bp3, bp4, bp5, bp6, btilde1, btilde2, btilde3, btilde4, btilde5, bptilde1, bptilde3, bptilde4, bptilde5, bptilde6 = cache
   k1 = integrator.fsalfirst.x[1]
 
   ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  k2 = f.f1(duprev,ku,p,t+dt*c1)
+  k2 = f.f1(duprev, ku, t+dt*c1, integrator)
   ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  k3 = f.f1(duprev,ku,p,t+dt*c2)
+  k3 = f.f1(duprev, ku, t+dt*c2, integrator)
   ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  k4 = f.f1(duprev,ku,p,t+dt*c3)
+  k4 = f.f1(duprev, ku, t+dt*c3, integrator)
   ku = uprev + dt*(c4*duprev + dt*(a51*k1 + a52*k2 + a53*k3 + a54*k4))
 
-  k5 = f.f1(duprev,ku,p,t+dt*c4)
+  k5 = f.f1(duprev, ku, t+dt*c4, integrator)
   ku = uprev + dt*(c5*duprev + dt*(a61*k1          + a63*k3 + a64*k4 + a65*k5)) # no a62
 
-  k6 = f.f1(duprev,ku,p,t+dt*c5)
+  k6 = f.f1(duprev, ku, t+dt*c5, integrator)
   u  = uprev + dt*(duprev + dt*(b1 *k1 + b3 *k3 + b4 *k4 + b5 *k5)) # b1 -- b5, no b2
   du = duprev                + dt*(bp1*k1 + bp3*k3 + bp4*k4 + bp5*k5 + bp6*k6) # bp1 -- bp6, no bp2
 
@@ -402,7 +402,7 @@ end
   =#
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.k[1] = ArrayPartition(integrator.fsalfirst.x[1],k2)
   integrator.k[2] = ArrayPartition(k3, k4)
   integrator.k[3] = ArrayPartition(k5, k6)
@@ -430,14 +430,14 @@ function initialize!(integrator, cache::DPRKN6Cache)
   integrator.k[1] = ArrayPartition(cache.fsalfirst.x[1],cache.k2)
   integrator.k[2] = ArrayPartition(cache.k3, cache.k4)
   integrator.k[3] = ArrayPartition(cache.k5, cache.k6)
-  integrator.f.f1(integrator.fsallast.x[1],duprev,uprev,integrator.p,integrator.t)
-  integrator.f.f2(integrator.fsallast.x[2],duprev,uprev,integrator.p,integrator.t)
+  integrator.f.f1(integrator.fsallast.x[1], duprev, uprev, integrator.t, integrator)
+  integrator.f.f2(integrator.fsallast.x[2], duprev, uprev, integrator.t, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 1
 end
 
 @muladd function perform_step!(integrator,cache::DPRKN6Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,atmp,fsalfirst,k2,k3,k4,k5,k6,k,utilde = cache
@@ -448,23 +448,23 @@ end
 
   @.. ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  f.f1(k2,du,ku,p,t+dt*c1)
+  f.f1(k2, du, ku, t+dt*c1, integrator)
   @.. ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  f.f1(k3,du,ku,p,t+dt*c2)
+  f.f1(k3, du, ku, t+dt*c2, integrator)
   @.. ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  f.f1(k4,du,ku,p,t+dt*c3)
+  f.f1(k4, du, ku, t+dt*c3, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c4*duprev[i] + dt*(a51*k1[i] + a52*k2[i] + a53*k3[i] + a54*k4[i]))
   end
 
-  f.f1(k5,du,ku,p,t+dt*c4)
+  f.f1(k5, du, ku, t+dt*c4, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c5*duprev[i] + dt*(a61*k1[i]                  + a63*k3[i] + a64*k4[i] + a65*k5[i])) # no a62
   end
 
-  f.f1(k6,du,ku,p,t+dt*c5)
+  f.f1(k6, du, ku, t+dt*c5, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i]  = uprev[i] + dt*(duprev[i] + dt*(b1 *k1[i] + b3 *k3[i] + b4 *k4[i] + b5 *k5[i])) # b1 -- b5, no b2
     @inbounds du[i] = duprev[i]                + dt*(bp1*k1[i] + bp3*k3[i] + bp4*k4[i] + bp5*k5[i] + bp6*k6[i]) # bp1 -- bp6, no bp2
@@ -476,8 +476,8 @@ end
   end
   =#
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 6
   integrator.destats.nf2 += 1
   if integrator.opts.adaptive
@@ -493,40 +493,40 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::DPRKN8ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   @unpack c1, c2, c3, c4, c5, c6, c7, c8, a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, a61, a62, a63, a64, a65, a71, a72, a73, a74, a75, a76, a81, a82, a83, a84, a85, a86, a87, a91, a93, a94, a95, a96, a97, b1, b3, b4, b5, b6, b7, bp1, bp3, bp4, bp5, bp6, bp7, bp8, btilde1, btilde3, btilde4, btilde5, btilde6, btilde7, bptilde1, bptilde3, bptilde4, bptilde5, bptilde6, bptilde7, bptilde8, bptilde9 = cache
   k1 = integrator.fsalfirst.x[1]
 
   ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  k2 = f.f1(duprev,ku,p,t+dt*c1)
+  k2 = f.f1(duprev, ku, t+dt*c1, integrator)
   ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  k3 = f.f1(duprev,ku,p,t+dt*c2)
+  k3 = f.f1(duprev, ku, t+dt*c2, integrator)
   ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  k4 = f.f1(duprev,ku,p,t+dt*c3)
+  k4 = f.f1(duprev, ku, t+dt*c3, integrator)
   ku = uprev + dt*(c4*duprev + dt*(a51*k1 + a52*k2 + a53*k3 + a54*k4))
 
-  k5 = f.f1(duprev,ku,p,t+dt*c4)
+  k5 = f.f1(duprev, ku, t+dt*c4, integrator)
   ku = uprev + dt*(c5*duprev + dt*(a61*k1 + a62*k2 + a63*k3 + a64*k4 + a65*k5))
 
-  k6 = f.f1(duprev,ku,p,t+dt*c5)
+  k6 = f.f1(duprev, ku, t+dt*c5, integrator)
   ku = uprev + dt*(c6*duprev + dt*(a71*k1 + a72*k2 + a73*k3 + a74*k4 + a75*k5 + a76*k6))
 
-  k7 = f.f1(duprev,ku,p,t+dt*c6)
+  k7 = f.f1(duprev, ku, t+dt*c6, integrator)
   ku = uprev + dt*(c7*duprev + dt*(a81*k1 + a82*k2 + a83*k3 + a84*k4 + a85*k5 + a86*k6 + a87*k7))
 
-  k8 = f.f1(duprev,ku,p,t+dt*c7)
+  k8 = f.f1(duprev, ku, t+dt*c7, integrator)
   ku = uprev + dt*(c8*duprev + dt*(a91*k1 + a93*k3 + a94*k4 + a95*k5 + a96*k6 + a97*k7)) # no a92 & a98
 
-  k9 = f.f1(duprev,ku,p,t+dt*c8)
+  k9 = f.f1(duprev, ku, t+dt*c8, integrator)
   u  = uprev + dt*(duprev + dt*(b1 *k1 + b3 *k3 + b4 *k4 + b5 *k5 + b6 *k6 + b7 *k7)) # b1 -- b7, no b2
   du = duprev+ dt*(bp1*k1 + bp3*k3 + bp4*k4 + bp5*k5 + bp6*k6 + bp7*k7 + bp8*k8) # bp1 -- bp8, no bp2
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 9
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -543,7 +543,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::DPRKN8Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,atmp,fsalfirst,k2,k3,k4,k5,k6,k7,k8,k9,k,utilde = cache
@@ -554,45 +554,45 @@ end
 
   @.. ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  f.f1(k2,duprev,ku,p,t+dt*c1)
+  f.f1(k2, duprev, ku, t+dt*c1, integrator)
   @.. ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  f.f1(k3,duprev,ku,p,t+dt*c2)
+  f.f1(k3, duprev, ku, t+dt*c2, integrator)
   @.. ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  f.f1(k4,duprev,ku,p,t+dt*c3)
+  f.f1(k4, duprev, ku, t+dt*c3, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c4*duprev[i] + dt*(a51*k1[i] + a52*k2[i] + a53*k3[i] + a54*k4[i]))
   end
 
-  f.f1(k5,duprev,ku,p,t+dt*c4)
+  f.f1(k5, duprev, ku, t+dt*c4, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c5*duprev[i] + dt*(a61*k1[i] + a62*k2[i] + a63*k3[i] + a64*k4[i] + a65*k5[i]))
   end
 
-  f.f1(k6,duprev,ku,p,t+dt*c5)
+  f.f1(k6, duprev, ku, t+dt*c5, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c6*duprev[i] + dt*(a71*k1[i] + a72*k2[i] + a73*k3[i] + a74*k4[i] + a75*k5[i] + a76*k6[i]))
   end
 
-  f.f1(k7,duprev,ku,p,t+dt*c6)
+  f.f1(k7, duprev, ku, t+dt*c6, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c7*duprev[i] + dt*(a81*k1[i] + a82*k2[i] + a83*k3[i] + a84*k4[i] + a85*k5[i] + a86*k6[i] + a87*k7[i]))
   end
 
-  f.f1(k8,duprev,ku,p,t+dt*c7)
+  f.f1(k8, duprev, ku, t+dt*c7, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c8*duprev[i] + dt*(a91*k1[i] + a93*k3[i] + a94*k4[i] + a95*k5[i] + a96*k6[i] + a97*k7[i])) # no a92 & a98
   end
 
-  f.f1(k9,duprev,ku,p,t+dt*c8)
+  f.f1(k9, duprev, ku, t+dt*c8, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i]  = uprev[i] + dt*(duprev[i] + dt*(b1 *k1[i] + b3 *k3[i] + b4 *k4[i] + b5 *k5[i] + b6 *k6[i] + b7 *k7[i])) # b1 -- b7, no b2
     @inbounds du[i] = duprev[i]+ dt*(bp1*k1[i] + bp3*k3[i] + bp4*k4[i] + bp5*k5[i] + bp6*k6[i] + bp7*k7[i] + bp8*k8[i]) # bp1 -- bp8, no bp2
   end
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 9
   integrator.destats.nf2 += 1
   if integrator.opts.adaptive
@@ -608,64 +608,64 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::DPRKN12ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   @unpack c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, a21, a31, a32, a41, a42, a43, a51, a53, a54, a61, a63, a64, a65, a71, a73, a74, a75, a76, a81, a84, a85, a86, a87, a91, a93, a94, a95, a96, a97, a98, a101, a103, a104, a105, a106, a107, a108, a109, a111, a113, a114, a115, a116, a117, a118, a119, a1110, a121, a123, a124, a125, a126, a127, a128, a129, a1210, a1211, a131, a133, a134, a135, a136, a137, a138, a139, a1310, a1311, a1312, a141, a143, a144, a145, a146, a147, a148, a149, a1410, a1411, a1412, a1413, a151, a153, a154, a155, a156, a157, a158, a159, a1510, a1511, a1512, a1513, a1514, a161, a163, a164, a165, a166, a167, a168, a169, a1610, a1611, a1612, a1613, a1614, a1615, a171, a173, a174, a175, a176, a177, a178, a179, a1710, a1711, a1712, a1713, a1714, a1715, b1, b7, b8, b9, b10, b11, b12, b13, b14, b15, bp1, bp7, bp8, bp9, bp10, bp11, bp12, bp13, bp14, bp15, bp16, bp17, btilde1, btilde7, btilde8, btilde9, btilde10, btilde11, btilde12, btilde13, btilde14, btilde15, bptilde1, bptilde7, bptilde8, bptilde9, bptilde10, bptilde11, bptilde12, bptilde13, bptilde14, bptilde15, bptilde16, bptilde17 = cache
   k1 = integrator.fsalfirst.x[1]
 
   ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  k2 = f.f1(duprev,ku,p,t+dt*c1)
+  k2 = f.f1(duprev, ku, t+dt*c1, integrator)
   ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  k3 = f.f1(duprev,ku,p,t+dt*c2)
+  k3 = f.f1(duprev, ku, t+dt*c2, integrator)
   ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  k4 = f.f1(duprev,ku,p,t+dt*c3)
+  k4 = f.f1(duprev, ku, t+dt*c3, integrator)
   ku = uprev + dt*(c4*duprev + dt*(a51*k1 + a53*k3 + a54*k4)) # no a52
 
-  k5 = f.f1(duprev,ku,p,t+dt*c4)
+  k5 = f.f1(duprev, ku, t+dt*c4, integrator)
   ku = uprev + dt*(c5*duprev + dt*(a61*k1 + a63*k3 + a64*k4 + a65*k5)) # no a62
 
-  k6 = f.f1(duprev,ku,p,t+dt*c5)
+  k6 = f.f1(duprev, ku, t+dt*c5, integrator)
   ku = uprev + dt*(c6*duprev + dt*(a71*k1 + a73*k3 + a74*k4 + a75*k5 + a76*k6)) # no a72
 
-  k7 = f.f1(duprev,ku,p,t+dt*c6)
+  k7 = f.f1(duprev, ku, t+dt*c6, integrator)
   ku = uprev + dt*(c7*duprev + dt*(a81*k1 + a84*k4 + a85*k5 + a86*k6 + a87*k7)) # no a82, a83
 
-  k8 = f.f1(duprev,ku,p,t+dt*c7)
+  k8 = f.f1(duprev, ku, t+dt*c7, integrator)
   ku = uprev + dt*(c8*duprev + dt*(a91*k1 + a93*k3 + a94*k4 + a95*k5 + a96*k6 + a97*k7 + a98*k8)) # no a92
 
-  k9 = f.f1(duprev,ku,p,t+dt*c8)
+  k9 = f.f1(duprev, ku, t+dt*c8, integrator)
   ku = uprev + dt*(c9*duprev + dt*(a101*k1 + a103*k3 + a104*k4 + a105*k5 + a106*k6 + a107*k7 + a108*k8 + a109*k9)) # no a102
 
-  k10 = f.f1(duprev,ku,p,t+dt*c9)
+  k10 = f.f1(duprev, ku, t+dt*c9, integrator)
   ku = uprev + dt*(c10*duprev + dt*(a111*k1 + a113*k3 + a114*k4 + a115*k5 + a116*k6 + a117*k7 + a118*k8 + a119*k9 + a1110*k10)) # no a112
 
-  k11 = f.f1(duprev,ku,p,t+dt*c10)
+  k11 = f.f1(duprev, ku, t+dt*c10, integrator)
   ku = uprev + dt*(c11*duprev + dt*(a121*k1 + a123*k3 + a124*k4 + a125*k5 + a126*k6 + a127*k7 + a128*k8 + a129*k9 + a1210*k10 + a1211*k11)) # no a122
 
-  k12 = f.f1(duprev,ku,p,t+dt*c11)
+  k12 = f.f1(duprev, ku, t+dt*c11, integrator)
   ku = uprev + dt*(c12*duprev + dt*(a131*k1 + a133*k3 + a134*k4 + a135*k5 + a136*k6 + a137*k7 + a138*k8 + a139*k9 + a1310*k10 + a1311*k11 + a1312*k12)) # no a132
 
-  k13 = f.f1(duprev,ku,p,t+dt*c12)
+  k13 = f.f1(duprev, ku, t+dt*c12, integrator)
   ku = uprev + dt*(c13*duprev + dt*(a141*k1 + a143*k3 + a144*k4 + a145*k5 + a146*k6 + a147*k7 + a148*k8 + a149*k9 + a1410*k10 + a1411*k11 + a1412*k12 + a1413*k13)) # no a142
 
-  k14 = f.f1(duprev,ku,p,t+dt*c13)
+  k14 = f.f1(duprev, ku, t+dt*c13, integrator)
   ku = uprev + dt*(c14*duprev + dt*(a151*k1 + a153*k3 + a154*k4 + a155*k5 + a156*k6 + a157*k7 + a158*k8 + a159*k9 + a1510*k10 + a1511*k11 + a1512*k12 + a1513*k13 + a1514*k14)) # no a152
 
-  k15 = f.f1(duprev,ku,p,t+dt*c14)
+  k15 = f.f1(duprev, ku, t+dt*c14, integrator)
   ku = uprev + dt*(c15*duprev + dt*(a161*k1 + a163*k3 + a164*k4 + a165*k5 + a166*k6 + a167*k7 + a168*k8 + a169*k9 + a1610*k10 + a1611*k11 + a1612*k12 + a1613*k13 + a1614*k14 + a1615*k15)) # no a162
 
-  k16 = f.f1(duprev,ku,p,t+dt*c15)
+  k16 = f.f1(duprev, ku, t+dt*c15, integrator)
   ku = uprev + dt*(c16*duprev + dt*(a171*k1 + a173*k3 + a174*k4 + a175*k5 + a176*k6 + a177*k7 + a178*k8 + a179*k9 + a1710*k10 + a1711*k11 + a1712*k12 + a1713*k13 + a1714*k14 + a1715*k15)) # no a172, a1716
 
-  k17 = f.f1(duprev,ku,p,t+dt*c16)
+  k17 = f.f1(duprev, ku, t+dt*c16, integrator)
   u  = uprev + dt*(duprev + dt*(b1 *k1 + b7 *k7+ b8 *k8+ b9 *k9+ b10 *k10+ b11 *k11+ b12 *k12+ b13 *k13+ b14 *k14+ b15 *k15)) # b1 & b7 -- b15
   du = duprev+ dt*(bp1*k1 + bp7*k7+ bp8*k8+ bp9*k9+ bp10*k10+ bp11*k11+ bp12*k12+ bp13*k13+ bp14*k14+ bp15*k15+ bp16*k16+ bp17*k17) # bp1 & bp7 -- bp17
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 17
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -681,7 +681,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::DPRKN12Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,atmp,fsalfirst,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,k17,k,utilde = cache
@@ -692,85 +692,85 @@ end
 
   @.. ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  f.f1(k2,duprev,ku,p,t+dt*c1)
+  f.f1(k2, duprev, ku, t+dt*c1, integrator)
   @.. ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  f.f1(k3,duprev,ku,p,t+dt*c2)
+  f.f1(k3, duprev, ku, t+dt*c2, integrator)
   @.. ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  f.f1(k4,duprev,ku,p,t+dt*c3)
+  f.f1(k4, duprev, ku, t+dt*c3, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c4*duprev[i] + dt*(a51*k1[i] + a53*k3[i] + a54*k4[i])) # no a52
   end
 
-  f.f1(k5,duprev,ku,p,t+dt*c4)
+  f.f1(k5, duprev, ku, t+dt*c4, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c5*duprev[i] + dt*(a61*k1[i] + a63*k3[i] + a64*k4[i] + a65*k5[i])) # no a62
   end
 
-  f.f1(k6,duprev,ku,p,t+dt*c5)
+  f.f1(k6, duprev, ku, t+dt*c5, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c6*duprev[i] + dt*(a71*k1[i] + a73*k3[i] + a74*k4[i] + a75*k5[i] + a76*k6[i])) # no a72
   end
 
-  f.f1(k7,duprev,ku,p,t+dt*c6)
+  f.f1(k7, duprev, ku, t+dt*c6, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c7*duprev[i] + dt*(a81*k1[i] + a84*k4[i] + a85*k5[i] + a86*k6[i] + a87*k7[i])) # no a82, a83
   end
 
-  f.f1(k8,duprev,ku,p,t+dt*c7)
+  f.f1(k8, duprev, ku, t+dt*c7, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c8*duprev[i] + dt*(a91*k1[i] + a93*k3[i] + a94*k4[i] + a95*k5[i] + a96*k6[i] + a97*k7[i] + a98*k8[i])) # no a92
   end
 
-  f.f1(k9,duprev,ku,p,t+dt*c8)
+  f.f1(k9, duprev, ku, t+dt*c8, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c9*duprev[i] + dt*(a101*k1[i] + a103*k3[i] + a104*k4[i] + a105*k5[i] + a106*k6[i] + a107*k7[i] + a108*k8[i] + a109*k9[i])) # no a102
   end
 
-  f.f1(k10,duprev,ku,p,t+dt*c9)
+  f.f1(k10, duprev, ku, t+dt*c9, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c10*duprev[i] + dt*(a111*k1[i] + a113*k3[i] + a114*k4[i] + a115*k5[i] + a116*k6[i] + a117*k7[i] + a118*k8[i] + a119*k9[i] + a1110*k10[i])) # no a112
   end
 
-  f.f1(k11,duprev,ku,p,t+dt*c10)
+  f.f1(k11, duprev, ku, t+dt*c10, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c11*duprev[i] + dt*(a121*k1[i] + a123*k3[i] + a124*k4[i] + a125*k5[i] + a126*k6[i] + a127*k7[i] + a128*k8[i] + a129*k9[i] + a1210*k10[i] + a1211*k11[i])) # no a122
   end
 
-  f.f1(k12,duprev,ku,p,t+dt*c11)
+  f.f1(k12, duprev, ku, t+dt*c11, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c12*duprev[i] + dt*(a131*k1[i] + a133*k3[i] + a134*k4[i] + a135*k5[i] + a136*k6[i] + a137*k7[i] + a138*k8[i] + a139*k9[i] + a1310*k10[i] + a1311*k11[i] + a1312*k12[i])) # no a132
   end
 
-  f.f1(k13,duprev,ku,p,t+dt*c12)
+  f.f1(k13, duprev, ku, t+dt*c12, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c13*duprev[i] + dt*(a141*k1[i] + a143*k3[i] + a144*k4[i] + a145*k5[i] + a146*k6[i] + a147*k7[i] + a148*k8[i] + a149*k9[i] + a1410*k10[i] + a1411*k11[i] + a1412*k12[i] + a1413*k13[i])) # no a142
   end
 
-  f.f1(k14,duprev,ku,p,t+dt*c13)
+  f.f1(k14, duprev, ku, t+dt*c13, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c14*duprev[i] + dt*(a151*k1[i] + a153*k3[i] + a154*k4[i] + a155*k5[i] + a156*k6[i] + a157*k7[i] + a158*k8[i] + a159*k9[i] + a1510*k10[i] + a1511*k11[i] + a1512*k12[i] + a1513*k13[i] + a1514*k14[i])) # no a152
   end
 
-  f.f1(k15,duprev,ku,p,t+dt*c14)
+  f.f1(k15, duprev, ku, t+dt*c14, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c15*duprev[i] + dt*(a161*k1[i] + a163*k3[i] + a164*k4[i] + a165*k5[i] + a166*k6[i] + a167*k7[i] + a168*k8[i] + a169*k9[i] + a1610*k10[i] + a1611*k11[i] + a1612*k12[i] + a1613*k13[i] + a1614*k14[i] + a1615*k15[i])) # no a162
   end
 
-  f.f1(k16,duprev,ku,p,t+dt*c15)
+  f.f1(k16, duprev, ku, t+dt*c15, integrator)
   @tight_loop_macros for i in uidx
     @inbounds ku[i] = uprev[i] + dt*(c16*duprev[i] + dt*(a171*k1[i] + a173*k3[i] + a174*k4[i] + a175*k5[i] + a176*k6[i] + a177*k7[i] + a178*k8[i] + a179*k9[i] + a1710*k10[i] + a1711*k11[i] + a1712*k12[i] + a1713*k13[i] + a1714*k14[i] + a1715*k15[i])) # no a172, a1716
   end
 
-  f.f1(k17,duprev,ku,p,t+dt*c16)
+  f.f1(k17, duprev, ku, t+dt*c16, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i]  = uprev[i] + dt*(duprev[i] + dt*(b1 *k1[i] + b7 *k7[i]+ b8 *k8[i]+ b9 *k9[i]+ b10 *k10[i]+ b11 *k11[i]+ b12 *k12[i]+ b13 *k13[i]+ b14 *k14[i]+ b15 *k15[i])) # b1 & b7 -- b15
     @inbounds du[i] = duprev[i]+ dt*(bp1*k1[i] + bp7*k7[i]+ bp8*k8[i]+ bp9*k9[i]+ bp10*k10[i]+ bp11*k11[i]+ bp12*k12[i]+ bp13*k13[i]+ bp14*k14[i]+ bp15*k15[i]+ bp16*k16[i]+ bp17*k17[i]) # bp1 & bp7 -- bp17
   end
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 17
   integrator.destats.nf2 += 1
   if integrator.opts.adaptive
@@ -786,25 +786,25 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::ERKN4ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   @unpack c1, c2, c3, a21, a31, a32, a41, a42, a43, b1, b2, b3, b4, bp1, bp2, bp3, bp4, btilde1, btilde2, btilde3, btilde4, bptilde1, bptilde2, bptilde3, bptilde4 = cache
   k1 = integrator.fsalfirst.x[1]
 
   ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  k2 = f.f1(duprev,ku,p,t+dt*c1)
+  k2 = f.f1(duprev, ku, t+dt*c1, integrator)
   ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  k3 = f.f1(duprev,ku,p,t+dt*c2)
+  k3 = f.f1(duprev, ku, t+dt*c2, integrator)
   ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  k4 = f.f1(duprev,ku,p,t+dt*c3)
+  k4 = f.f1(duprev, ku, t+dt*c3, integrator)
   u  = uprev + dt*(duprev + dt*(b1 *k1 + b2 *k2 + b3 *k3 + b4 *k4))
   du = duprev                + dt*(bp1*k1 + bp2*k2 + bp3*k3 + bp4*k4)
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -821,7 +821,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::ERKN4Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,atmp,fsalfirst,k2,k3,k4,k,utilde = cache
@@ -832,20 +832,20 @@ end
 
   @.. ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  f.f1(k2,duprev,ku,p,t+dt*c1)
+  f.f1(k2, duprev, ku, t+dt*c1, integrator)
   @.. ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  f.f1(k3,duprev,ku,p,t+dt*c2)
+  f.f1(k3, duprev, ku, t+dt*c2, integrator)
   @.. ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  f.f1(k4,duprev,ku,p,t+dt*c3)
+  f.f1(k4, duprev, ku, t+dt*c3, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i]  = uprev[i] + dt*(duprev[i] + dt*(b1 *k1[i] + b2 *k2[i] + b3 *k3[i] + b4 *k4[i]))
     @inbounds du[i] = duprev[i]                + dt*(bp1*k1[i] + bp2*k2[i] + bp3*k3[i] + bp4*k4[i])
   end
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   if integrator.opts.adaptive
@@ -861,25 +861,25 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::ERKN5ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   @unpack c1, c2, c3, a21, a31, a32, a41, a42, a43, b1, b2, b3, b4, bp1, bp2, bp3, bp4, btilde1, btilde2, btilde3, btilde4 = cache
   k1 = integrator.fsalfirst.x[1]
 
   ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  k2 = f.f1(duprev,ku,p,t+dt*c1)
+  k2 = f.f1(duprev, ku, t+dt*c1, integrator)
   ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  k3 = f.f1(duprev,ku,p,t+dt*c2)
+  k3 = f.f1(duprev, ku, t+dt*c2, integrator)
   ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  k4 = f.f1(duprev,ku,p,t+dt*c3)
+  k4 = f.f1(duprev, ku, t+dt*c3, integrator)
   u  = uprev + dt*(duprev + dt*(b1 *k1 + b2 *k2 + b3 *k3 + b4 *k4))
   du = duprev                + dt*(bp1*k1 + bp2*k2 + bp3*k3 + bp4*k4)
 
   integrator.u = ArrayPartition((du,u))
-  integrator.fsallast = ArrayPartition((f.f1(du,u,p,t+dt),f.f2(du,u,p,t+dt)))
+  integrator.fsallast = ArrayPartition((f.f1(du, u, t+dt, integrator),f.f2(du, u, t+dt, integrator)))
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   integrator.k[1] = integrator.fsalfirst
@@ -893,7 +893,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::ERKN5Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   du,u = integrator.u.x
   duprev,uprev = integrator.uprev.x
   @unpack tmp,atmp,fsalfirst,k2,k3,k4,k,utilde = cache
@@ -904,20 +904,20 @@ end
 
   @.. ku = uprev + dt*(c1*duprev + dt*a21*k1)
 
-  f.f1(k2,duprev,ku,p,t+dt*c1)
+  f.f1(k2, duprev, ku, t+dt*c1, integrator)
   @.. ku = uprev + dt*(c2*duprev + dt*(a31*k1 + a32*k2))
 
-  f.f1(k3,duprev,ku,p,t+dt*c2)
+  f.f1(k3, duprev, ku, t+dt*c2, integrator)
   @.. ku = uprev + dt*(c3*duprev + dt*(a41*k1 + a42*k2 + a43*k3))
 
-  f.f1(k4,duprev,ku,p,t+dt*c3)
+  f.f1(k4, duprev, ku, t+dt*c3, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i]  = uprev[i] + dt*(duprev[i] + dt*(b1 *k1[i] + b2 *k2[i] + b3 *k3[i] + b4 *k4[i]))
     @inbounds du[i] = duprev[i]                + dt*(bp1*k1[i] + bp2*k2[i] + bp3*k3[i] + bp4*k4[i])
   end
 
-  f.f1(k.x[1],du,u,p,t+dt)
-  f.f2(k.x[2],du,u,p,t+dt)
+  f.f1(k.x[1], du, u, t+dt, integrator)
+  f.f2(k.x[2], du, u, t+dt, integrator)
   integrator.destats.nf += 4
   integrator.destats.nf2 += 1
   if integrator.opts.adaptive

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -1,5 +1,5 @@
 function initialize!(integrator,cache::SSPRK22ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -10,15 +10,15 @@ function initialize!(integrator,cache::SSPRK22ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK22ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
 
   # u1 -> stored as u
   u = uprev + dt*integrator.fsalfirst
-  k = f(u, p, t+dt)
+  k = f(u, t+dt, integrator)
   # u
   u = (uprev + u + dt*k) / 2
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 2
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -31,29 +31,29 @@ function initialize!(integrator,cache::SSPRK22Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK22Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,stage_limiter!,step_limiter! = cache
 
   # u1 -> stored as u
   @.. u = uprev + dt*fsalfirst
   stage_limiter!(u, f, t+dt)
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
   # u
   @.. u = (uprev + u + dt*k) / 2
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 2
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK33ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -64,18 +64,18 @@ function initialize!(integrator,cache::SSPRK33ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK33ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
 
   # u1
   u = uprev + dt*integrator.fsalfirst
-  k = f(u, p, t+dt)
+  k = f(u, t+dt, integrator)
   # u2
   u = (3*uprev + u + dt*k) / 4
-  k = f(u,p,t+dt/2)
+  k = f(u, t+dt/2, integrator)
   # u
   u = (uprev + 2*u + 2*dt*k) / 3
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 3
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -88,33 +88,33 @@ function initialize!(integrator,cache::SSPRK33Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK33Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,stage_limiter!,step_limiter! = cache
 
   # u1
   @.. u = uprev + dt*fsalfirst
   stage_limiter!(u, f, t+dt)
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
   # u2
   @.. u = (3*uprev + u + dt*k) / 4
   stage_limiter!(u, f, t+dt/2)
-  f(k,u,p,t+dt/2)
+  f(k, u, t+dt/2, integrator)
   # u
   @.. u = (uprev + 2*u + 2*dt*k) / 3
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 3
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK53ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -125,25 +125,25 @@ function initialize!(integrator,cache::SSPRK53ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK53ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α30,α32,α40,α43,α52,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache
 
   # u1
   tmp = uprev + β10 * dt * integrator.fsalfirst
-  k = f(tmp, p, t+c1*dt)
+  k = f(tmp, t+c1*dt, integrator)
   # u2 -> stored as u
   u = tmp + β21 * dt * k
-  k = f(u, p, t+c2*dt)
+  k = f(u, t+c2*dt, integrator)
   # u3
   tmp = α30 * uprev + α32 * u + β32 * dt * k
-  k = f(tmp, p, t+c3*dt)
+  k = f(tmp, t+c3*dt, integrator)
   # u4
   tmp = α40 * uprev + α43 * tmp + β43 * dt * k
-  k = f(tmp, p, t+c4*dt)
+  k = f(tmp, t+c4*dt, integrator)
   # u
   u = α52 * u + α54 * tmp + β54 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 5
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -156,42 +156,42 @@ function initialize!(integrator,cache::SSPRK53Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK53Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack α30,α32,α40,α43,α52,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache.tab
 
   # u1
   @.. tmp = uprev + β10 * dt * fsalfirst
   stage_limiter!(tmp, f, t+c1*dt)
-  f( k,  tmp, p, t+c1*dt)
+  f( k, tmp, t+c1*dt, integrator)
   # u2 -> stored as u
   @.. u = tmp + β21 * dt * k
   stage_limiter!(u, f, t+c2*dt)
-  f( k,  u, p, t+c2*dt)
+  f( k, u, t+c2*dt, integrator)
   # u3
   @.. tmp = α30 * uprev + α32 * u + β32 * dt * k
   stage_limiter!(tmp, f, t+c3*dt)
-  f( k,  tmp, p, t+c3*dt)
+  f( k, tmp, t+c3*dt, integrator)
   # u4
   @.. tmp = α40 * uprev + α43 * tmp + β43 * dt * k
   stage_limiter!(tmp, f, t+c4*dt)
-  f( k,  tmp, p, t+c4*dt)
+  f( k, tmp, t+c4*dt, integrator)
   # u
   @.. u = α52 * u + α54 * tmp + β54 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 5
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK53_2N1ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -202,25 +202,25 @@ function initialize!(integrator,cache::SSPRK53_2N1ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK53_2N1ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α40,α43,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache
   #stores in u for all intermediate stages
   # u1
   u = uprev + β10 * dt * integrator.fsalfirst
-  k = f(u, p, t+c1*dt)
+  k = f(u, t+c1*dt, integrator)
   # u2
   u = u + β21 * dt * k
-  k = f(u, p, t+c2*dt)
+  k = f(u, t+c2*dt, integrator)
   # u3
   u = u + β32 * dt * k
-  k = f(u, p, t+c3*dt)
+  k = f(u, t+c3*dt, integrator)
   # u4
   u= α40 * uprev + α43 * u + β43 * dt * k
-  k = f(u, p, t+c4*dt)
+  k = f(u, t+c4*dt, integrator)
   # u
   u =  u + β54 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 1
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -233,42 +233,42 @@ function initialize!(integrator,cache::SSPRK53_2N1Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK53_2N1Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack α40,α43,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache.tab
   #stores in u for all intermediate stages
   # u1
   @.. u = uprev + β10 * dt * fsalfirst
   stage_limiter!(u, f, t+c1*dt)
-  f( k,  u, p, t+c1*dt)
+  f( k, u, t+c1*dt, integrator)
   # u2
   @.. u = u + β21 * dt * k
   stage_limiter!(u, f, t+c2*dt)
-  f( k,  u, p, t+c2*dt)
+  f( k, u, t+c2*dt, integrator)
   # u3
   @.. u = u + β32 * dt * k
   stage_limiter!(u, f, t+c3*dt)
-  f( k,  u, p, t+c3*dt)
+  f( k, u, t+c3*dt, integrator)
   # u4
   @.. u = α40 * uprev + α43 * u + β43 * dt * k
   stage_limiter!(u, f, t+c4*dt)
-  f( k,  u, p, t+c4*dt)
+  f( k, u, t+c4*dt, integrator)
   # u
   @.. u = u + β54 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 5
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK53_2N2ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -279,25 +279,25 @@ function initialize!(integrator,cache::SSPRK53_2N2ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK53_2N2ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α30,α32,α50,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache
   #stores in u for all intermediate stages
   # u1
   u = uprev + β10 * dt * integrator.fsalfirst
-  k = f(u, p, t+c1*dt)
+  k = f(u, t+c1*dt, integrator)
   # u2 -> stored as u
   u = u + β21 * dt * k
-  k = f(u, p, t+c2*dt)
+  k = f(u, t+c2*dt, integrator)
   # u3
   u = α30 * uprev + α32 * u + β32 * dt * k
-  k = f(u, p, t+c3*dt)
+  k = f(u, t+c3*dt, integrator)
   # u4
   u = u + β43 * dt * k
-  k = f(u, p, t+c4*dt)
+  k = f(u, t+c4*dt, integrator)
   # u
   u = α50 * uprev + α54 * u + β54 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 5
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -310,42 +310,42 @@ function initialize!(integrator,cache::SSPRK53_2N2Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK53_2N2Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack α30,α32,α50,α54,β10,β21,β32,β43,β54,c1,c2,c3,c4 = cache.tab
 
   # u1
   @.. u = uprev + β10 * dt * integrator.fsalfirst
   stage_limiter!(u, f, t+c1*dt)
-  f( k,  u, p, t+c1*dt)
+  f( k, u, t+c1*dt, integrator)
   # u2 -> stored as u
   @.. u = u + β21 * dt * k
   stage_limiter!(u, f, t+c2*dt)
-  f( k,  u, p, t+c2*dt)
+  f( k, u, t+c2*dt, integrator)
   # u3
   @.. u = α30 * uprev + α32 * u + β32 * dt * k
   stage_limiter!(u, f, t+c3*dt)
-  f( k,  u, p, t+c3*dt)
+  f( k, u, t+c3*dt, integrator)
   # u4
   @.. u = u + β43 * dt * k
   stage_limiter!(u, f, t+c4*dt)
-  f( k,  u, p, t+c4*dt)
+  f( k, u, t+c4*dt, integrator)
   # u
   @.. u = α50* uprev + α54 * u+ β54 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 5
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK63ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -356,28 +356,28 @@ function initialize!(integrator,cache::SSPRK63ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK63ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α40,α41,α43,α62,α65,β10,β21,β32,β43,β54,β65,c1,c2,c3,c4,c5 = cache
 
   # u1 -> stored as u
   u = uprev + β10 * dt * integrator.fsalfirst
-  k = f(u, p, t+c1*dt)
+  k = f(u, t+c1*dt, integrator)
   # u2
   u₂ = u + β21 * dt * k
-  k = f(u₂,p,t+c2*dt)
+  k = f(u₂, t+c2*dt, integrator)
   # u3
   tmp = u₂ + β32 * dt * k
-  k = f(tmp, p, t+c3*dt)
+  k = f(tmp, t+c3*dt, integrator)
   # u4
   tmp = α40 * uprev + α41 * u + α43 * tmp + β43 * dt * k
-  k = f(tmp, p, t+c4*dt)
+  k = f(tmp, t+c4*dt, integrator)
   # u5
   tmp = tmp + β54 * dt * k
-  k = f(tmp, p, t+c5*dt)
+  k = f(tmp, t+c5*dt, integrator)
   # u
   u = α62 * u₂ + α65 * tmp + β65 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 6
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -390,46 +390,46 @@ function initialize!(integrator,cache::SSPRK63Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK63Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,tmp,u₂,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack α40,α41,α43,α62,α65,β10,β21,β32,β43,β54,β65,c1,c2,c3,c4,c5 = cache.tab
 
   # u1 -> stored as u
   @.. u = uprev + β10 * dt * integrator.fsalfirst
   stage_limiter!(u, f, t+c1*dt)
-  f( k,  u, p, t+c1*dt)
+  f( k, u, t+c1*dt, integrator)
   # u2
   @.. u₂ = u + β21 * dt * k
   stage_limiter!(u₂, f, t+c2*dt)
-  f(k,u₂,p,t+c2*dt)
+  f(k, u₂, t+c2*dt, integrator)
   # u3
   @.. tmp = u₂ + β32 * dt * k
   stage_limiter!(tmp, f, t+c3*dt)
-  f( k,  tmp, p, t+c3*dt)
+  f( k, tmp, t+c3*dt, integrator)
   # u4
   @.. tmp = α40 * uprev + α41 * u + α43 * tmp + β43 * dt * k
   stage_limiter!(tmp, f, t+c4*dt)
-  f( k,  tmp, p, t+c4*dt)
+  f( k, tmp, t+c4*dt, integrator)
   # u5
   @.. tmp = tmp + β54 * dt * k
   stage_limiter!(tmp, f, t+c5*dt)
-  f( k,  tmp, p, t+c5*dt)
+  f( k, tmp, t+c5*dt, integrator)
   # u
   @.. u = α62 * u₂ + α65 * tmp + β65 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 6
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK73ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -440,31 +440,31 @@ function initialize!(integrator,cache::SSPRK73ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK73ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α40,α43,α50,α51,α54,α73,α76,β10,β21,β32,β43,β54,β65,β76,c1,c2,c3,c4,c5,c6 = cache
 
   # u1
   u₁ = uprev + β10 * dt * integrator.fsalfirst
-  k = f(u₁,p,t+c1*dt)
+  k = f(u₁, t+c1*dt, integrator)
   # u2
   tmp = u₁ + β21 * dt * k
-  k = f(tmp, p, t+c2*dt)
+  k = f(tmp, t+c2*dt, integrator)
   # u3 -> stored as u
   u = tmp + β32 * dt * k
-  k = f(u, p, t+c3*dt)
+  k = f(u, t+c3*dt, integrator)
   # u4
   tmp = α40 * uprev + α43 * u + β43 * dt * k
-  k = f(tmp, p, t+c4*dt)
+  k = f(tmp, t+c4*dt, integrator)
   # u5
   tmp = α50 * uprev + α51 * u₁ + α54 * tmp + β54 * dt * k
-  k = f(tmp, p, t+c5*dt)
+  k = f(tmp, t+c5*dt, integrator)
   # u6
   tmp = tmp + β65 * dt * k
-  k = f(tmp, p, t+c6*dt)
+  k = f(tmp, t+c6*dt, integrator)
   # u
   u = α73 * u + α76 * tmp + β76 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 7
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -477,50 +477,50 @@ function initialize!(integrator,cache::SSPRK73Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK73Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,tmp,u₁,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack α40,α43,α50,α51,α54,α73,α76,β10,β21,β32,β43,β54,β65,β76,c1,c2,c3,c4,c5,c6 = cache.tab
 
   # u1
   @.. u₁ = uprev + β10 * dt * integrator.fsalfirst
   stage_limiter!(u₁, f, t+c1*dt)
-  f(k,u₁,p,t+c1*dt)
+  f(k, u₁, t+c1*dt, integrator)
   # u2
   @.. tmp = u₁ + β21 * dt * k
   stage_limiter!(tmp, f, t+c2*dt)
-  f( k,  tmp, p, t+c2*dt)
+  f( k, tmp, t+c2*dt, integrator)
   # u3 -> stored as u
   @.. u = tmp + β32 * dt * k
   stage_limiter!(u, f, t+c3*dt)
-  f( k,  u, p, t+c3*dt)
+  f( k, u, t+c3*dt, integrator)
   # u4
   @.. tmp = α40 * uprev + α43 * u + β43 * dt * k
   stage_limiter!(tmp, f, t+c4*dt)
-  f( k,  tmp, p, t+c4*dt)
+  f( k, tmp, t+c4*dt, integrator)
   # u5
   @.. tmp = α50 * uprev + α51 * u₁ + α54 * tmp + β54 * dt * k
   stage_limiter!(tmp, f, t+c5*dt)
-  f( k,  tmp, p, t+c5*dt)
+  f( k, tmp, t+c5*dt, integrator)
   # u6
   @.. tmp = tmp + β65 * dt * k
   stage_limiter!(tmp, f, t+c6*dt)
-  f( k,  tmp, p, t+c6*dt)
+  f( k, tmp, t+c6*dt, integrator)
   # u
   @.. u = α73 * u + α76 * tmp + β76 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 7
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK83ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -531,34 +531,34 @@ function initialize!(integrator,cache::SSPRK83ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK83ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack α50,α51,α54,α61,α65,α72,α73,α76,β10,β21,β32,β43,β54,β65,β76,β87,c1,c2,c3,c4,c5,c6,c7 = cache
 
   # u1 -> save as u
   u = uprev + β10 * dt * integrator.fsalfirst
-  k = f(u, p, t+c1*dt)
+  k = f(u, t+c1*dt, integrator)
   # u2
   u₂ = u + β21 * dt * k
-  k = f(u₂,p,t+c2*dt)
+  k = f(u₂, t+c2*dt, integrator)
   # u3
   u₃ = u₂ + β32 * dt * k
-  k = f(u₃,p,t+c3*dt)
+  k = f(u₃, t+c3*dt, integrator)
   # u4
   tmp = u₃ + β43 * dt * k
-  k = f(tmp, p, t+c4*dt)
+  k = f(tmp, t+c4*dt, integrator)
   # u5
   tmp = α50 * uprev + α51 * u + α54 * tmp + β54 * dt * k
-  k = f(tmp, p, t+c5*dt)
+  k = f(tmp, t+c5*dt, integrator)
   # u6
   tmp = α61 * u + α65 * tmp + β65 * dt * k
-  k = f(tmp, p, t+c6*dt)
+  k = f(tmp, t+c6*dt, integrator)
   # u7
   tmp = α72 * u₂ + α73 * u₃ + α76 * tmp + β76 * dt * k
-  k = f(tmp, p, t+c7*dt)
+  k = f(tmp, t+c7*dt, integrator)
   # u
   u = tmp + β87 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 8
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -571,56 +571,56 @@ function initialize!(integrator,cache::SSPRK83Cache)
   integrator.kshortsize = 1
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK83Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,tmp,u₂,u₃,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack α50,α51,α54,α61,α65,α72,α73,α76,β10,β21,β32,β43,β54,β65,β76,β87,c1,c2,c3,c4,c5,c6,c7 = cache.tab
 
   # u1 -> save as u
   @.. u = uprev + β10 * dt * integrator.fsalfirst
   stage_limiter!(u, f, t+c1*dt)
-  f( k,  u, p, t+c1*dt)
+  f( k, u, t+c1*dt, integrator)
   # u2
   @.. u₂ = u + β21 * dt * k
   stage_limiter!(u₂, f, t+c2*dt)
-  f(k,u₂,p,t+c2*dt)
+  f(k, u₂, t+c2*dt, integrator)
   # u3
   @.. u₃ = u₂ + β32 * dt * k
   stage_limiter!(u₃, f, t+c3*dt)
-  f(k,u₃,p,t+c3*dt)
+  f(k, u₃, t+c3*dt, integrator)
   # u4
   @.. tmp = u₃ + β43 * dt * k
   stage_limiter!(tmp, f, t+c4*dt)
-  f( k,  tmp, p, t+c4*dt)
+  f( k, tmp, t+c4*dt, integrator)
   # u5
   @.. tmp = α50 * uprev + α51 * u + α54 * tmp + β54 * dt * k
   stage_limiter!(tmp, f, t+c5*dt)
-  f( k,  tmp, p, t+c5*dt)
+  f( k, tmp, t+c5*dt, integrator)
   # u6
   @.. tmp = α61 * u + α65 * tmp + β65 * dt * k
   stage_limiter!(tmp, f, t+c6*dt)
-  f( k,  tmp, p, t+c6*dt)
+  f( k, tmp, t+c6*dt, integrator)
   # u7
   @.. tmp = α72 * u₂ + α73 * u₃ + α76 * tmp + β76 * dt * k
   stage_limiter!(tmp, f, t+c7*dt)
-  f( k,  tmp, p, t+c7*dt)
+  f( k, tmp, t+c7*dt, integrator)
   # u
   @.. u = tmp + β87 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 8
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK432ConstantCache)
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -629,26 +629,26 @@ function initialize!(integrator,cache::SSPRK432ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK432ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   dt_2 = dt / 2
 
   # u1
   u = uprev + dt_2*integrator.fsalfirst
-  k = f(u, p, t+dt_2)
+  k = f(u, t+dt_2, integrator)
   # u2
   u = u + dt_2*k
-  k = f(u, p, t+dt)
+  k = f(u, t+dt, integrator)
   u = u + dt_2*k
   if integrator.opts.adaptive
     utilde = (uprev + 2*u) / 3
   end
   # u3
   u = (2*uprev + u) / 3
-  k = f(u, p, t+dt_2)
+  k = f(u, t+dt_2, integrator)
   # u
   u = u + dt_2*k
 
-  integrator.fsallast = f(u, p, t+dt)
+  integrator.fsallast = f(u, t+dt, integrator)
   integrator.destats.nf += 4
   if integrator.opts.adaptive
     utilde = utilde - u
@@ -665,23 +665,23 @@ function initialize!(integrator,cache::SSPRK432Cache)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK432Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,utilde,atmp,stage_limiter!,step_limiter! = cache
   dt_2 = dt / 2
 
   # u1
   @.. u = uprev + dt_2*fsalfirst
   stage_limiter!(u, f, t+dt_2)
-  f( k,  u, p, t+dt_2)
+  f( k, u, t+dt_2, integrator)
   # u2
   @.. u = u + dt_2*k
   stage_limiter!(u, f, t+dt)
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
   #
   @.. u = u + dt_2*k
   stage_limiter!(u, f, t+dt+dt_2)
@@ -690,7 +690,7 @@ end
   end
   # u3
   @.. u = (2*uprev + u) / 3
-  f( k,  u, p, t+dt_2)
+  f( k, u, t+dt_2, integrator)
   #
   @.. u = u + dt_2*k
   stage_limiter!(u, f, t+dt)
@@ -702,14 +702,14 @@ end
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
   integrator.destats.nf += 4
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRKMSVS32ConstantCache)
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -718,7 +718,7 @@ function initialize!(integrator,cache::SSPRKMSVS32ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRKMSVS32ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack u_1,u_2,dts,dtf,μ,v_n = cache
 
   if integrator.iter == 1
@@ -731,9 +731,9 @@ end
 
 
   if cache.step < 3 #starting Procedure
-    k = f(u,p,t+dt)
+    k = f(u, t+dt, integrator)
     u = uprev + dt*k
-    k = f(u, p, t+dt)
+    k = f(u, t+dt, integrator)
     integrator.destats.nf += 2
     u = (uprev + u + dt*k) / 2
       if cache.step == 1
@@ -775,12 +775,12 @@ end
     end
   end
   if accpt == true
-    integrator.fsallast = f(u, p, t+dt)
+    integrator.fsallast = f(u, t+dt, integrator)
     integrator.destats.nf += 1
     integrator.k[1] = integrator.fsalfirst
     integrator.u = u
   else
-    integrator.fsallast = f(uprev, p, t+dt)
+    integrator.fsallast = f(uprev, t+dt, integrator)
     integrator.destats.nf += 1
     integrator.k[1] = integrator.fsalfirst
     integrator.u = uprev
@@ -798,18 +798,18 @@ function initialize!(integrator,cache::SSPRKMSVS32Cache)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator)
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRKMSVS32Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,u_1,u_2,stage_limiter!,step_limiter! = cache
 
   if cache.step < 3
     @.. u = uprev + dt*fsalfirst
     stage_limiter!(u, f, t+dt)
-    f(k,u, p, t+dt)
+    f(k, u, t+dt, integrator)
     integrator.destats.nf += 1
     @.. u = (uprev + u + dt*k) / 2
     stage_limiter!(u, f, t+dt)
@@ -830,14 +830,14 @@ end
   end
   cache.step += 1
   integrator.destats.nf += 1
-  f(k,u, p, t+dt)
+  f(k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRKMSVS43ConstantCache)
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -846,26 +846,26 @@ function initialize!(integrator,cache::SSPRKMSVS43ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRKMSVS43ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack u_1,u_2,u_3,k1,k2,k3 = cache
 
   if cache.step < 4
     u = uprev + dt*integrator.fsalfirst
-    k = f(u, p, t+dt)
+    k = f(u, t+dt, integrator)
     u = (uprev + u + dt*k) / 2
       if cache.step == 1
         u_3 = uprev
-        cache.k3 = f(u_3,p,t+dt)
+        cache.k3 = f(u_3, t+dt, integrator)
         integrator.destats.nf += 1
       end
       if cache.step == 2
         u_2 = uprev
-        cache.k2 = f(u_2,p,t+dt)
+        cache.k2 = f(u_2, t+dt, integrator)
         integrator.destats.nf += 1
       end
       if cache.step == 3
         u_1 = uprev
-        cache.k1 = f(u_1,p,t+dt)
+        cache.k1 = f(u_1, t+dt, integrator)
         integrator.destats.nf += 1
       end
   # u
@@ -878,7 +878,7 @@ end
     u_2 = u_1
     u_1 = uprev
   end
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 1
   integrator.k[1] = integrator.fsalfirst
   integrator.u = u
@@ -894,36 +894,36 @@ function initialize!(integrator,cache::SSPRKMSVS43Cache)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 
 @muladd function perform_step!(integrator,cache::SSPRKMSVS43Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,u_1,u_2,u_3,stage_limiter!,step_limiter!,k1,k2,k3 = cache
 
   if cache.step < 4
     @.. u = uprev + dt*fsalfirst
     stage_limiter!(u, f, t+dt)
-    f(k,u, p, t+dt)
+    f(k, u, t+dt, integrator)
     integrator.destats.nf += 1
     @.. u = (uprev + u + dt*k) / 2
     stage_limiter!(u, f, t+dt)
     step_limiter!(u, f, t+dt)
     if cache.step == 1
       cache.u_3 .= uprev
-      f(k3,u_3,p,t+dt)
+      f(k3, u_3, t+dt, integrator)
       integrator.destats.nf += 1
     end
     if cache.step == 2
       cache.u_2 .= uprev
-      f(k2,u_2,p,t+dt)
+      f(k2, u_2, t+dt, integrator)
       integrator.destats.nf += 1
     end
     if cache.step == 3
       cache.u_1 .= uprev
-      f(k1,u_1,p,t+dt)
+      f(k1, u_1, t+dt, integrator)
       integrator.destats.nf += 1
     end
   # u
@@ -940,14 +940,14 @@ end
   end
   cache.step += 1
   integrator.destats.nf += 1
-  f( k, u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK932ConstantCache)
   integrator.kshortsize = 1
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 
   # Avoid undefined entries if k is an array of arrays
@@ -956,47 +956,47 @@ function initialize!(integrator,cache::SSPRK932ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK932ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   dt_6 = dt / 6
   dt_3 = dt / 3
   dt_2 = dt / 2
 
   # u1
   u = uprev + dt_6*integrator.fsalfirst
-  k = f(u, p, t+dt_6)
+  k = f(u, t+dt_6, integrator)
   # u2
   u = u + dt_6*k
-  k = f(u, p, t+dt_3)
+  k = f(u, t+dt_3, integrator)
   # u3
   u = u + dt_6*k
-  k = f(u, p, t+dt_2)
+  k = f(u, t+dt_2, integrator)
   # u4
   u = u + dt_6*k
-  k = f(u, p, t+2*dt_3)
+  k = f(u, t+2*dt_3, integrator)
   # u5
   u = u + dt_6*k
-  k = f(u, p, t+5*dt_6)
+  k = f(u, t+5*dt_6, integrator)
   integrator.destats.nf += 5
   # u6
   u = u + dt_6*k
   if integrator.opts.adaptive
-    k = f(u, p, t+dt)
+    k = f(u, t+dt, integrator)
     integrator.destats.nf += 1
     utilde = (uprev + 6*u + 6*dt*k) / 7
   end
   # u6*
   u = (3*uprev + dt_2*integrator.fsalfirst + 2*u) / 5
-  k = f(u, p, t+dt_2)
+  k = f(u, t+dt_2, integrator)
   # u7*
   u = u + dt_6*k
-  k = f(u, p, t+2*dt_3)
+  k = f(u, t+2*dt_3, integrator)
   # u8*
   u = u + dt_6*k
-  k = f(u, p, t+5*dt_6)
+  k = f(u, t+5*dt_6, integrator)
   # u
   u = u + dt_6*k
 
-  integrator.fsallast = f(u, p, t+dt)
+  integrator.fsallast = f(u, t+dt, integrator)
   integrator.destats.nf += 4
   if integrator.opts.adaptive
     utilde = utilde - u
@@ -1013,12 +1013,12 @@ function initialize!(integrator,cache::SSPRK932Cache)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
   integrator.k[1] = integrator.fsalfirst
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK932Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,fsalfirst,utilde,atmp,stage_limiter!,step_limiter! = cache
   dt_6 = dt / 6
   dt_3 = dt / 3
@@ -1027,29 +1027,29 @@ end
   # u1
   @.. u = uprev + dt_6*fsalfirst
   stage_limiter!(u, f, t+dt_6)
-  f( k,  u, p, t+dt_6)
+  f( k, u, t+dt_6, integrator)
   # u2
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+dt_3)
-  f( k,  u, p, t+dt_3)
+  f( k, u, t+dt_3, integrator)
   # u3
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+dt_2)
-  f( k,  u, p, t+dt_2)
+  f( k, u, t+dt_2, integrator)
   # u4
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+2*dt_3)
-  f( k,  u, p, t+2*dt_3)
+  f( k, u, t+2*dt_3, integrator)
   # u5
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+5*dt_6)
-  f( k,  u, p, t+5*dt_6)
+  f( k, u, t+5*dt_6, integrator)
   integrator.destats.nf += 5
   # u6
   @.. u = u + dt_6*k
   if integrator.opts.adaptive
     stage_limiter!(u, f, t+dt)
-    f( k,  u, p, t+dt)
+    f( k, u, t+dt, integrator)
     integrator.destats.nf += 1
     @.. utilde = (uprev + 6*u + 6*dt*k) / 7
     stage_limiter!(utilde, f, t+dt)
@@ -1057,15 +1057,15 @@ end
   # u6*
   @.. u = (3*uprev + dt_2*fsalfirst + 2*u) / 5
   stage_limiter!(u, f, t+dt_6)
-  f( k,  u, p, t+dt_2)
+  f( k, u, t+dt_2, integrator)
   # u7*
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+2*dt_3)
-  f( k,  u, p, t+2*dt_3)
+  f( k, u, t+2*dt_3, integrator)
   # u8*
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+5*dt_6)
-  f( k,  u, p, t+5*dt_6)
+  f( k, u, t+5*dt_6, integrator)
   # u9*
   @.. u = u + dt_6*k
   stage_limiter!(u, f, t+dt)
@@ -1077,12 +1077,12 @@ end
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
   integrator.destats.nf += 4
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK54ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -1094,25 +1094,25 @@ function initialize!(integrator,cache::SSPRK54ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK54ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack β10,α20,α21,β21,α30,α32,β32,α40,α43,β43,α52,α53,β53,α54,β54,c1,c2,c3,c4 = cache
 
   # u₁
   u₂ = uprev + β10 * dt * integrator.fsalfirst
-  k = f(u₂,p,t+c1*dt)
+  k = f(u₂, t+c1*dt, integrator)
   # u₂
   u₂ = α20 * uprev + α21 * u₂ + β21 * dt * k
-  k = f(u₂,p,t+c2*dt)
+  k = f(u₂, t+c2*dt, integrator)
   # u₃
   u₃ = α30 * uprev + α32 * u₂ + β32 * dt * k
-  k₃ = f(u₃,p,t+c3*dt)
+  k₃ = f(u₃, t+c3*dt, integrator)
   # u₄ -> stored as tmp
   tmp = α40 * uprev + α43 * u₃ + β43 * dt * k₃
-  k = f(tmp, p, t+c4*dt)
+  k = f(tmp, t+c4*dt, integrator)
   # u
   u = α52 * u₂ + α53 * u₃ + β53 * dt * k₃ + α54 * tmp + β54 * dt * k
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 5
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -1127,42 +1127,42 @@ function initialize!(integrator,cache::SSPRK54Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK54Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,k₃,u₂,u₃,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
   @unpack β10,α20,α21,β21,α30,α32,β32,α40,α43,β43,α52,α53,β53,α54,β54,c1,c2,c3,c4 = cache.tab
 
   # u₁
   @.. u₂ = uprev + β10 * dt * integrator.fsalfirst
   stage_limiter!(u₂, f, t+c1*dt)
-  f(k,u₂,p,t+c1*dt)
+  f(k, u₂, t+c1*dt, integrator)
   # u₂
   @.. u₂ = α20 * uprev + α21 * u₂ + β21 * dt * k
   stage_limiter!(u₂, f, t+c2*dt)
-  f(k,u₂,p,t+c2*dt)
+  f(k, u₂, t+c2*dt, integrator)
   # u₃
   @.. u₃ = α30 * uprev + α32 * u₂ + β32 * dt * k
   stage_limiter!(u₃, f, t+c3*dt)
-  f(k₃,u₃,p,t+c3*dt)
+  f(k₃, u₃, t+c3*dt, integrator)
   # u₄ -> stored as tmp
   @.. tmp = α40 * uprev + α43 * u₃ + β43 * dt * k₃
   stage_limiter!(tmp, f, t+c4*dt)
-  f( k,  tmp, p, t+c4*dt)
+  f( k, tmp, t+c4*dt, integrator)
   # u
   @.. u = α52 * u₂ + α53 * u₃ + β53 * dt * k₃ + α54 * tmp + β54 * dt * k
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 5
-  f( k,  u, p, t+dt)
+  f( k, u, t+dt, integrator)
 end
 
 
 function initialize!(integrator,cache::SSPRK104ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
@@ -1174,32 +1174,32 @@ function initialize!(integrator,cache::SSPRK104ConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK104ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   dt_6 = dt/6
   dt_3 = dt/3
   dt_2 = dt/2
 
   tmp = uprev + dt_6 * integrator.fsalfirst # u₁
-  k = f(tmp, p, t+dt_6)
+  k = f(tmp, t+dt_6, integrator)
   tmp = tmp + dt_6 * k # u₂
-  k = f(tmp, p, t+dt_3)
+  k = f(tmp, t+dt_3, integrator)
   tmp = tmp + dt_6 * k # u₃
-  k = f(tmp, p, t+dt_2)
+  k = f(tmp, t+dt_2, integrator)
   u = tmp + dt_6 * k # u₄
-  k₄ = f(u, p, t+2*dt_3)
+  k₄ = f(u, t+2*dt_3, integrator)
   tmp = (3*uprev + 2*u + dt_3 * k₄) / 5 # u₅
-  k = f(tmp, p, t+dt_3)
+  k = f(tmp, t+dt_3, integrator)
   tmp = tmp + dt_6 * k # u₆
-  k = f(tmp, p, t+dt_2)
+  k = f(tmp, t+dt_2, integrator)
   tmp = tmp + dt_6 * k # u₇
-  k = f(tmp, p, t+2*dt_3)
+  k = f(tmp, t+2*dt_3, integrator)
   tmp = tmp + dt_6 * k # u₈
-  k = f(tmp, p, t+5*dt_6)
+  k = f(tmp, t+5*dt_6, integrator)
   tmp = tmp + dt_6 * k # u₉
-  k = f(tmp, p, t+dt)
+  k = f(tmp, t+dt, integrator)
   u = (uprev + 9*(u + dt_6*k₄) + 15*(tmp + dt_6*k)) / 25
 
-  integrator.fsallast = f(u, p, t+dt) # For interpolation, then FSAL'd
+  integrator.fsallast = f(u, t+dt, integrator) # For interpolation, then FSAL'd
   integrator.destats.nf += 10
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -1214,12 +1214,12 @@ function initialize!(integrator,cache::SSPRK104Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
-  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # FSAL for interpolation
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator,cache::SSPRK104Cache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack k,k₄,tmp,fsalfirst,stage_limiter!,step_limiter! = cache
   dt_6 = dt/6
   dt_3 = dt/3
@@ -1227,34 +1227,34 @@ end
 
   @.. tmp = uprev + dt_6 * integrator.fsalfirst
   stage_limiter!(tmp, f, t+dt_6)
-  f( k,  tmp, p, t+dt_6)
+  f( k, tmp, t+dt_6, integrator)
   @.. tmp = tmp + dt_6 * k
   stage_limiter!(tmp, f, t+dt_3)
-  f( k,  tmp, p, t+dt_3)
+  f( k, tmp, t+dt_3, integrator)
   @.. tmp = tmp + dt_6 * k
   stage_limiter!(tmp, f, t+dt_2)
-  f( k,  tmp, p, t+dt_2)
+  f( k, tmp, t+dt_2, integrator)
   @.. u = tmp + dt_6 * k
   stage_limiter!(u, f, t+2*dt_3)
-  f(k₄,u,p,t+2*dt_3)
+  f(k₄, u, t+2*dt_3, integrator)
   @.. tmp = (3*uprev + 2*u + 2*dt_6 * k₄) / 5
   stage_limiter!(tmp, f, t+dt_3)
-  f( k,  tmp, p, t+dt_3)
+  f( k, tmp, t+dt_3, integrator)
   @.. tmp = tmp + dt_6 * k
   stage_limiter!(tmp, f, t+dt_2)
-  f( k,  tmp, p, t+dt_2)
+  f( k, tmp, t+dt_2, integrator)
   @.. tmp = tmp + dt_6 * k
   stage_limiter!(tmp, f, t+2*dt_3)
-  f( k,  tmp, p, t+2*dt_3)
+  f( k, tmp, t+2*dt_3, integrator)
   @.. tmp = tmp + dt_6 * k
   stage_limiter!(tmp, f, t+5*dt_6)
-  f( k,  tmp, p, t+5*dt_6)
+  f( k, tmp, t+5*dt_6, integrator)
   @.. tmp = tmp + dt_6 * k
   stage_limiter!(tmp, f, t+dt)
-  f( k,  tmp, p, t+dt)
+  f( k, tmp, t+dt, integrator)
   @.. u = (uprev + 9*(u + dt_6*k₄) + 15*(tmp + dt_6*k)) / 25
   stage_limiter!(u, f, t+dt)
   step_limiter!(u, f, t+dt)
   integrator.destats.nf += 10
-  f(k, u, p, t+dt)
+  f(k, u, t+dt, integrator)
 end

--- a/src/perform_step/symplectic_perform_step.jl
+++ b/src/perform_step/symplectic_perform_step.jl
@@ -7,10 +7,10 @@ function initialize!(integrator,cache::SymplecticEulerConstantCache)
   # So that way FSAL interpolation
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
-  kdu = integrator.f.f1(duprev,uprev,integrator.p,integrator.t)
-  kuprev = integrator.f.f2(duprev,uprev,integrator.p,integrator.t)
+  kdu = integrator.f.f1(duprev, uprev, integrator.t, integrator)
+  kuprev = integrator.f.f2(duprev, uprev, integrator.t, integrator)
   @muladd du = duprev + integrator.dt*kdu
-  ku = integrator.f.f2(du,uprev,integrator.p,integrator.t)
+  ku = integrator.f.f2(du, uprev, integrator.t, integrator)
   integrator.destats.nf2 += 1
   integrator.destats.nf += 2
   integrator.fsalfirst = ArrayPartition((kdu,kuprev))
@@ -18,15 +18,15 @@ function initialize!(integrator,cache::SymplecticEulerConstantCache)
 end
 
 @muladd function perform_step!(integrator,cache::SymplecticEulerConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   kuprev = integrator.fsalfirst.x[2]
   u = uprev + dt*kuprev
   # Now actually compute the step
   # Do it at the end for interpolations!
-  kdu = f.f1(duprev,u,p,t)
+  kdu = f.f1(duprev, u, t, integrator)
   du = duprev + dt*kdu
-  ku = f.f2(du,u,p,t)
+  ku = f.f2(du, u, t, integrator)
   integrator.destats.nf2 += 1
   integrator.destats.nf += 1
 
@@ -50,16 +50,16 @@ function initialize!(integrator,cache::SymplecticEulerCache)
   du,u = integrator.u.x
   kuprev = integrator.fsalfirst.x[2]
   kdu,ku = integrator.fsallast.x
-  integrator.f.f1(kdu,duprev,uprev,integrator.p,integrator.t)
-  integrator.f.f2(kuprev,duprev,uprev,integrator.p,integrator.t)
+  integrator.f.f1(kdu, duprev, uprev, integrator.t, integrator)
+  integrator.f.f2(kuprev, duprev, uprev, integrator.t, integrator)
   @muladd @.. du = duprev + integrator.dt*kdu
-  integrator.f.f2(ku,du,uprev,integrator.p,integrator.t)
+  integrator.f.f2(ku, du, uprev, integrator.t, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 2
 end
 
 @muladd function perform_step!(integrator,cache::SymplecticEulerCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
   kuprev = integrator.fsalfirst.x[2]
@@ -69,9 +69,9 @@ end
   # Do it at the end for interpolations!
   integrator.destats.nf2 += 1
   integrator.destats.nf += 1
-  f.f1(kdu,duprev,u,p,t)
+  f.f1(kdu, duprev, u, t, integrator)
   @.. du = duprev + dt*kdu
-  f.f2(ku,du,u,p,t)
+  f.f2(ku, du, u, t, integrator)
 end
 
 function initialize!(integrator,cache::C) where
@@ -87,8 +87,8 @@ function initialize!(integrator,cache::C) where
   integrator.k[2] = integrator.fsallast
 
   duprev,uprev = integrator.uprev.x
-  integrator.f.f1(integrator.k[2].x[1],duprev,uprev,integrator.p,integrator.t)
-  integrator.f.f2(integrator.k[2].x[2],duprev,uprev,integrator.p,integrator.t)
+  integrator.f.f1(integrator.k[2].x[1], duprev, uprev, integrator.t, integrator)
+  integrator.f.f2(integrator.k[2].x[2], duprev, uprev, integrator.t, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 1
 end
@@ -103,22 +103,22 @@ function initialize!(integrator,cache::C) where
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
   duprev,uprev = integrator.uprev.x
-  kdu  = integrator.f.f1(duprev,uprev,integrator.p,integrator.t)
-  ku = integrator.f.f2(duprev,uprev,integrator.p,integrator.t)
+  kdu  = integrator.f.f1(duprev, uprev, integrator.t, integrator)
+  ku = integrator.f.f2(duprev, uprev, integrator.t, integrator)
   integrator.destats.nf += 1
   integrator.destats.nf2 += 1
   integrator.fsalfirst = ArrayPartition((kdu,ku))
 end
 
 @muladd function perform_step!(integrator,cache::VelocityVerletConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   # x(t+Δt) = x(t) + v(t)*Δt + 1/2*a(t)*Δt^2
-  ku = f.f1(duprev,uprev,p,t)
+  ku = f.f1(duprev, uprev, t, integrator)
   dtsq = dt^2
   half = cache.half
   u = uprev + dt*duprev + dtsq*(half*ku)
-  kdu = f.f1(duprev,u,p,t+dt)
+  kdu = f.f1(duprev, u, t+dt, integrator)
   integrator.destats.nf += 2
   # v(t+Δt) = v(t) + 1/2*(a(t)+a(t+Δt))*Δt
   du = duprev + dt*(half*ku + half*kdu)
@@ -130,16 +130,16 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::VelocityVerletCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
   kdu, ku = integrator.cache.tmp.x[1], integrator.cache.tmp.x[2]
   # x(t+Δt) = x(t) + v(t)*Δt + 1/2*a(t)*Δt^2
-  f.f1(ku,duprev,uprev,p,t)
+  f.f1(ku, duprev, uprev, t, integrator)
   dtsq = dt^2
   half = cache.half
   @.. u = uprev + dt*duprev + dtsq*(half*ku)
-  f.f1(kdu,duprev,u,p,t+dt)
+  f.f1(kdu, duprev, u, t+dt, integrator)
   integrator.destats.nf += 2
   # v(t+Δt) = v(t) + 1/2*(a(t)+a(t+Δt))*Δt
   @.. du = duprev + dt*(half*ku + half*kdu)
@@ -150,20 +150,20 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic2ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,b1,b2 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,t)
+  kdu = f.f1(duprev, u, t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
   integrator.destats.nf += 2
   integrator.destats.nf2 += 1
@@ -175,7 +175,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic2Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,b1,b2 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -183,14 +183,14 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,t)
+  f.f1(kdu, duprev, u, t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
   integrator.destats.nf += 2
   integrator.destats.nf2 += 1
@@ -201,28 +201,28 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic3ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,b1,b2,b3 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   integrator.destats.nf += 3
   integrator.destats.nf2 += 2
   du = du + dt*a3*kdu
@@ -233,7 +233,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic3Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,b1,b2,b3 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -241,22 +241,22 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
   integrator.destats.nf += 3
   integrator.destats.nf2 += 2
@@ -267,36 +267,36 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic4ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,b1,b2,b3,b4 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,t)
+  kdu = f.f1(duprev, u, t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
   integrator.destats.nf += 4
   integrator.destats.nf2 += 3 
@@ -307,7 +307,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic4Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,b1,b2,b3,b4 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -315,30 +315,30 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,t)
+  f.f1(kdu, duprev, u, t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
   integrator.destats.nf += 4
   integrator.destats.nf2 += 3
@@ -349,44 +349,44 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic45ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,b1,b2,b3,b4,b5 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,t)
+  kdu = f.f1(duprev, u, t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   integrator.destats.nf += 5
   integrator.destats.nf2 += 4
   if typeof(integrator.alg) <: McAte42
@@ -399,7 +399,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic45Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,b1,b2,b3,b4,b5 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -407,38 +407,38 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,t)
+  f.f1(kdu, duprev, u, t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   integrator.destats.nf += 5
   integrator.destats.nf2 += 4
   if typeof(integrator.alg) <: McAte42
@@ -451,51 +451,51 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic5ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,b1,b2,b3,b4,b5,b6 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a5*kdu
 
   tnew = tnew + t+a5*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b6*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a6*kdu
   integrator.destats.nf += 6
   integrator.destats.nf2 += 5
@@ -506,7 +506,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic5Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,b1,b2,b3,b4,b5,b6 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -514,45 +514,45 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a5*kdu
 
   tnew = tnew + t+a5*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b6*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a6*kdu
   integrator.destats.nf += 6
   integrator.destats.nf2 += 5
@@ -563,65 +563,65 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic6ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,b1,b2,b3,b4,b5,b6,b7,b8 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b6*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b7*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b8*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   # @.. du = du + dt*a8*kdu
   integrator.destats.nf += 8
   integrator.destats.nf2 += 7
@@ -632,7 +632,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic6Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,b1,b2,b3,b4,b5,b6,b7,b8 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -640,59 +640,59 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b6*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b7*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b8*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   # @.. du = du + dt*a8*kdu
   integrator.destats.nf += 8
   integrator.destats.nf2 += 7
@@ -703,79 +703,79 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic62ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b6*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b7*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b8*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b9*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b10*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   # @.. du = du + dt*a10*kdu
   integrator.destats.nf += 10
   integrator.destats.nf2 += 9
@@ -786,7 +786,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::Symplectic62Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10 = cache.tab
   duprev,uprev = integrator.uprev.x
   du,u = integrator.u.x
@@ -794,73 +794,73 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b6*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b7*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b8*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b9*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b10*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   # @.. du = du + dt*a10*kdu
   integrator.destats.nf += 10
   integrator.destats.nf2 += 9
@@ -871,122 +871,122 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::McAte8ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,
           b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b6*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b7*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b8*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b9*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b10*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a10*kdu
 
   tnew = tnew + a10*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b11*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a11*kdu
 
   tnew = tnew + a11*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b12*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a12*kdu
 
   tnew = tnew + a12*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b13*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a13*kdu
 
   tnew = tnew + a13*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b14*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a14*kdu
 
   tnew = tnew + a14*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b15*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a15*kdu
 
   tnew = tnew + a15*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b16*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   # @.. du = du + dt*a16*kdu
   integrator.destats.nf += 16
   integrator.destats.nf2 += 15
@@ -997,7 +997,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::McAte8Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,
           b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16 = cache.tab
   duprev,uprev = integrator.uprev.x
@@ -1006,115 +1006,115 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b6*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b7*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b8*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b9*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b10*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a10*kdu
 
   tnew = tnew + a10*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b11*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a11*kdu
 
   tnew = tnew + a11*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b12*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a12*kdu
 
   tnew = tnew + a12*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b13*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a13*kdu
 
   tnew = tnew + a13*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b14*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a14*kdu
 
   tnew = tnew + a14*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b15*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a15*kdu
 
   tnew = tnew + a15*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b16*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   # @.. du = du + dt*a16*kdu
   integrator.destats.nf += 16
   integrator.destats.nf2 += 15
@@ -1125,136 +1125,136 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::KahanLi8ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,
           b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18 = cache
   duprev,uprev = integrator.uprev.x
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b6*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b7*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b8*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b9*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b10*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a10*kdu
 
   tnew = tnew + a10*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b11*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a11*kdu
 
   tnew = tnew + a11*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b12*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a12*kdu
 
   tnew = tnew + a12*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b13*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a13*kdu
 
   tnew = tnew + a13*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b14*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a14*kdu
 
   tnew = tnew + a14*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b15*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a15*kdu
 
   tnew = tnew + a15*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b16*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a16*kdu
 
   tnew = tnew + a16*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b17*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a17*kdu
 
   tnew = tnew + a17*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b18*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   # @.. du = du + dt*a18*kdu
   integrator.destats.nf += 18
   integrator.destats.nf2 += 17
@@ -1265,7 +1265,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::KahanLi8Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,
           b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15,b16,b17,b18 = cache.tab
   duprev,uprev = integrator.uprev.x
@@ -1274,129 +1274,129 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b6*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b7*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b8*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b9*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b10*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a10*kdu
 
   tnew = tnew + a10*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b11*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a11*kdu
 
   tnew = tnew + a11*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b12*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a12*kdu
 
   tnew = tnew + a12*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b13*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a13*kdu
 
   tnew = tnew + a13*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b14*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a14*kdu
 
   tnew = tnew + a14*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b15*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a15*kdu
 
   tnew = tnew + a15*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b16*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a16*kdu
 
   tnew = tnew + a16*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b17*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a17*kdu
 
   tnew = tnew + a17*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b18*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   # @.. du = du + dt*a18*kdu
   integrator.destats.nf += 18
   integrator.destats.nf2 += 17
@@ -1407,7 +1407,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::SofSpa10ConstantCache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,
           a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,
           a35,a36,
@@ -1418,255 +1418,255 @@ end
   # update position
   u = uprev + dt*b1*duprev
   # update velocity
-  kdu = f.f1(duprev,u,p,integrator.t)
+  kdu = f.f1(duprev, u, integrator.t, integrator)
   du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b2*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b3*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b4*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b5*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b6*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b7*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b8*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b9*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b10*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a10*kdu
 
   tnew = tnew + a10*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b11*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a11*kdu
 
   tnew = tnew + a11*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b12*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a12*kdu
 
   tnew = tnew + a12*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b13*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a13*kdu
 
   tnew = tnew + a13*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b14*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a14*kdu
 
   tnew = tnew + a14*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b15*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a15*kdu
 
   tnew = tnew + a15*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b16*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a16*kdu
 
   tnew = tnew + a16*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b17*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a17*kdu
 
   tnew = tnew + a17*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b18*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a18*kdu
 
   tnew = tnew + a18*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b19*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a19*kdu
 
   tnew = tnew + a19*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b20*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a20*kdu
 
   tnew = tnew + a20*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b21*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a21*kdu
 
   tnew = tnew + a21*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b22*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a22*kdu
 
   tnew = tnew + a22*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b23*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a23*kdu
 
   tnew = tnew + a23*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b24*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a24*kdu
 
   tnew = tnew + a24*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b25*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a25*kdu
 
   tnew = tnew + a25*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b26*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a26*kdu
 
   tnew = tnew + a26*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b27*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a27*kdu
 
   tnew = tnew + a27*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b28*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a28*kdu
 
   tnew = tnew + a28*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b29*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a29*kdu
 
   tnew = tnew + a29*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b30*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a30*kdu
 
   tnew = tnew + a30*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b31*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a31*kdu
 
   tnew = tnew + a31*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b32*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a32*kdu
 
   tnew = tnew + a32*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b33*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a33*kdu
 
   tnew = tnew + a33*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b34*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a34*kdu
 
   tnew = tnew + a34*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b35*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   du = du + dt*a35*kdu
 
   tnew = tnew + a35*dt
-  ku = f.f2(du,u,p,tnew)
+  ku = f.f2(du, u, tnew, integrator)
   u = u + dt*b36*ku
 
-  kdu = f.f1(du,u,p,tnew)
+  kdu = f.f1(du, u, tnew, integrator)
   # @.. du = du + dt*a30*kdu
   integrator.destats.nf += 36
   integrator.destats.nf2 += 35
@@ -1677,7 +1677,7 @@ end
 end
 
 @muladd function perform_step!(integrator,cache::SofSpa10Cache,repeat_step=false)
-  @unpack t,dt,f,p = integrator
+  @unpack t,dt,f = integrator
   @unpack a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,
           a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,
           a35,a36,
@@ -1690,255 +1690,255 @@ end
   # update position
   @.. u = uprev + dt*b1*duprev
   # update velocity
-  f.f1(kdu,duprev,u,p,integrator.t)
+  f.f1(kdu, duprev, u, integrator.t, integrator)
   @.. du = duprev + dt*a1*kdu
   # update position & velocity
   tnew = t+a1*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b2*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a2*kdu
 
   # update position & velocity
   tnew = tnew + a2*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b3*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a3*kdu
 
   # update position & velocity
   tnew = tnew + a3*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b4*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a4*kdu
 
   # update position & velocity
   tnew = tnew + a4*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b5*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a5*kdu
 
   tnew = tnew + a5*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b6*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a6*kdu
 
   tnew = tnew + a6*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b7*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a7*kdu
 
   tnew = tnew + a7*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b8*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a8*kdu
 
   tnew = tnew + a8*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b9*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a9*kdu
 
   tnew = tnew + a9*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b10*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a10*kdu
 
   tnew = tnew + a10*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b11*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a11*kdu
 
   tnew = tnew + a11*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b12*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a12*kdu
 
   tnew = tnew + a12*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b13*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a13*kdu
 
   tnew = tnew + a13*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b14*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a14*kdu
 
   tnew = tnew + a14*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b15*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a15*kdu
 
   tnew = tnew + a15*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b16*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a16*kdu
 
   tnew = tnew + a16*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b17*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a17*kdu
 
   tnew = tnew + a17*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b18*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a18*kdu
 
   tnew = tnew + a18*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b19*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a19*kdu
 
   tnew = tnew + a19*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b20*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a20*kdu
 
   tnew = tnew + a20*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b21*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a21*kdu
 
   tnew = tnew + a21*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b22*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a22*kdu
 
   tnew = tnew + a22*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b23*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a23*kdu
 
   tnew = tnew + a23*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b24*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a24*kdu
 
   tnew = tnew + a24*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b25*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a25*kdu
 
   tnew = tnew + a25*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b26*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a26*kdu
 
   tnew = tnew + a26*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b27*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a27*kdu
 
   tnew = tnew + a27*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b28*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a28*kdu
 
   tnew = tnew + a28*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b29*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a29*kdu
 
   tnew = tnew + a29*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b30*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a30*kdu
 
   tnew = tnew + a30*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b31*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a31*kdu
 
   tnew = tnew + a31*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b32*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a32*kdu
 
   tnew = tnew + a32*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b33*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a33*kdu
 
   tnew = tnew + a33*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b34*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a34*kdu
 
   tnew = tnew + a34*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b35*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   @.. du = du + dt*a35*kdu
 
   tnew = tnew + a35*dt
-  f.f2(ku,du,u,p,tnew)
+  f.f2(ku, du, u, tnew, integrator)
   @.. u = u + dt*b36*ku
 
-  f.f1(kdu,du,u,p,tnew)
+  f.f1(kdu, du, u, tnew, integrator)
   # @.. du = du + dt*a30*kdu
   integrator.destats.nf += 36
   integrator.destats.nf2 += 35

--- a/src/perform_step/verner_rk_perform_step.jl
+++ b/src/perform_step/verner_rk_perform_step.jl
@@ -1,5 +1,5 @@
 function initialize!(integrator, cache::Vern6ConstantCache)
-  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
   alg = unwrap_alg(integrator, false)
   alg.lazy ? (integrator.kshortsize = 9) : (integrator.kshortsize = 12)
@@ -21,20 +21,20 @@ function initialize!(integrator, cache::Vern6ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern6ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a94,a95,a96,a97,a98,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9 = cache
   k1 = integrator.fsalfirst
   a = dt*a21
-  k2 = f(uprev+a*k1, p, t + c1*dt)
-  k3 = f(uprev+dt*(a31*k1+a32*k2), p, t + c2*dt)
-  k4 = f(uprev+dt*(a41*k1       +a43*k3), p, t + c3*dt)
-  k5 = f(uprev+dt*(a51*k1       +a53*k3+a54*k4), p, t + c4*dt)
-  k6 = f(uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5), p, t + c5*dt)
-  k7 = f(uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6), p, t + c6*dt)
+  k2 = f(uprev+a*k1, t + c1*dt, integrator)
+  k3 = f(uprev+dt*(a31*k1+a32*k2), t + c2*dt, integrator)
+  k4 = f(uprev+dt*(a41*k1       +a43*k3), t + c3*dt, integrator)
+  k5 = f(uprev+dt*(a51*k1       +a53*k3+a54*k4), t + c4*dt, integrator)
+  k6 = f(uprev+dt*(a61*k1       +a63*k3+a64*k4+a65*k5), t + c5*dt, integrator)
+  k7 = f(uprev+dt*(a71*k1       +a73*k3+a74*k4+a75*k5+a76*k6), t + c6*dt, integrator)
   g8 =   uprev+dt*(a81*k1       +a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
-  k8 = f(g8, p, t+dt)
+  k8 = f(g8, t+dt, integrator)
   u = uprev+dt*(a91*k1              +a94*k4+a95*k5+a96*k6+a97*k7+a98*k8)
-  integrator.fsallast = f(u, p, t+dt); k9 = integrator.fsallast
+  integrator.fsallast = f(u, t+dt, integrator); k9 = integrator.fsallast
   integrator.destats.nf += 8
   if typeof(integrator.alg) <: CompositeAlgorithm
     g9 = u
@@ -57,9 +57,9 @@ end
   if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
     k = integrator.k
     @unpack c10,a1001,a1004,a1005,a1006,a1007,a1008,a1009,c11,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,c12,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache
-    k[10] = f(uprev+dt*(a1001*k[1]+a1004*k[4]+a1005*k[5]+a1006*k[6]+a1007*k[7]+a1008*k[8]+a1009*k[9]),p,t+c10*dt)
-    k[11] = f(uprev+dt*(a1101*k[1]+a1104*k[4]+a1105*k[5]+a1106*k[6]+a1107*k[7]+a1108*k[8]+a1109*k[9]+a1110*k[10]),p,t+c11*dt)
-    k[12] = f(uprev+dt*(a1201*k[1]+a1204*k[4]+a1205*k[5]+a1206*k[6]+a1207*k[7]+a1208*k[8]+a1209*k[9]+a1210*k[10]+a1211*k[11]),p,t+c12*dt)
+    k[10] = f(uprev+dt*(a1001*k[1]+a1004*k[4]+a1005*k[5]+a1006*k[6]+a1007*k[7]+a1008*k[8]+a1009*k[9]), t+c10*dt, integrator)
+    k[11] = f(uprev+dt*(a1101*k[1]+a1104*k[4]+a1105*k[5]+a1106*k[6]+a1107*k[7]+a1108*k[8]+a1109*k[9]+a1110*k[10]), t+c11*dt, integrator)
+    k[12] = f(uprev+dt*(a1201*k[1]+a1204*k[4]+a1205*k[5]+a1206*k[6]+a1207*k[7]+a1208*k[8]+a1209*k[9]+a1210*k[10]+a1211*k[11]), t+c12*dt, integrator)
     integrator.destats.nf += 3
   end
 
@@ -82,32 +82,32 @@ function initialize!(integrator, cache::Vern6Cache)
     k[12] = similar(cache.k1)
   end
 
-  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst, integrator.uprev, integrator.t, integrator) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
 @muladd function perform_step!(integrator, cache::Vern6Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a94,a95,a96,a97,a98,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,utilde,tmp,atmp = cache
   a = dt*a21
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev+dt*(a31*k1+a32*k2)
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a41*k1+a43*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a51*k1+a53*k3+a54*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a61*k1+a63*k3+a64*k4+a65*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a71*k1+a73*k3+a74*k4+a75*k5+a76*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a81*k1+a83*k3+a84*k4+a85*k5+a86*k6+a87*k7)
-  f(k8, tmp, p, t+dt)
+  f(k8, tmp, t+dt, integrator)
   @.. u = uprev+dt*(a91*k1+a94*k4+a95*k5+a96*k6+a97*k7+a98*k8)
-  f(k9, u, p, t+dt)
+  f(k9, u, t+dt, integrator)
   integrator.destats.nf += 8
   if integrator.alg isa CompositeAlgorithm
     g9 = u
@@ -130,19 +130,19 @@ end
     @unpack c10,a1001,a1004,a1005,a1006,a1007,a1008,a1009,c11,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,c12,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache.tab
     @unpack tmp = cache
     @.. tmp = uprev+dt*(a1001*k[1]+a1004*k[4]+a1005*k[5]+a1006*k[6]+a1007*k[7]+a1008*k[8]+a1009*k[9])
-    f(k[10],tmp,p,t+c10*dt)
+    f(k[10], tmp, t+c10*dt, integrator)
     @.. tmp = uprev+dt*(a1101*k[1]+a1104*k[4]+a1105*k[5]+a1106*k[6]+a1107*k[7]+a1108*k[8]+a1109*k[9]+a1110*k[10])
-    f(k[11],tmp,p,t+c11*dt)
+    f(k[11], tmp, t+c11*dt, integrator)
     @.. tmp = uprev+dt*(a1201*k[1]+a1204*k[4]+a1205*k[5]+a1206*k[6]+a1207*k[7]+a1208*k[8]+a1209*k[9]+a1210*k[10]+a1211*k[11])
     integrator.destats.nf += 3
-    f(k[12],tmp,p,t+c12*dt)
+    f(k[12], tmp, t+c12*dt, integrator)
   end
   return nothing
 end
 
 #=
 @muladd function perform_step!(integrator, cache::Vern6Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a94,a95,a96,a97,a98,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,utilde,tmp,atmp = cache
@@ -150,35 +150,35 @@ end
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a43*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a53*k3[i]+a54*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
   end
-  f(k8, tmp, p, t+dt)
+  f(k8, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i]+dt*(a91*k1[i]+a94*k4[i]+a95*k5[i]+a96*k6[i]+a97*k7[i]+a98*k8[i])
   end
-  f(k9, u, p, t+dt)
+  f(k9, u, t+dt, integrator)
   integrator.destats.nf += 8
   if typeof(integrator.alg) <: CompositeAlgorithm
     g9 = u
@@ -205,16 +205,16 @@ end
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1001*k[1][i]+a1004*k[4][i]+a1005*k[5][i]+a1006*k[6][i]+a1007*k[7][i]+a1008*k[8][i]+a1009*k[9][i])
     end
-    f(k[10],tmp,p,t+c10*dt)
+    f(k[10], tmp, t+c10*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1101*k[1][i]+a1104*k[4][i]+a1105*k[5][i]+a1106*k[6][i]+a1107*k[7][i]+a1108*k[8][i]+a1109*k[9][i]+a1110*k[10][i])
     end
-    f(k[11],tmp,p,t+c11*dt)
+    f(k[11], tmp, t+c11*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1201*k[1][i]+a1204*k[4][i]+a1205*k[5][i]+a1206*k[6][i]+a1207*k[7][i]+a1208*k[8][i]+a1209*k[9][i]+a1210*k[10][i]+a1211*k[11][i])
     end
     integrator.destats.nf += 3
-    f(k[12],tmp,p,t+c12*dt)
+    f(k[12], tmp, t+c12*dt, integrator)
   end
 end
 =#
@@ -231,21 +231,21 @@ function initialize!(integrator, cache::Vern7ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern7ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,k,f,p = integrator
+  @unpack t,dt,uprev,u,k,f = integrator
   @unpack c2,c3,c4,c5,c6,c7,c8,a021,a031,a032,a041,a043,a051,a053,a054,a061,a063,a064,a065,a071,a073,a074,a075,a076,a081,a083,a084,a085,a086,a087,a091,a093,a094,a095,a096,a097,a098,a101,a103,a104,a105,a106,a107,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10 = cache
-  k1 = f(uprev, p, t)
+  k1 = f(uprev, t, integrator)
   a = dt*a021
-  k2 = f(uprev+a*k1, p, t + c2*dt)
-  k3 = f(uprev+dt*(a031*k1+a032*k2), p, t + c3*dt)
-  k4 = f(uprev+dt*(a041*k1       +a043*k3), p, t + c4*dt)
-  k5 = f(uprev+dt*(a051*k1       +a053*k3+a054*k4), p, t + c5*dt)
-  k6 = f(uprev+dt*(a061*k1       +a063*k3+a064*k4+a065*k5), p, t + c6*dt)
-  k7 = f(uprev+dt*(a071*k1       +a073*k3+a074*k4+a075*k5+a076*k6), p, t + c7*dt)
-  k8 = f(uprev+dt*(a081*k1       +a083*k3+a084*k4+a085*k5+a086*k6+a087*k7), p, t + c8*dt)
+  k2 = f(uprev+a*k1, t + c2*dt, integrator)
+  k3 = f(uprev+dt*(a031*k1+a032*k2), t + c3*dt, integrator)
+  k4 = f(uprev+dt*(a041*k1       +a043*k3), t + c4*dt, integrator)
+  k5 = f(uprev+dt*(a051*k1       +a053*k3+a054*k4), t + c5*dt, integrator)
+  k6 = f(uprev+dt*(a061*k1       +a063*k3+a064*k4+a065*k5), t + c6*dt, integrator)
+  k7 = f(uprev+dt*(a071*k1       +a073*k3+a074*k4+a075*k5+a076*k6), t + c7*dt, integrator)
+  k8 = f(uprev+dt*(a081*k1       +a083*k3+a084*k4+a085*k5+a086*k6+a087*k7), t + c8*dt, integrator)
   g9 =   uprev+dt*(a091*k1          +a093*k3+a094*k4+a095*k5+a096*k6+a097*k7+a098*k8)
   g10=   uprev+dt*(a101*k1          +a103*k3+a104*k4+a105*k5+a106*k6+a107*k7)
-  k9 = f(g9, p, t+dt)
-  k10= f(g10, p, t+dt)
+  k9 = f(g9, t+dt, integrator)
+  k10= f(g10, t+dt, integrator)
   integrator.destats.nf += 10
   u = uprev + dt*(b1*k1 + b4*k4 + b5*k5 + b6*k6 + b7*k7 + b8*k8 + b9*k9)
   if typeof(integrator.alg) <: CompositeAlgorithm
@@ -269,12 +269,12 @@ end
   if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
     k = integrator.k
     @unpack c11,a1101,a1104,a1105,a1106,a1107,a1108,a1109,c12,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1211,c13,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1311,a1312,c14,a1401,a1404,a1405,a1406,a1407,a1408,a1409,a1411,a1412,a1413,c15,a1501,a1504,a1505,a1506,a1507,a1508,a1509,a1511,a1512,a1513,c16,a1601,a1604,a1605,a1606,a1607,a1608,a1609,a1611,a1612,a1613 = cache
-    k[11] = f(uprev+dt*(a1101*k[1]+a1104*k[4]+a1105*k[5]+a1106*k[6]+a1107*k[7]+a1108*k[8]+a1109*k[9]),p,t+c11*dt)
-    k[12] = f(uprev+dt*(a1201*k[1]+a1204*k[4]+a1205*k[5]+a1206*k[6]+a1207*k[7]+a1208*k[8]+a1209*k[9]+a1211*k[11]),p,t+c12*dt)
-    k[13] = f(uprev+dt*(a1301*k[1]+a1304*k[4]+a1305*k[5]+a1306*k[6]+a1307*k[7]+a1308*k[8]+a1309*k[9]+a1311*k[11]+a1312*k[12]),p,t+c13*dt)
-    k[14] = f(uprev+dt*(a1401*k[1]+a1404*k[4]+a1405*k[5]+a1406*k[6]+a1407*k[7]+a1408*k[8]+a1409*k[9]+a1411*k[11]+a1412*k[12]+a1413*k[13]),p,t+c14*dt)
-    k[15] = f(uprev+dt*(a1501*k[1]+a1504*k[4]+a1505*k[5]+a1506*k[6]+a1507*k[7]+a1508*k[8]+a1509*k[9]+a1511*k[11]+a1512*k[12]+a1513*k[13]),p,t+c15*dt)
-    k[16] = f(uprev+dt*(a1601*k[1]+a1604*k[4]+a1605*k[5]+a1606*k[6]+a1607*k[7]+a1608*k[8]+a1609*k[9]+a1611*k[11]+a1612*k[12]+a1613*k[13]),p,t+c16*dt)
+    k[11] = f(uprev+dt*(a1101*k[1]+a1104*k[4]+a1105*k[5]+a1106*k[6]+a1107*k[7]+a1108*k[8]+a1109*k[9]), t+c11*dt, integrator)
+    k[12] = f(uprev+dt*(a1201*k[1]+a1204*k[4]+a1205*k[5]+a1206*k[6]+a1207*k[7]+a1208*k[8]+a1209*k[9]+a1211*k[11]), t+c12*dt, integrator)
+    k[13] = f(uprev+dt*(a1301*k[1]+a1304*k[4]+a1305*k[5]+a1306*k[6]+a1307*k[7]+a1308*k[8]+a1309*k[9]+a1311*k[11]+a1312*k[12]), t+c13*dt, integrator)
+    k[14] = f(uprev+dt*(a1401*k[1]+a1404*k[4]+a1405*k[5]+a1406*k[6]+a1407*k[7]+a1408*k[8]+a1409*k[9]+a1411*k[11]+a1412*k[12]+a1413*k[13]), t+c14*dt, integrator)
+    k[15] = f(uprev+dt*(a1501*k[1]+a1504*k[4]+a1505*k[5]+a1506*k[6]+a1507*k[7]+a1508*k[8]+a1509*k[9]+a1511*k[11]+a1512*k[12]+a1513*k[13]), t+c15*dt, integrator)
+    k[16] = f(uprev+dt*(a1601*k[1]+a1604*k[4]+a1605*k[5]+a1606*k[6]+a1607*k[7]+a1608*k[8]+a1609*k[9]+a1611*k[11]+a1612*k[12]+a1613*k[13]), t+c16*dt, integrator)
     integrator.destats.nf += 6
   end
 
@@ -299,29 +299,29 @@ function initialize!(integrator, cache::Vern7Cache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern7Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c2,c3,c4,c5,c6,c7,c8,a021,a031,a032,a041,a043,a051,a053,a054,a061,a063,a064,a065,a071,a073,a074,a075,a076,a081,a083,a084,a085,a086,a087,a091,a093,a094,a095,a096,a097,a098,a101,a103,a104,a105,a106,a107,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a021
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c2*dt)
+  f(k2, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a031*k1+a032*k2)
-  f(k3, tmp, p, t + c3*dt)
+  f(k3, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a041*k1+a043*k3)
-  f(k4, tmp, p, t + c4*dt)
+  f(k4, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a051*k1+a053*k3+a054*k4)
-  f(k5, tmp, p, t + c5*dt)
+  f(k5, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a061*k1+a063*k3+a064*k4+a065*k5)
-  f(k6, tmp, p, t + c6*dt)
+  f(k6, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a071*k1+a073*k3+a074*k4+a075*k5+a076*k6)
-  f(k7, tmp, p, t + c7*dt)
+  f(k7, tmp, t + c7*dt, integrator)
   @.. tmp = uprev+dt*(a081*k1+a083*k3+a084*k4+a085*k5+a086*k6+a087*k7)
-  f(k8, tmp, p, t + c8*dt)
+  f(k8, tmp, t + c8*dt, integrator)
   @.. tmp = uprev+dt*(a091*k1+a093*k3+a094*k4+a095*k5+a096*k6+a097*k7+a098*k8)
-  f(k9, tmp, p, t+dt)
+  f(k9, tmp, t+dt, integrator)
   @.. tmp = uprev+dt*(a101*k1+a103*k3+a104*k4+a105*k5+a106*k6+a107*k7)
-  f(k10, tmp, p, t+dt)
+  f(k10, tmp, t+dt, integrator)
   @.. u = uprev + dt*(b1*k1 + b4*k4 + b5*k5 + b6*k6 + b7*k7 + b8*k8 + b9*k9)
   integrator.destats.nf += 10
   if integrator.alg isa CompositeAlgorithm
@@ -344,17 +344,17 @@ end
     @unpack tmp = cache
     @unpack c11,a1101,a1104,a1105,a1106,a1107,a1108,a1109,c12,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1211,c13,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1311,a1312,c14,a1401,a1404,a1405,a1406,a1407,a1408,a1409,a1411,a1412,a1413,c15,a1501,a1504,a1505,a1506,a1507,a1508,a1509,a1511,a1512,a1513,c16,a1601,a1604,a1605,a1606,a1607,a1608,a1609,a1611,a1612,a1613 = cache.tab
     @.. tmp = uprev+dt*(a1101*k[1]+a1104*k[4]+a1105*k[5]+a1106*k[6]+a1107*k[7]+a1108*k[8]+a1109*k[9])
-    f(k[11],tmp,p,t+c11*dt)
+    f(k[11], tmp, t+c11*dt, integrator)
     @.. tmp = uprev+dt*(a1201*k[1]+a1204*k[4]+a1205*k[5]+a1206*k[6]+a1207*k[7]+a1208*k[8]+a1209*k[9]+a1211*k[11])
-    f(k[12],tmp,p,t+c12*dt)
+    f(k[12], tmp, t+c12*dt, integrator)
     @.. tmp = uprev+dt*(a1301*k[1]+a1304*k[4]+a1305*k[5]+a1306*k[6]+a1307*k[7]+a1308*k[8]+a1309*k[9]+a1311*k[11]+a1312*k[12])
-    f(k[13],tmp,p,t+c13*dt)
+    f(k[13], tmp, t+c13*dt, integrator)
     @.. tmp = uprev+dt*(a1401*k[1]+a1404*k[4]+a1405*k[5]+a1406*k[6]+a1407*k[7]+a1408*k[8]+a1409*k[9]+a1411*k[11]+a1412*k[12]+a1413*k[13])
-    f(k[14],tmp,p,t+c14*dt)
+    f(k[14], tmp, t+c14*dt, integrator)
     tmp=  uprev+dt*(a1501*k[1]+a1504*k[4]+a1505*k[5]+a1506*k[6]+a1507*k[7]+a1508*k[8]+a1509*k[9]+a1511*k[11]+a1512*k[12]+a1513*k[13])
-    f(k[15],tmp,p,t+c15*dt)
+    f(k[15], tmp, t+c15*dt, integrator)
     @.. tmp = uprev+dt*(a1601*k[1]+a1604*k[4]+a1605*k[5]+a1606*k[6]+a1607*k[7]+a1608*k[8]+a1609*k[9]+a1611*k[11]+a1612*k[12]+a1613*k[13])
-    f(k[16],tmp,p,t+c16*dt)
+    f(k[16], tmp, t+c16*dt, integrator)
     integrator.destats.nf += 6
   end
   return nothing
@@ -362,48 +362,48 @@ end
 
 #=
 @muladd function perform_step!(integrator, cache::Vern7Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c2,c3,c4,c5,c6,c7,c8,a021,a031,a032,a041,a043,a051,a053,a054,a061,a063,a064,a065,a071,a073,a074,a075,a076,a081,a083,a084,a085,a086,a087,a091,a093,a094,a095,a096,a097,a098,a101,a103,a104,a105,a106,a107,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10= cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a021
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c2*dt)
+  f(k2, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a031*k1[i]+a032*k2[i])
   end
-  f(k3, tmp, p, t + c3*dt)
+  f(k3, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a041*k1[i]+a043*k3[i])
   end
-  f(k4, tmp, p, t + c4*dt)
+  f(k4, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a051*k1[i]+a053*k3[i]+a054*k4[i])
   end
-  f(k5, tmp, p, t + c5*dt)
+  f(k5, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a061*k1[i]+a063*k3[i]+a064*k4[i]+a065*k5[i])
   end
-  f(k6, tmp, p, t + c6*dt)
+  f(k6, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a071*k1[i]+a073*k3[i]+a074*k4[i]+a075*k5[i]+a076*k6[i])
   end
-  f(k7, tmp, p, t + c7*dt)
+  f(k7, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a081*k1[i]+a083*k3[i]+a084*k4[i]+a085*k5[i]+a086*k6[i]+a087*k7[i])
   end
-  f(k8, tmp, p, t + c8*dt)
+  f(k8, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a091*k1[i]+a093*k3[i]+a094*k4[i]+a095*k5[i]+a096*k6[i]+a097*k7[i]+a098*k8[i])
   end
-  f(k9, tmp, p, t+dt)
+  f(k9, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i]+dt*(a101*k1[i]+a103*k3[i]+a104*k4[i]+a105*k5[i]+a106*k6[i]+a107*k7[i])
   end
-  f(k10, u, p, t+dt)
+  f(k10, u, t+dt, integrator)
   integrator.destats.nf += 10
   if typeof(integrator.alg) <: CompositeAlgorithm
     g10 = u
@@ -433,28 +433,28 @@ end
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1101*k[1][i]+a1104*k[4][i]+a1105*k[5][i]+a1106*k[6][i]+a1107*k[7][i]+a1108*k[8][i]+a1109*k[9][i])
     end
-    f(k[11],tmp,p,t+c11*dt)
+    f(k[11], tmp, t+c11*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1201*k[1][i]+a1204*k[4][i]+a1205*k[5][i]+a1206*k[6][i]+a1207*k[7][i]+a1208*k[8][i]+a1209*k[9][i]+a1211*k[11][i])
     end
-    f(k[12],tmp,p,t+c12*dt)
+    f(k[12], tmp, t+c12*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1301*k[1][i]+a1304*k[4][i]+a1305*k[5][i]+a1306*k[6][i]+a1307*k[7][i]+a1308*k[8][i]+a1309*k[9][i]+a1311*k[11][i]+a1312*k[12][i])
     end
-    f(k[13],tmp,p,t+c13*dt)
+    f(k[13], tmp, t+c13*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1401*k[1][i]+a1404*k[4][i]+a1405*k[5][i]+a1406*k[6][i]+a1407*k[7][i]+a1408*k[8][i]+a1409*k[9][i]+a1411*k[11][i]+a1412*k[12][i]+a1413*k[13][i])
     end
-    f(k[14],tmp,p,t+c14*dt)
+    f(k[14], tmp, t+c14*dt, integrator)
     @tight_loop_macros for i in uidx
       tmp[i]=  uprev[i]+dt*(a1501*k[1][i]+a1504*k[4][i]+a1505*k[5][i]+a1506*k[6][i]+a1507*k[7][i]+a1508*k[8][i]+a1509*k[9][i]+a1511*k[11][i]+a1512*k[12][i]+a1513*k[13][i])
     end
-    f(k[15],tmp,p,t+c15*dt)
+    f(k[15], tmp, t+c15*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1601*k[1][i]+a1604*k[4][i]+a1605*k[5][i]+a1606*k[6][i]+a1607*k[7][i]+a1608*k[8][i]+a1609*k[9][i]+a1611*k[11][i]+a1612*k[12][i]+a1613*k[13][i])
     end
     integrator.destats.nf += 6
-    f(k[16],tmp,p,t+c16*dt)
+    f(k[16], tmp, t+c16*dt, integrator)
   end
 
 end
@@ -472,24 +472,24 @@ function initialize!(integrator, cache::Vern8ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern8ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache
-  k1 = f(uprev, p, t)
+  k1 = f(uprev, t, integrator)
   a = dt*a0201
-  k2 = f(uprev+a*k1, p, t + c2*dt)
-  k3 = f(uprev+dt*(a0301*k1+a0302*k2), p, t + c3*dt)
-  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), p, t + c4*dt)
-  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), p, t + c5*dt)
-  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), p, t + c6*dt)
-  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), p, t + c7*dt)
-  k8 = f(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7), p, t + c8*dt)
-  k9 = f(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8), p, t + c9*dt)
-  k10= f(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9), p, t + c10*dt)
-  k11= f(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), p, t + c11*dt)
+  k2 = f(uprev+a*k1, t + c2*dt, integrator)
+  k3 = f(uprev+dt*(a0301*k1+a0302*k2), t + c3*dt, integrator)
+  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), t + c4*dt, integrator)
+  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), t + c5*dt, integrator)
+  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), t + c6*dt, integrator)
+  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), t + c7*dt, integrator)
+  k8 = f(uprev+dt*(a0801*k1                +a0804*k4+a0805*k5+a0806*k6+a0807*k7), t + c8*dt, integrator)
+  k9 = f(uprev+dt*(a0901*k1                +a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8), t + c9*dt, integrator)
+  k10= f(uprev+dt*(a1001*k1                +a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9), t + c10*dt, integrator)
+  k11= f(uprev+dt*(a1101*k1                +a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), t + c11*dt, integrator)
   g12=  uprev+dt*(a1201*k1                +a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
   g13=  uprev+dt*(a1301*k1                +a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10)
-  k12= f(g12, p, t+dt)
-  k13= f(g13, p, t+dt)
+  k12= f(g12, t+dt, integrator)
+  k13= f(g13, t+dt, integrator)
   integrator.destats.nf += 13
   u = uprev + dt*(b1*k1 + b6*k6 + b7*k7 + b8*k8 + b9*k9 + b10*k10 + b11*k11 + b12*k12)
   if typeof(integrator.alg) <: CompositeAlgorithm
@@ -515,14 +515,14 @@ end
   if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
     k = integrator.k
     @unpack c14,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,c15,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1514,c16,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1614,a1615,c17,a1701,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1714,a1715,a1716,c18,a1801,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1814,a1815,a1816,a1817,c19,a1901,a1906,a1907,a1908,a1909,a1910,a1911,a1912,a1914,a1915,a1916,a1917,c20,a2001,a2006,a2007,a2008,a2009,a2010,a2011,a2012,a2014,a2015,a2016,a2017,c21,a2101,a2106,a2107,a2108,a2109,a2110,a2111,a2112,a2114,a2115,a2116,a2117 = cache
-    k[14] = f(uprev+dt*(a1401*k[1]+a1406*k[6]+a1407*k[7]+a1408*k[8]+a1409*k[9]+a1410*k[10]+a1411*k[11]+a1412*k[12]),p,t+c14*dt)
-    k[15] = f(uprev+dt*(a1501*k[1]+a1506*k[6]+a1507*k[7]+a1508*k[8]+a1509*k[9]+a1510*k[10]+a1511*k[11]+a1512*k[12]+a1514*k[14]),p,t+c15*dt)
-    k[16] = f(uprev+dt*(a1601*k[1]+a1606*k[6]+a1607*k[7]+a1608*k[8]+a1609*k[9]+a1610*k[10]+a1611*k[11]+a1612*k[12]+a1614*k[14]+a1615*k[15]),p,t+c16*dt)
-    k[17] = f(uprev+dt*(a1701*k[1]+a1706*k[6]+a1707*k[7]+a1708*k[8]+a1709*k[9]+a1710*k[10]+a1711*k[11]+a1712*k[12]+a1714*k[14]+a1715*k[15]+a1716*k[16]),p,t+c17*dt)
-    k[18] = f(uprev+dt*(a1801*k[1]+a1806*k[6]+a1807*k[7]+a1808*k[8]+a1809*k[9]+a1810*k[10]+a1811*k[11]+a1812*k[12]+a1814*k[14]+a1815*k[15]+a1816*k[16]+a1817*k[17]),p,t+c18*dt)
-    k[19] = f(uprev+dt*(a1901*k[1]+a1906*k[6]+a1907*k[7]+a1908*k[8]+a1909*k[9]+a1910*k[10]+a1911*k[11]+a1912*k[12]+a1914*k[14]+a1915*k[15]+a1916*k[16]+a1917*k[17]),p,t+c19*dt)
-    k[20] = f(uprev+dt*(a2001*k[1]+a2006*k[6]+a2007*k[7]+a2008*k[8]+a2009*k[9]+a2010*k[10]+a2011*k[11]+a2012*k[12]+a2014*k[14]+a2015*k[15]+a2016*k[16]+a2017*k[17]),p,t+c20*dt)
-    k[21] = f(uprev+dt*(a2101*k[1]+a2106*k[6]+a2107*k[7]+a2108*k[8]+a2109*k[9]+a2110*k[10]+a2111*k[11]+a2112*k[12]+a2114*k[14]+a2115*k[15]+a2116*k[16]+a2117*k[17]),p,t+c21*dt)
+    k[14] = f(uprev+dt*(a1401*k[1]+a1406*k[6]+a1407*k[7]+a1408*k[8]+a1409*k[9]+a1410*k[10]+a1411*k[11]+a1412*k[12]), t+c14*dt, integrator)
+    k[15] = f(uprev+dt*(a1501*k[1]+a1506*k[6]+a1507*k[7]+a1508*k[8]+a1509*k[9]+a1510*k[10]+a1511*k[11]+a1512*k[12]+a1514*k[14]), t+c15*dt, integrator)
+    k[16] = f(uprev+dt*(a1601*k[1]+a1606*k[6]+a1607*k[7]+a1608*k[8]+a1609*k[9]+a1610*k[10]+a1611*k[11]+a1612*k[12]+a1614*k[14]+a1615*k[15]), t+c16*dt, integrator)
+    k[17] = f(uprev+dt*(a1701*k[1]+a1706*k[6]+a1707*k[7]+a1708*k[8]+a1709*k[9]+a1710*k[10]+a1711*k[11]+a1712*k[12]+a1714*k[14]+a1715*k[15]+a1716*k[16]), t+c17*dt, integrator)
+    k[18] = f(uprev+dt*(a1801*k[1]+a1806*k[6]+a1807*k[7]+a1808*k[8]+a1809*k[9]+a1810*k[10]+a1811*k[11]+a1812*k[12]+a1814*k[14]+a1815*k[15]+a1816*k[16]+a1817*k[17]), t+c18*dt, integrator)
+    k[19] = f(uprev+dt*(a1901*k[1]+a1906*k[6]+a1907*k[7]+a1908*k[8]+a1909*k[9]+a1910*k[10]+a1911*k[11]+a1912*k[12]+a1914*k[14]+a1915*k[15]+a1916*k[16]+a1917*k[17]), t+c19*dt, integrator)
+    k[20] = f(uprev+dt*(a2001*k[1]+a2006*k[6]+a2007*k[7]+a2008*k[8]+a2009*k[9]+a2010*k[10]+a2011*k[11]+a2012*k[12]+a2014*k[14]+a2015*k[15]+a2016*k[16]+a2017*k[17]), t+c20*dt, integrator)
+    k[21] = f(uprev+dt*(a2101*k[1]+a2106*k[6]+a2107*k[7]+a2108*k[8]+a2109*k[9]+a2110*k[10]+a2111*k[11]+a2112*k[12]+a2114*k[14]+a2115*k[15]+a2116*k[16]+a2117*k[17]), t+c21*dt, integrator)
     integrator.destats.nf += 8
   end
 
@@ -544,36 +544,36 @@ function initialize!(integrator, cache::Vern8Cache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c2*dt)
+  f(k2, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a0301*k1+a0302*k2)
-  f(k3, tmp, p, t + c3*dt)
+  f(k3, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a0401*k1+a0403*k3)
-  f(k4, tmp, p, t + c4*dt)
+  f(k4, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
-  f(k5, tmp, p, t + c5*dt)
+  f(k5, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
-  f(k6, tmp, p, t + c6*dt)
+  f(k6, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
-  f(k7, tmp, p, t + c7*dt)
+  f(k7, tmp, t + c7*dt, integrator)
   @.. tmp = uprev+dt*(a0801*k1+a0804*k4+a0805*k5+a0806*k6+a0807*k7)
-  f(k8, tmp, p, t + c8*dt)
+  f(k8, tmp, t + c8*dt, integrator)
   @.. tmp = uprev+dt*(a0901*k1+a0904*k4+a0905*k5+a0906*k6+a0907*k7+a0908*k8)
-  f(k9, tmp, p, t + c9*dt)
+  f(k9, tmp, t + c9*dt, integrator)
   @.. tmp = uprev+dt*(a1001*k1+a1004*k4+a1005*k5+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
-  f(k10, tmp, p, t + c10*dt)
+  f(k10, tmp, t + c10*dt, integrator)
   @.. tmp = uprev+dt*(a1101*k1+a1104*k4+a1105*k5+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
-  f(k11, tmp, p, t + c11*dt)
+  f(k11, tmp, t + c11*dt, integrator)
   @.. tmp = uprev+dt*(a1201*k1+a1204*k4+a1205*k5+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
-  f(k12, tmp, p, t+dt)
+  f(k12, tmp, t+dt, integrator)
   @.. u = uprev+dt*(a1301*k1+a1304*k4+a1305*k5+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10)
-  f(k13, u, p, t+dt)
+  f(k13, u, t+dt, integrator)
   integrator.destats.nf += 13
   if integrator.alg isa CompositeAlgorithm
     g13 = u
@@ -597,82 +597,82 @@ end
     @unpack c14,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,c15,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1514,c16,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1614,a1615,c17,a1701,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1714,a1715,a1716,c18,a1801,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1814,a1815,a1816,a1817,c19,a1901,a1906,a1907,a1908,a1909,a1910,a1911,a1912,a1914,a1915,a1916,a1917,c20,a2001,a2006,a2007,a2008,a2009,a2010,a2011,a2012,a2014,a2015,a2016,a2017,c21,a2101,a2106,a2107,a2108,a2109,a2110,a2111,a2112,a2114,a2115,a2116,a2117 = cache.tab
     @unpack tmp = cache
     @.. tmp = uprev+dt*(a1401*k[1]+a1406*k[6]+a1407*k[7]+a1408*k[8]+a1409*k[9]+a1410*k[10]+a1411*k[11]+a1412*k[12])
-    f(k[14],tmp,p,t+c14*dt)
+    f(k[14], tmp, t+c14*dt, integrator)
     @.. tmp = uprev+dt*(a1501*k[1]+a1506*k[6]+a1507*k[7]+a1508*k[8]+a1509*k[9]+a1510*k[10]+a1511*k[11]+a1512*k[12]+a1514*k[14])
-    f(k[15],tmp,p,t+c15*dt)
+    f(k[15], tmp, t+c15*dt, integrator)
     @.. tmp = uprev+dt*(a1601*k[1]+a1606*k[6]+a1607*k[7]+a1608*k[8]+a1609*k[9]+a1610*k[10]+a1611*k[11]+a1612*k[12]+a1614*k[14]+a1615*k[15])
-    f(k[16],tmp,p,t+c16*dt)
+    f(k[16], tmp, t+c16*dt, integrator)
     @.. tmp = uprev+dt*(a1701*k[1]+a1706*k[6]+a1707*k[7]+a1708*k[8]+a1709*k[9]+a1710*k[10]+a1711*k[11]+a1712*k[12]+a1714*k[14]+a1715*k[15]+a1716*k[16])
-    f(k[17],tmp,p,t+c17*dt)
+    f(k[17], tmp, t+c17*dt, integrator)
     @.. tmp = uprev+dt*(a1801*k[1]+a1806*k[6]+a1807*k[7]+a1808*k[8]+a1809*k[9]+a1810*k[10]+a1811*k[11]+a1812*k[12]+a1814*k[14]+a1815*k[15]+a1816*k[16]+a1817*k[17])
-    f(k[18],tmp,p,t+c18*dt)
+    f(k[18], tmp, t+c18*dt, integrator)
     @.. tmp = uprev+dt*(a1901*k[1]+a1906*k[6]+a1907*k[7]+a1908*k[8]+a1909*k[9]+a1910*k[10]+a1911*k[11]+a1912*k[12]+a1914*k[14]+a1915*k[15]+a1916*k[16]+a1917*k[17])
-    f(k[19],tmp,p,t+c19*dt)
+    f(k[19], tmp, t+c19*dt, integrator)
     @.. tmp = uprev+dt*(a2001*k[1]+a2006*k[6]+a2007*k[7]+a2008*k[8]+a2009*k[9]+a2010*k[10]+a2011*k[11]+a2012*k[12]+a2014*k[14]+a2015*k[15]+a2016*k[16]+a2017*k[17])
-    f(k[20],tmp,p,t+c20*dt)
+    f(k[20], tmp, t+c20*dt, integrator)
     @.. tmp = uprev+dt*(a2101*k[1]+a2106*k[6]+a2107*k[7]+a2108*k[8]+a2109*k[9]+a2110*k[10]+a2111*k[11]+a2112*k[12]+a2114*k[14]+a2115*k[15]+a2116*k[16]+a2117*k[17])
     integrator.destats.nf += 8
-    f(k[21],tmp,p,t+c21*dt)
+    f(k[21], tmp, t+c21*dt, integrator)
   end
   return nothing
 end
 
 #=
 @muladd function perform_step!(integrator, cache::Vern8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c2*dt)
+  f(k2, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
   end
-  f(k3, tmp, p, t + c3*dt)
+  f(k3, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
   end
-  f(k4, tmp, p, t + c4*dt)
+  f(k4, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
   end
-  f(k5, tmp, p, t + c5*dt)
+  f(k5, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
   end
-  f(k6, tmp, p, t + c6*dt)
+  f(k6, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
   end
-  f(k7, tmp, p, t + c7*dt)
+  f(k7, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
   end
-  f(k8, tmp, p, t + c8*dt)
+  f(k8, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
   end
-  f(k9, tmp, p, t + c9*dt)
+  f(k9, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
   end
-  f(k10, tmp, p, t + c10*dt)
+  f(k10, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
   end
-  f(k11, tmp, p, t + c11*dt)
+  f(k11, tmp, t + c11*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
   end
-  f(k12, tmp, p, t+dt)
+  f(k12, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i]+dt*(a1301*k1[i]+a1304*k4[i]+a1305*k5[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i])
   end
-  f(k13, u, p, t+dt)
+  f(k13, u, t+dt, integrator)
   integrator.destats.nf += 13
   if typeof(integrator.alg) <: CompositeAlgorithm
     g13 = u
@@ -702,36 +702,36 @@ end
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1401*k[1][i]+a1406*k[6][i]+a1407*k[7][i]+a1408*k[8][i]+a1409*k[9][i]+a1410*k[10][i]+a1411*k[11][i]+a1412*k[12][i])
     end
-    f(k[14],tmp,p,t+c14*dt)
+    f(k[14], tmp, t+c14*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1501*k[1][i]+a1506*k[6][i]+a1507*k[7][i]+a1508*k[8][i]+a1509*k[9][i]+a1510*k[10][i]+a1511*k[11][i]+a1512*k[12][i]+a1514*k[14][i])
     end
-    f(k[15],tmp,p,t+c15*dt)
+    f(k[15], tmp, t+c15*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1601*k[1][i]+a1606*k[6][i]+a1607*k[7][i]+a1608*k[8][i]+a1609*k[9][i]+a1610*k[10][i]+a1611*k[11][i]+a1612*k[12][i]+a1614*k[14][i]+a1615*k[15][i])
     end
-    f(k[16],tmp,p,t+c16*dt)
+    f(k[16], tmp, t+c16*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1701*k[1][i]+a1706*k[6][i]+a1707*k[7][i]+a1708*k[8][i]+a1709*k[9][i]+a1710*k[10][i]+a1711*k[11][i]+a1712*k[12][i]+a1714*k[14][i]+a1715*k[15][i]+a1716*k[16][i])
     end
-    f(k[17],tmp,p,t+c17*dt)
+    f(k[17], tmp, t+c17*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1801*k[1][i]+a1806*k[6][i]+a1807*k[7][i]+a1808*k[8][i]+a1809*k[9][i]+a1810*k[10][i]+a1811*k[11][i]+a1812*k[12][i]+a1814*k[14][i]+a1815*k[15][i]+a1816*k[16][i]+a1817*k[17][i])
     end
-    f(k[18],tmp,p,t+c18*dt)
+    f(k[18], tmp, t+c18*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1901*k[1][i]+a1906*k[6][i]+a1907*k[7][i]+a1908*k[8][i]+a1909*k[9][i]+a1910*k[10][i]+a1911*k[11][i]+a1912*k[12][i]+a1914*k[14][i]+a1915*k[15][i]+a1916*k[16][i]+a1917*k[17][i])
     end
-    f(k[19],tmp,p,t+c19*dt)
+    f(k[19], tmp, t+c19*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2001*k[1][i]+a2006*k[6][i]+a2007*k[7][i]+a2008*k[8][i]+a2009*k[9][i]+a2010*k[10][i]+a2011*k[11][i]+a2012*k[12][i]+a2014*k[14][i]+a2015*k[15][i]+a2016*k[16][i]+a2017*k[17][i])
     end
-    f(k[20],tmp,p,t+c20*dt)
+    f(k[20], tmp, t+c20*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2101*k[1][i]+a2106*k[6][i]+a2107*k[7][i]+a2108*k[8][i]+a2109*k[9][i]+a2110*k[10][i]+a2111*k[11][i]+a2112*k[12][i]+a2114*k[14][i]+a2115*k[15][i]+a2116*k[16][i]+a2117*k[17][i])
     end
     integrator.destats.nf += 8
-    f(k[21],tmp,p,t+c21*dt)
+    f(k[21], tmp, t+c21*dt, integrator)
   end
 
 end
@@ -749,27 +749,27 @@ function initialize!(integrator, cache::Vern9ConstantCache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern9ConstantCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0806,a0807,a0901,a0906,a0907,a0908,a1001,a1006,a1007,a1008,a1009,a1101,a1106,a1107,a1108,a1109,a1110,a1201,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,b1,b8,b9,b10,b11,b12,b13,b14,b15,btilde1,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13,btilde14,btilde15,btilde16 = cache
-  k1 = f(uprev, p, t)
+  k1 = f(uprev, t, integrator)
   a = dt*a0201
-  k2 = f(uprev+a*k1, p, t + c1*dt)
-  k3 = f(uprev+dt*(a0301*k1+a0302*k2), p, t + c2*dt)
-  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), p, t + c3*dt)
-  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), p, t + c4*dt)
-  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), p, t + c5*dt)
-  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), p, t + c6*dt)
-  k8 = f(uprev+dt*(a0801*k1                                  +a0806*k6+a0807*k7), p, t + c7*dt)
-  k9 = f(uprev+dt*(a0901*k1                                  +a0906*k6+a0907*k7+a0908*k8), p, t + c8*dt)
-  k10 =f(uprev+dt*(a1001*k1                                  +a1006*k6+a1007*k7+a1008*k8+a1009*k9), p, t + c9*dt)
-  k11= f(uprev+dt*(a1101*k1                                  +a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), p, t + c10*dt)
-  k12= f(uprev+dt*(a1201*k1                                  +a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11), p, t + c11*dt)
-  k13= f(uprev+dt*(a1301*k1                                  +a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10+a1311*k11+a1312*k12), p, t + c12*dt)
-  k14= f(uprev+dt*(a1401*k1                                  +a1406*k6+a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13), p, t + c13*dt)
+  k2 = f(uprev+a*k1, t + c1*dt, integrator)
+  k3 = f(uprev+dt*(a0301*k1+a0302*k2), t + c2*dt, integrator)
+  k4 = f(uprev+dt*(a0401*k1       +a0403*k3), t + c3*dt, integrator)
+  k5 = f(uprev+dt*(a0501*k1       +a0503*k3+a0504*k4), t + c4*dt, integrator)
+  k6 = f(uprev+dt*(a0601*k1                +a0604*k4+a0605*k5), t + c5*dt, integrator)
+  k7 = f(uprev+dt*(a0701*k1                +a0704*k4+a0705*k5+a0706*k6), t + c6*dt, integrator)
+  k8 = f(uprev+dt*(a0801*k1                                  +a0806*k6+a0807*k7), t + c7*dt, integrator)
+  k9 = f(uprev+dt*(a0901*k1                                  +a0906*k6+a0907*k7+a0908*k8), t + c8*dt, integrator)
+  k10 =f(uprev+dt*(a1001*k1                                  +a1006*k6+a1007*k7+a1008*k8+a1009*k9), t + c9*dt, integrator)
+  k11= f(uprev+dt*(a1101*k1                                  +a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10), t + c10*dt, integrator)
+  k12= f(uprev+dt*(a1201*k1                                  +a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11), t + c11*dt, integrator)
+  k13= f(uprev+dt*(a1301*k1                                  +a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10+a1311*k11+a1312*k12), t + c12*dt, integrator)
+  k14= f(uprev+dt*(a1401*k1                                  +a1406*k6+a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13), t + c13*dt, integrator)
   g15=   uprev+dt*(a1501*k1                                  +a1506*k6+a1507*k7+a1508*k8+a1509*k9+a1510*k10+a1511*k11+a1512*k12+a1513*k13+a1514*k14)
   g16=   uprev+dt*(a1601*k1                                  +a1606*k6+a1607*k7+a1608*k8+a1609*k9+a1610*k10+a1611*k11+a1612*k12+a1613*k13)
-  k15= f(g15, p, t+dt)
-  k16= f(g16, p, t+dt)
+  k15= f(g15, t+dt, integrator)
+  k16= f(g16, t+dt, integrator)
   integrator.destats.nf += 16
   u = uprev + dt*(b1*k1+b8*k8+b9*k9+b10*k10+b11*k11+b12*k12+b13*k13+b14*k14+b15*k15)
   if typeof(integrator.alg) <: CompositeAlgorithm
@@ -795,16 +795,16 @@ end
   if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
     k = integrator.k
     @unpack c17,a1701,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,c18,a1801,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1817,c19,a1901,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1917,a1918,c20,a2001,a2008,a2009,a2010,a2011,a2012,a2013,a2014,a2015,a2017,a2018,a2019,c21,a2101,a2108,a2109,a2110,a2111,a2112,a2113,a2114,a2115,a2117,a2118,a2119,a2120,c22,a2201,a2208,a2209,a2210,a2211,a2212,a2213,a2214,a2215,a2217,a2218,a2219,a2220,a2221,c23,a2301,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2317,a2318,a2319,a2320,a2321,c24,a2401,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2417,a2418,a2419,a2420,a2421,c25,a2501,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2517,a2518,a2519,a2520,a2521,c26,a2601,a2608,a2609,a2610,a2611,a2612,a2613,a2614,a2615,a2617,a2618,a2619,a2620,a2621 = cache
-    k[11] = f(uprev+dt*(a1701*k[1]+a1708*k[2]+a1709*k[3]+a1710*k[4]+a1711*k[5]+a1712*k[6]+a1713*k[7]+a1714*k[8]+a1715*k[9]),p,t+c17*dt)
-    k[12] = f(uprev+dt*(a1801*k[1]+a1808*k[2]+a1809*k[3]+a1810*k[4]+a1811*k[5]+a1812*k[6]+a1813*k[7]+a1814*k[8]+a1815*k[9]+a1817*k[11]),p,t+c18*dt)
-    k[13] = f(uprev+dt*(a1901*k[1]+a1908*k[2]+a1909*k[3]+a1910*k[4]+a1911*k[5]+a1912*k[6]+a1913*k[7]+a1914*k[8]+a1915*k[9]+a1917*k[11]+a1918*k[12]),p,t+c19*dt)
-    k[14] = f(uprev+dt*(a2001*k[1]+a2008*k[2]+a2009*k[3]+a2010*k[4]+a2011*k[5]+a2012*k[6]+a2013*k[7]+a2014*k[8]+a2015*k[9]+a2017*k[11]+a2018*k[12]+a2019*k[13]),p,t+c20*dt)
-    k[15] = f(uprev+dt*(a2101*k[1]+a2108*k[2]+a2109*k[3]+a2110*k[4]+a2111*k[5]+a2112*k[6]+a2113*k[7]+a2114*k[8]+a2115*k[9]+a2117*k[11]+a2118*k[12]+a2119*k[13]+a2120*k[14]),p,t+c21*dt)
-    k[16] = f(uprev+dt*(a2201*k[1]+a2208*k[2]+a2209*k[3]+a2210*k[4]+a2211*k[5]+a2212*k[6]+a2213*k[7]+a2214*k[8]+a2215*k[9]+a2217*k[11]+a2218*k[12]+a2219*k[13]+a2220*k[14]+a2221*k[15]),p,t+c22*dt)
-    k[17] = f(uprev+dt*(a2301*k[1]+a2308*k[2]+a2309*k[3]+a2310*k[4]+a2311*k[5]+a2312*k[6]+a2313*k[7]+a2314*k[8]+a2315*k[9]+a2317*k[11]+a2318*k[12]+a2319*k[13]+a2320*k[14]+a2321*k[15]),p,t+c23*dt)
-    k[18] = f(uprev+dt*(a2401*k[1]+a2408*k[2]+a2409*k[3]+a2410*k[4]+a2411*k[5]+a2412*k[6]+a2413*k[7]+a2414*k[8]+a2415*k[9]+a2417*k[11]+a2418*k[12]+a2419*k[13]+a2420*k[14]+a2421*k[15]),p,t+c24*dt)
-    k[19] = f(uprev+dt*(a2501*k[1]+a2508*k[2]+a2509*k[3]+a2510*k[4]+a2511*k[5]+a2512*k[6]+a2513*k[7]+a2514*k[8]+a2515*k[9]+a2517*k[11]+a2518*k[12]+a2519*k[13]+a2520*k[14]+a2521*k[15]),p,t+c25*dt)
-    k[20] = f(uprev+dt*(a2601*k[1]+a2608*k[2]+a2609*k[3]+a2610*k[4]+a2611*k[5]+a2612*k[6]+a2613*k[7]+a2614*k[8]+a2615*k[9]+a2617*k[11]+a2618*k[12]+a2619*k[13]+a2620*k[14]+a2621*k[15]),p,t+c26*dt)
+    k[11] = f(uprev+dt*(a1701*k[1]+a1708*k[2]+a1709*k[3]+a1710*k[4]+a1711*k[5]+a1712*k[6]+a1713*k[7]+a1714*k[8]+a1715*k[9]), t+c17*dt, integrator)
+    k[12] = f(uprev+dt*(a1801*k[1]+a1808*k[2]+a1809*k[3]+a1810*k[4]+a1811*k[5]+a1812*k[6]+a1813*k[7]+a1814*k[8]+a1815*k[9]+a1817*k[11]), t+c18*dt, integrator)
+    k[13] = f(uprev+dt*(a1901*k[1]+a1908*k[2]+a1909*k[3]+a1910*k[4]+a1911*k[5]+a1912*k[6]+a1913*k[7]+a1914*k[8]+a1915*k[9]+a1917*k[11]+a1918*k[12]), t+c19*dt, integrator)
+    k[14] = f(uprev+dt*(a2001*k[1]+a2008*k[2]+a2009*k[3]+a2010*k[4]+a2011*k[5]+a2012*k[6]+a2013*k[7]+a2014*k[8]+a2015*k[9]+a2017*k[11]+a2018*k[12]+a2019*k[13]), t+c20*dt, integrator)
+    k[15] = f(uprev+dt*(a2101*k[1]+a2108*k[2]+a2109*k[3]+a2110*k[4]+a2111*k[5]+a2112*k[6]+a2113*k[7]+a2114*k[8]+a2115*k[9]+a2117*k[11]+a2118*k[12]+a2119*k[13]+a2120*k[14]), t+c21*dt, integrator)
+    k[16] = f(uprev+dt*(a2201*k[1]+a2208*k[2]+a2209*k[3]+a2210*k[4]+a2211*k[5]+a2212*k[6]+a2213*k[7]+a2214*k[8]+a2215*k[9]+a2217*k[11]+a2218*k[12]+a2219*k[13]+a2220*k[14]+a2221*k[15]), t+c22*dt, integrator)
+    k[17] = f(uprev+dt*(a2301*k[1]+a2308*k[2]+a2309*k[3]+a2310*k[4]+a2311*k[5]+a2312*k[6]+a2313*k[7]+a2314*k[8]+a2315*k[9]+a2317*k[11]+a2318*k[12]+a2319*k[13]+a2320*k[14]+a2321*k[15]), t+c23*dt, integrator)
+    k[18] = f(uprev+dt*(a2401*k[1]+a2408*k[2]+a2409*k[3]+a2410*k[4]+a2411*k[5]+a2412*k[6]+a2413*k[7]+a2414*k[8]+a2415*k[9]+a2417*k[11]+a2418*k[12]+a2419*k[13]+a2420*k[14]+a2421*k[15]), t+c24*dt, integrator)
+    k[19] = f(uprev+dt*(a2501*k[1]+a2508*k[2]+a2509*k[3]+a2510*k[4]+a2511*k[5]+a2512*k[6]+a2513*k[7]+a2514*k[8]+a2515*k[9]+a2517*k[11]+a2518*k[12]+a2519*k[13]+a2520*k[14]+a2521*k[15]), t+c25*dt, integrator)
+    k[20] = f(uprev+dt*(a2601*k[1]+a2608*k[2]+a2609*k[3]+a2610*k[4]+a2611*k[5]+a2612*k[6]+a2613*k[7]+a2614*k[8]+a2615*k[9]+a2617*k[11]+a2618*k[12]+a2619*k[13]+a2620*k[14]+a2621*k[15]), t+c26*dt, integrator)
     integrator.destats.nf += 10
   end
 end
@@ -827,42 +827,42 @@ function initialize!(integrator, cache::Vern9Cache)
 end
 
 @muladd function perform_step!(integrator, cache::Vern9Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0806,a0807,a0901,a0906,a0907,a0908,a1001,a1006,a1007,a1008,a1009,a1101,a1106,a1107,a1108,a1109,a1110,a1201,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,b1,b8,b9,b10,b11,b12,b13,b14,b15,btilde1,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13,btilde14,btilde15,btilde16 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @.. tmp = uprev+a*k1
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @.. tmp = uprev+dt*(a0301*k1+a0302*k2)
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @.. tmp = uprev+dt*(a0401*k1+a0403*k3)
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @.. tmp = uprev+dt*(a0501*k1+a0503*k3+a0504*k4)
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @.. tmp = uprev+dt*(a0601*k1+a0604*k4+a0605*k5)
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @.. tmp = uprev+dt*(a0701*k1+a0704*k4+a0705*k5+a0706*k6)
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @.. tmp = uprev+dt*(a0801*k1+a0806*k6+a0807*k7)
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @.. tmp = uprev+dt*(a0901*k1+a0906*k6+a0907*k7+a0908*k8)
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @.. tmp = uprev+dt*(a1001*k1+a1006*k6+a1007*k7+a1008*k8+a1009*k9)
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @.. tmp = uprev+dt*(a1101*k1+a1106*k6+a1107*k7+a1108*k8+a1109*k9+a1110*k10)
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @.. tmp = uprev+dt*(a1201*k1+a1206*k6+a1207*k7+a1208*k8+a1209*k9+a1210*k10+a1211*k11)
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @.. tmp = uprev+dt*(a1301*k1+a1306*k6+a1307*k7+a1308*k8+a1309*k9+a1310*k10+a1311*k11+a1312*k12)
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @.. tmp = uprev+dt*(a1401*k1+a1406*k6+a1407*k7+a1408*k8+a1409*k9+a1410*k10+a1411*k11+a1412*k12+a1413*k13)
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @.. tmp = uprev+dt*(a1501*k1+a1506*k6+a1507*k7+a1508*k8+a1509*k9+a1510*k10+a1511*k11+a1512*k12+a1513*k13+a1514*k14)
-  f(k15, tmp, p, t+dt)
+  f(k15, tmp, t+dt, integrator)
   @.. u = uprev+dt*(a1601*k1+a1606*k6+a1607*k7+a1608*k8+a1609*k9+a1610*k10+a1611*k11+a1612*k12+a1613*k13)
-  f(k16, u, p, t+dt)
+  f(k16, u, t+dt, integrator)
   integrator.destats.nf += 16
   if integrator.alg isa CompositeAlgorithm
     g16 = u
@@ -886,98 +886,98 @@ end
     @unpack tmp = cache
     @unpack c17,a1701,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,c18,a1801,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1817,c19,a1901,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1917,a1918,c20,a2001,a2008,a2009,a2010,a2011,a2012,a2013,a2014,a2015,a2017,a2018,a2019,c21,a2101,a2108,a2109,a2110,a2111,a2112,a2113,a2114,a2115,a2117,a2118,a2119,a2120,c22,a2201,a2208,a2209,a2210,a2211,a2212,a2213,a2214,a2215,a2217,a2218,a2219,a2220,a2221,c23,a2301,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2317,a2318,a2319,a2320,a2321,c24,a2401,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2417,a2418,a2419,a2420,a2421,c25,a2501,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2517,a2518,a2519,a2520,a2521,c26,a2601,a2608,a2609,a2610,a2611,a2612,a2613,a2614,a2615,a2617,a2618,a2619,a2620,a2621 = cache.tab
     @.. tmp = uprev+dt*(a1701*k[1]+a1708*k[2]+a1709*k[3]+a1710*k[4]+a1711*k[5]+a1712*k[6]+a1713*k[7]+a1714*k[8]+a1715*k[9])
-    f(k[11],tmp,p,t+c17*dt)
+    f(k[11], tmp, t+c17*dt, integrator)
     @.. tmp = uprev+dt*(a1801*k[1]+a1808*k[2]+a1809*k[3]+a1810*k[4]+a1811*k[5]+a1812*k[6]+a1813*k[7]+a1814*k[8]+a1815*k[9]+a1817*k[11])
-    f(k[12],tmp,p,t+c18*dt)
+    f(k[12], tmp, t+c18*dt, integrator)
     @.. tmp = uprev+dt*(a1901*k[1]+a1908*k[2]+a1909*k[3]+a1910*k[4]+a1911*k[5]+a1912*k[6]+a1913*k[7]+a1914*k[8]+a1915*k[9]+a1917*k[11]+a1918*k[12])
-    f(k[13],tmp,p,t+c19*dt)
+    f(k[13], tmp, t+c19*dt, integrator)
     @.. tmp = uprev+dt*(a2001*k[1]+a2008*k[2]+a2009*k[3]+a2010*k[4]+a2011*k[5]+a2012*k[6]+a2013*k[7]+a2014*k[8]+a2015*k[9]+a2017*k[11]+a2018*k[12]+a2019*k[13])
-    f(k[14],tmp,p,t+c20*dt)
+    f(k[14], tmp, t+c20*dt, integrator)
     @.. tmp = uprev+dt*(a2101*k[1]+a2108*k[2]+a2109*k[3]+a2110*k[4]+a2111*k[5]+a2112*k[6]+a2113*k[7]+a2114*k[8]+a2115*k[9]+a2117*k[11]+a2118*k[12]+a2119*k[13]+a2120*k[14])
-    f(k[15],tmp,p,t+c21*dt)
+    f(k[15], tmp, t+c21*dt, integrator)
     @.. tmp = uprev+dt*(a2201*k[1]+a2208*k[2]+a2209*k[3]+a2210*k[4]+a2211*k[5]+a2212*k[6]+a2213*k[7]+a2214*k[8]+a2215*k[9]+a2217*k[11]+a2218*k[12]+a2219*k[13]+a2220*k[14]+a2221*k[15])
-    f(k[16],tmp,p,t+c22*dt)
+    f(k[16], tmp, t+c22*dt, integrator)
     @.. tmp = uprev+dt*(a2301*k[1]+a2308*k[2]+a2309*k[3]+a2310*k[4]+a2311*k[5]+a2312*k[6]+a2313*k[7]+a2314*k[8]+a2315*k[9]+a2317*k[11]+a2318*k[12]+a2319*k[13]+a2320*k[14]+a2321*k[15])
-    f(k[17],tmp,p,t+c23*dt)
+    f(k[17], tmp, t+c23*dt, integrator)
     @.. tmp  = uprev+dt*(a2401*k[1]+a2408*k[2]+a2409*k[3]+a2410*k[4]+a2411*k[5]+a2412*k[6]+a2413*k[7]+a2414*k[8]+a2415*k[9]+a2417*k[11]+a2418*k[12]+a2419*k[13]+a2420*k[14]+a2421*k[15])
-    f(k[18],tmp,p,t+c24*dt)
+    f(k[18], tmp, t+c24*dt, integrator)
     @.. tmp = uprev+dt*(a2501*k[1]+a2508*k[2]+a2509*k[3]+a2510*k[4]+a2511*k[5]+a2512*k[6]+a2513*k[7]+a2514*k[8]+a2515*k[9]+a2517*k[11]+a2518*k[12]+a2519*k[13]+a2520*k[14]+a2521*k[15])
-    f(k[19],tmp,p,t+c25*dt)
+    f(k[19], tmp, t+c25*dt, integrator)
     @.. tmp = uprev+dt*(a2601*k[1]+a2608*k[2]+a2609*k[3]+a2610*k[4]+a2611*k[5]+a2612*k[6]+a2613*k[7]+a2614*k[8]+a2615*k[9]+a2617*k[11]+a2618*k[12]+a2619*k[13]+a2620*k[14]+a2621*k[15])
     integrator.destats.nf += 10
-    f(k[20],tmp,p,t+c26*dt)
+    f(k[20], tmp, t+c26*dt, integrator)
   end
   return nothing
 end
 
 #=
 @muladd function perform_step!(integrator, cache::Vern9Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack t,dt,uprev,u,f = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0806,a0807,a0901,a0906,a0907,a0908,a1001,a1006,a1007,a1008,a1009,a1101,a1106,a1107,a1108,a1109,a1110,a1201,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,b1,b8,b9,b10,b11,b12,b13,b14,b15,btilde1,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13,btilde14,btilde15,btilde16 = cache.tab
   @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,utilde,tmp,atmp = cache
-  f(k1, uprev, p, t)
+  f(k1, uprev, t, integrator)
   a = dt*a0201
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+a*k1[i]
   end
-  f(k2, tmp, p, t + c1*dt)
+  f(k2, tmp, t + c1*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
   end
-  f(k3, tmp, p, t + c2*dt)
+  f(k3, tmp, t + c2*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
   end
-  f(k4, tmp, p, t + c3*dt)
+  f(k4, tmp, t + c3*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
   end
-  f(k5, tmp, p, t + c4*dt)
+  f(k5, tmp, t + c4*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
   end
-  f(k6, tmp, p, t + c5*dt)
+  f(k6, tmp, t + c5*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
   end
-  f(k7, tmp, p, t + c6*dt)
+  f(k7, tmp, t + c6*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0806*k6[i]+a0807*k7[i])
   end
-  f(k8, tmp, p, t + c7*dt)
+  f(k8, tmp, t + c7*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
   end
-  f(k9, tmp, p, t + c8*dt)
+  f(k9, tmp, t + c8*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
   end
-  f(k10, tmp, p, t + c9*dt)
+  f(k10, tmp, t + c9*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
   end
-  f(k11, tmp, p, t + c10*dt)
+  f(k11, tmp, t + c10*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
   end
-  f(k12, tmp, p, t + c11*dt)
+  f(k12, tmp, t + c11*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1301*k1[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i]+a1311*k11[i]+a1312*k12[i])
   end
-  f(k13, tmp, p, t + c12*dt)
+  f(k13, tmp, t + c12*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1401*k1[i]+a1406*k6[i]+a1407*k7[i]+a1408*k8[i]+a1409*k9[i]+a1410*k10[i]+a1411*k11[i]+a1412*k12[i]+a1413*k13[i])
   end
-  f(k14, tmp, p, t + c13*dt)
+  f(k14, tmp, t + c13*dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds tmp[i] = uprev[i]+dt*(a1501*k1[i]+a1506*k6[i]+a1507*k7[i]+a1508*k8[i]+a1509*k9[i]+a1510*k10[i]+a1511*k11[i]+a1512*k12[i]+a1513*k13[i]+a1514*k14[i])
   end
-  f(k15, tmp, p, t+dt)
+  f(k15, tmp, t+dt, integrator)
   @tight_loop_macros for i in uidx
     @inbounds u[i] = uprev[i]+dt*(a1601*k1[i]+a1606*k6[i]+a1607*k7[i]+a1608*k8[i]+a1609*k9[i]+a1610*k10[i]+a1611*k11[i]+a1612*k12[i]+a1613*k13[i])
   end
-  f(k16, u, p, t+dt)
+  f(k16, u, t+dt, integrator)
   integrator.destats.nf += 16
   if typeof(integrator.alg) <: CompositeAlgorithm
     g16 = u
@@ -1007,44 +1007,44 @@ end
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1701*k[1][i]+a1708*k[2][i]+a1709*k[3][i]+a1710*k[4][i]+a1711*k[5][i]+a1712*k[6][i]+a1713*k[7][i]+a1714*k[8][i]+a1715*k[9][i])
     end
-    f(k[11],tmp,p,t+c17*dt)
+    f(k[11], tmp, t+c17*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1801*k[1][i]+a1808*k[2][i]+a1809*k[3][i]+a1810*k[4][i]+a1811*k[5][i]+a1812*k[6][i]+a1813*k[7][i]+a1814*k[8][i]+a1815*k[9][i]+a1817*k[11][i])
     end
-    f(k[12],tmp,p,t+c18*dt)
+    f(k[12], tmp, t+c18*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a1901*k[1][i]+a1908*k[2][i]+a1909*k[3][i]+a1910*k[4][i]+a1911*k[5][i]+a1912*k[6][i]+a1913*k[7][i]+a1914*k[8][i]+a1915*k[9][i]+a1917*k[11][i]+a1918*k[12][i])
     end
-    f(k[13],tmp,p,t+c19*dt)
+    f(k[13], tmp, t+c19*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2001*k[1][i]+a2008*k[2][i]+a2009*k[3][i]+a2010*k[4][i]+a2011*k[5][i]+a2012*k[6][i]+a2013*k[7][i]+a2014*k[8][i]+a2015*k[9][i]+a2017*k[11][i]+a2018*k[12][i]+a2019*k[13][i])
     end
-    f(k[14],tmp,p,t+c20*dt)
+    f(k[14], tmp, t+c20*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2101*k[1][i]+a2108*k[2][i]+a2109*k[3][i]+a2110*k[4][i]+a2111*k[5][i]+a2112*k[6][i]+a2113*k[7][i]+a2114*k[8][i]+a2115*k[9][i]+a2117*k[11][i]+a2118*k[12][i]+a2119*k[13][i]+a2120*k[14][i])
     end
-    f(k[15],tmp,p,t+c21*dt)
+    f(k[15], tmp, t+c21*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2201*k[1][i]+a2208*k[2][i]+a2209*k[3][i]+a2210*k[4][i]+a2211*k[5][i]+a2212*k[6][i]+a2213*k[7][i]+a2214*k[8][i]+a2215*k[9][i]+a2217*k[11][i]+a2218*k[12][i]+a2219*k[13][i]+a2220*k[14][i]+a2221*k[15][i])
     end
-    f(k[16],tmp,p,t+c22*dt)
+    f(k[16], tmp, t+c22*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2301*k[1][i]+a2308*k[2][i]+a2309*k[3][i]+a2310*k[4][i]+a2311*k[5][i]+a2312*k[6][i]+a2313*k[7][i]+a2314*k[8][i]+a2315*k[9][i]+a2317*k[11][i]+a2318*k[12][i]+a2319*k[13][i]+a2320*k[14][i]+a2321*k[15][i])
     end
-    f(k[17],tmp,p,t+c23*dt)
+    f(k[17], tmp, t+c23*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i]  = uprev[i]+dt*(a2401*k[1][i]+a2408*k[2][i]+a2409*k[3][i]+a2410*k[4][i]+a2411*k[5][i]+a2412*k[6][i]+a2413*k[7][i]+a2414*k[8][i]+a2415*k[9][i]+a2417*k[11][i]+a2418*k[12][i]+a2419*k[13][i]+a2420*k[14][i]+a2421*k[15][i])
     end
-    f(k[18],tmp,p,t+c24*dt)
+    f(k[18], tmp, t+c24*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2501*k[1][i]+a2508*k[2][i]+a2509*k[3][i]+a2510*k[4][i]+a2511*k[5][i]+a2512*k[6][i]+a2513*k[7][i]+a2514*k[8][i]+a2515*k[9][i]+a2517*k[11][i]+a2518*k[12][i]+a2519*k[13][i]+a2520*k[14][i]+a2521*k[15][i])
     end
-    f(k[19],tmp,p,t+c25*dt)
+    f(k[19], tmp, t+c25*dt, integrator)
     @tight_loop_macros for i in uidx
       @inbounds tmp[i] = uprev[i]+dt*(a2601*k[1][i]+a2608*k[2][i]+a2609*k[3][i]+a2610*k[4][i]+a2611*k[5][i]+a2612*k[6][i]+a2613*k[7][i]+a2614*k[8][i]+a2615*k[9][i]+a2617*k[11][i]+a2618*k[12][i]+a2619*k[13][i]+a2620*k[14][i]+a2621*k[15][i])
     end
     integrator.destats.nf += 10
-    f(k[20],tmp,p,t+c26*dt)
+    f(k[20], tmp, t+c26*dt, integrator)
   end
 end
 =#

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -288,7 +288,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem,
                       calculate_error = false, destats=destats)
   end
 
-  if recompile_flag == true
+  if recompile_flag
     FType = typeof(f)
     SolType = typeof(sol)
     cacheType = typeof(cache)

--- a/test/integrators/event_detection_tests.jl
+++ b/test/integrators/event_detection_tests.jl
@@ -38,11 +38,10 @@ sol=solve(prob, Vern9(), abstol=1e-14, reltol=1e-14, save_everystep=false, save_
 
 @test length(sol) > 1500
 
-using ParameterizedFunctions
-f = @ode_def BallBounce begin
-  dy =  v
-  dv = -g
-end g
+f = function (du,u,p,t)
+  du[1] = u[2]
+  du[2] = -p[1]
+end
 function condition(u,t,integrator) # Event when event_f(u,t) == 0
   u[1]
 end


### PR DESCRIPTION
I started to pass `integrator` instead of `p` when calling `f` (see https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/116). I tried to be consistent with the method signatures used for continuous callbacks (http://docs.juliadiffeq.org/latest/features/callback_functions.html#ContinuousCallbacks-1), and hence replaced `f([du, ]u, p, t)` with `f([du, ]u, t, integrator)`. Depending on whether the user wants to unpack the parameters of `integrator` (which would be default) or not, this call would be forwarded to `f.f([du, ], u, get_param(integrator), t)` or `f.f([du, ], u, t, integrator)`. [It would be possible to just forward the arguments to `f.f` if the last argument is not a `DEIntegrator` - not sure whether that would be useful but then it would still be possible for a user to evaluate `f` with a fixed set of parameters.]

However, even at this early stage of the implementation I noticed some (possible) issues:
- As mentioned in https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/116#issuecomment-508266533, I don't know how to avoid passing `p` in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/integrators/integrator_utils.jl#L399 since that call happens before the integrator is created.
- Similarly, the ODE solution is created before the integrator exists. That seems problematic due to https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/master/src/solutions/ode_solutions.jl#L15-L16: the solution will always compute an interpolation based on the parameters of the ODE problem and not on the integrator.

The primary use case I had in mind (not knowing how well this will work in the end) was passing around the integrator while solving DDEs, to be able to access the history function more easily/directly. In this case it seems strange/insufficient if the solution would only pass around the parameters.

The problem regarding the solution could maybe be avoided if the solution is not part of the integrator, and e.g. only created in `solve!(integrator)` (which could forward to `solve!!(sol, integrator)` to allow passing an existing solution) and then passed to `loopfooter!` and `postamble!`. However, since in that case the solution could not be accessed as a field of `integrator`, it's not obvious anymore that the whole setup would be beneficial for solving DDEs.

Since I confused myself quite a bit now, I'm wondering:
- What would be a typical scenario and function `f` in an ODE setting, in which we want to pass around `integrator`?
- In such a scenario, is it reasonable to assume that the analytic solution does not depend on the integrator?
- Which other properties can we expect to not depend on the integrator but only on the problem parameters? Or could everything be dependent on `integrator`?