### PR TITLE
[WIP] Remove redundant NLSolve fields from alg cache

### DIFF
--- a/src/bdf_utils.jl
+++ b/src/bdf_utils.jl
@@ -48,7 +48,7 @@ end
 # Implementation of an Adaptive BDF2 Formula and Comparison with the MATLAB Ode15s paper
 # E. Alberdi Celaya, J. J. Anza Aguirrezabala, and P. Chatzipantelidis
 function reinterpolate_history!(cache::OrdinaryDiffEqMutableCache, D, R, k)
-  @unpack tmp = cache
+  @unpack tmp = cache.nlsolver
   fill!(tmp,zero(eltype(D[1])))
   for j = 1:k
     for k = 1:k

--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -917,8 +917,8 @@ end
 
 function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//2, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   k2 = rate_prototype
@@ -931,7 +931,7 @@ end
 function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//2, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   k1 = zero(rate_prototype)
@@ -980,8 +980,8 @@ end
 
 function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//1, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   k2 = rate_prototype
@@ -995,7 +995,7 @@ end
 function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   k1 = zero(rate_prototype)

--- a/src/caches/adams_bashforth_moulton_caches.jl
+++ b/src/caches/adams_bashforth_moulton_caches.jl
@@ -883,33 +883,21 @@ end
 
 # CNAB2
 
-@cache mutable struct CNAB2ConstantCache{rateType,F,N,uType,tType} <: OrdinaryDiffEqConstantCache
+@cache mutable struct CNAB2ConstantCache{rateType,N,uType,tType} <: OrdinaryDiffEqConstantCache
   k2::rateType
-  uf::F
   nlsolver::N
   uprev3::uType
   tprev2::tType
 end
 
-@cache mutable struct CNAB2Cache{uType,rateType,JType,WType,UF,JC,N,tType,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct CNAB2Cache{uType,rateType,N,tType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
   fsalfirst::rateType
-  k::rateType
   k1::rateType
   k2::rateType
   du₁::rateType
-  du1::rateType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   uprev3::uType
   tprev2::tType
@@ -919,20 +907,19 @@ function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = 1//2, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   k2 = rate_prototype
   uprev3 = u
   tprev2 = t
 
-  CNAB2ConstantCache(k2,uf,nlsolver,uprev3,tprev2)
+  CNAB2ConstantCache(k2,nlsolver,uprev3,tprev2)
 end
 
 function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//2, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   k1 = zero(rate_prototype)
   k2 = zero(rate_prototype)
@@ -940,39 +927,27 @@ function alg_cache(alg::CNAB2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev3 = zero(u)
   tprev2 = t
 
-  CNAB2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolver,uprev3,tprev2)
+  CNAB2Cache(u,uprev,uprev2,fsalfirst,k1,k2,du₁,nlsolver,uprev3,tprev2)
 end
 
 # CNLF2
 
-@cache mutable struct CNLF2ConstantCache{rateType,F,N,uType,tType} <: OrdinaryDiffEqConstantCache
+@cache mutable struct CNLF2ConstantCache{rateType,N,uType,tType} <: OrdinaryDiffEqConstantCache
   k2::rateType
-  uf::F
   nlsolver::N
   uprev2::uType
   uprev3::uType
   tprev2::tType
 end
 
-@cache mutable struct CNLF2Cache{uType,rateType,JType,WType,UF,JC,N,tType,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct CNLF2Cache{uType,rateType,N,tType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
   fsalfirst::rateType
-  k::rateType
   k1::rateType
   k2::rateType
   du₁::rateType
-  du1::rateType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   uprev3::uType
   tprev2::tType
@@ -982,21 +957,20 @@ function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = 1//1, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   k2 = rate_prototype
   uprev2 = u
   uprev3 = u
   tprev2 = t
 
-  CNLF2ConstantCache(k2,uf,nlsolver,uprev2,uprev3,tprev2)
+  CNLF2ConstantCache(k2,nlsolver,uprev2,uprev3,tprev2)
 end
 
 function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   k1 = zero(rate_prototype)
   k2 = zero(rate_prototype)
@@ -1005,5 +979,5 @@ function alg_cache(alg::CNLF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev3 = zero(u)
   tprev2 = t
 
-  CNLF2Cache(u,uprev,uprev2,fsalfirst,k,k1,k2,du₁,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolver,uprev3,tprev2)
+  CNLF2Cache(u,uprev,uprev2,fsalfirst,k1,k2,du₁,nlsolver,uprev3,tprev2)
 end

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -66,7 +66,7 @@ end
   du₂::rateType
 end
 
-@cache mutable struct SBDFCache{uType,rateType,N,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct SBDFCache{uType,rateType,N} <: OrdinaryDiffEqMutableCache
   cnt::Int
   u::uType
   uprev::uType

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -1,5 +1,4 @@
-@cache mutable struct ABDF2ConstantCache{F,N,dtType,rate_prototype} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct ABDF2ConstantCache{N,dtType,rate_prototype} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   eulercache::ImplicitEulerConstantCache
   dtₙ₋₁::dtType
@@ -8,40 +7,25 @@ end
 
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
-  γ, c = 1//1, 1
+  γ, c = 2//3, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  eulercache = ImplicitEulerConstantCache(uf,nlsolver)
-
-  nlsolver.γ = 2//3
-  nlsolver.c = 1
+  eulercache = ImplicitEulerConstantCache(nlsolver)
 
   dtₙ₋₁ = one(dt)
   fsalfirstprev = rate_prototype
 
-  ABDF2ConstantCache(uf, nlsolver, eulercache, dtₙ₋₁, fsalfirstprev)
+  ABDF2ConstantCache(nlsolver, eulercache, dtₙ₋₁, fsalfirstprev)
 end
 
-@cache mutable struct ABDF2Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,F,dtType} <: OrdinaryDiffEqMutableCache
+@cache mutable struct ABDF2Cache{uType,rateType,uNoUnitsType,N,dtType} <: OrdinaryDiffEqMutableCache
   uₙ::uType
   uₙ₋₁::uType
   uₙ₋₂::uType
-  du1::rateType
   fsalfirst::rateType
   fsalfirstprev::rateType
-  k::rateType
-  z::uType
   zₙ₋₁::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   eulercache::ImplicitEulerCache
   dtₙ₋₁::dtType
@@ -49,32 +33,28 @@ end
 
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
-  γ, c = 1//1, 1
+  γ, c = 2//3, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   fsalfirstprev = zero(rate_prototype)
   atmp = similar(u,uEltypeNoUnits)
 
-  eulercache = ImplicitEulerCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolver)
-
-  nlsolver.γ = 2//3
-  nlsolver.c = 1
+  eulercache = ImplicitEulerCache(u,uprev,uprev2,fsalfirst,atmp,nlsolver)
 
   dtₙ₋₁ = one(dt)
   zₙ₋₁ = zero(u)
 
-  ABDF2Cache(u,uprev,uprev2,du1,fsalfirst,fsalfirstprev,k,z,zₙ₋₁,dz,b,tmp,atmp,J,
-              W,uf,jac_config,linsolve,nlsolver,eulercache,dtₙ₋₁)
+  ABDF2Cache(u,uprev,uprev2,fsalfirst,fsalfirstprev,zₙ₋₁,atmp,
+              nlsolver,eulercache,dtₙ₋₁)
 end
 
 # SBDF
 
-@cache mutable struct SBDFConstantCache{rateType,F,N,uType} <: OrdinaryDiffEqConstantCache
+@cache mutable struct SBDFConstantCache{rateType,N,uType} <: OrdinaryDiffEqConstantCache
   cnt::Int
   k2::rateType
-  uf::F
   nlsolver::N
   uprev2::uType
   uprev4::uType
@@ -86,22 +66,11 @@ end
   du₂::rateType
 end
 
-@cache mutable struct SBDFCache{uType,rateType,JType,WType,UF,JC,N,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct SBDFCache{uType,rateType,N,F} <: OrdinaryDiffEqMutableCache
   cnt::Int
   u::uType
   uprev::uType
   fsalfirst::rateType
-  k::rateType
-  du1::rateType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   uprev2::uType
   uprev3::uType
@@ -117,7 +86,6 @@ function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   γ, c = 1//1, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   k2 = rate_prototype
   k₁ = rate_prototype; k₂ = rate_prototype; k₃ = rate_prototype
@@ -125,14 +93,14 @@ function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
 
   uprev2 = u; uprev3 = u; uprev4 = u
 
-  SBDFConstantCache(1,k2,uf,nlsolver,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
+  SBDFConstantCache(1,k2,nlsolver,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
 function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   order = alg.order
 
@@ -146,13 +114,12 @@ function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   uprev3 = order >= 3 ? zero(u) : uprev2
   uprev4 = order == 4 ? zero(u) : uprev2
 
-  SBDFCache(1,u,uprev,fsalfirst,k,du1,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolver,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
+  SBDFCache(1,u,uprev,fsalfirst,nlsolver,uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂)
 end
 
 # QNDF1
 
-@cache mutable struct QNDF1ConstantCache{F,N,coefType,coefType1,dtType,uType} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct QNDF1ConstantCache{N,coefType,coefType1,dtType,uType} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   D::coefType
   D2::coefType1
@@ -162,26 +129,15 @@ end
   dtₙ₋₁::dtType
 end
 
-@cache mutable struct QNDF1Cache{uType,rateType,coefType,coefType1,coefType2,uNoUnitsType,JType,WType,UF,JC,N,F,dtType} <: OrdinaryDiffEqMutableCache
+@cache mutable struct QNDF1Cache{uType,rateType,coefType,coefType1,coefType2,uNoUnitsType,N,dtType} <: OrdinaryDiffEqMutableCache
   uprev2::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
-  z::uType
-  dz::uType
-  b::uType
   D::coefType1
   D2::coefType2
   R::coefType
   U::coefType
-  tmp::uType
   atmp::uNoUnitsType
   utilde::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   dtₙ₋₁::dtType
 end
@@ -190,7 +146,6 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = zero(inv((1-alg.kappa))), 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   uprev2 = u
   dtₙ₋₁ = t
@@ -202,14 +157,14 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   U!(1,U)
 
-  QNDF1ConstantCache(uf,nlsolver,D,D2,R,U,uprev2,dtₙ₋₁)
+  QNDF1ConstantCache(nlsolver,D,D2,R,U,uprev2,dtₙ₋₁)
 end
 
 function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = zero(inv((1-alg.kappa))), 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   D = Array{typeof(u)}(undef, 1, 1)
   D2 = Array{typeof(u)}(undef, 1, 2)
@@ -226,14 +181,12 @@ function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uprev2 = zero(u)
   dtₙ₋₁ = one(dt)
 
-  QNDF1Cache(uprev2,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
-              W,uf,jac_config,linsolve,nlsolver,dtₙ₋₁)
+  QNDF1Cache(uprev2,fsalfirst,D,D2,R,U,atmp,utilde,nlsolver,dtₙ₋₁)
 end
 
 # QNDF2
 
-@cache mutable struct QNDF2ConstantCache{F,N,coefType,coefType1,uType,dtType} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct QNDF2ConstantCache{N,coefType,coefType1,uType,dtType} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   D::coefType
   D2::coefType
@@ -245,27 +198,16 @@ end
   dtₙ₋₂::dtType
 end
 
-@cache mutable struct QNDF2Cache{uType,rateType,coefType,coefType1,coefType2,uNoUnitsType,JType,WType,UF,JC,N,F,dtType} <: OrdinaryDiffEqMutableCache
+@cache mutable struct QNDF2Cache{uType,rateType,coefType,coefType1,coefType2,uNoUnitsType,N,dtType} <: OrdinaryDiffEqMutableCache
   uprev2::uType
   uprev3::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
-  z::uType
-  dz::uType
-  b::uType
   D::coefType1
   D2::coefType2
   R::coefType
   U::coefType
-  tmp::uType
   atmp::uNoUnitsType
   utilde::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   dtₙ₋₁::dtType
   dtₙ₋₂::dtType
@@ -275,7 +217,6 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = zero(inv((1-alg.kappa))), 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   uprev2 = u
   uprev3 = u
@@ -289,14 +230,14 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
 
   U!(2,U)
 
-  QNDF2ConstantCache(uf,nlsolver,D,D2,R,U,uprev2,uprev3,dtₙ₋₁,dtₙ₋₂)
+  QNDF2ConstantCache(nlsolver,D,D2,R,U,uprev2,uprev3,dtₙ₋₁,dtₙ₋₂)
 end
 
 function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = zero(inv((1-alg.kappa))), 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   D = Array{typeof(u)}(undef, 1, 2)
   D2 = Array{typeof(u)}(undef, 1, 3)
@@ -315,12 +256,10 @@ function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   dtₙ₋₁ = zero(dt)
   dtₙ₋₂ = zero(dt)
 
-  QNDF2Cache(uprev2,uprev3,du1,fsalfirst,k,z,dz,b,D,D2,R,U,tmp,atmp,utilde,J,
-             W,uf,jac_config,linsolve,nlsolver,dtₙ₋₁,dtₙ₋₂)
+  QNDF2Cache(uprev2,uprev3,fsalfirst,D,D2,R,U,atmp,utilde,nlsolver,dtₙ₋₁,dtₙ₋₂)
 end
 
-@cache mutable struct QNDFConstantCache{F,N,coefType1,coefType2,coefType3,uType,dtType,dtsType} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct QNDFConstantCache{N,coefType1,coefType2,coefType3,uType,dtType,dtsType} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   D::coefType3
   D2::coefType2
@@ -334,13 +273,8 @@ end
   c::Int64
 end
 
-@cache mutable struct QNDFCache{uType,rateType,coefType1,coefType,coefType2,coefType3,dtType,dtsType,uNoUnitsType,JType,WType,UF,JC,N,F} <: OrdinaryDiffEqMutableCache
-  du1::rateType
+@cache mutable struct QNDFCache{uType,rateType,coefType1,coefType,coefType2,coefType3,dtType,dtsType,uNoUnitsType,N} <: OrdinaryDiffEqMutableCache
   fsalfirst::rateType
-  k::rateType
-  z::uType
-  dz::uType
-  b::uType
   D::coefType3
   D2::coefType2
   R::coefType1
@@ -349,14 +283,8 @@ end
   max_order::Int64
   udiff::coefType
   dts::dtsType
-  tmp::uType
   atmp::uNoUnitsType
   utilde::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   h::dtType
   c::Int64
@@ -366,7 +294,6 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   γ, c = one(eltype(alg.kappa)), 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   udiff = fill(zero(u), 1, 6)
   dts = fill(zero(dt), 1, 6)
@@ -379,14 +306,14 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
 
   max_order = 5
 
-  QNDFConstantCache(uf,nlsolver,D,D2,R,U,1,max_order,udiff,dts,h,0)
+  QNDFConstantCache(nlsolver,D,D2,R,U,1,max_order,udiff,dts,h,0)
 end
 
 function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = one(eltype(alg.kappa)), 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   udiff = Array{typeof(u)}(undef, 1, 6)
   dts = fill(zero(dt), 1, 6)
@@ -409,33 +336,21 @@ function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
 
   max_order = 5
   atmp = similar(u,uEltypeNoUnits)
-  utilde = tmp
+  utilde = nlsolver.tmp
 
-  QNDFCache(du1,fsalfirst,k,z,dz,b,D,D2,R,U,1,max_order,udiff,dts,tmp,atmp,utilde,J,
-            W,uf,jac_config,linsolve,nlsolver,h,0)
+  QNDFCache(fsalfirst,D,D2,R,U,1,max_order,udiff,dts,atmp,utilde,nlsolver,h,0)
 end
 
 
-@cache mutable struct MEBDF2Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,F,N} <: OrdinaryDiffEqMutableCache
+@cache mutable struct MEBDF2Cache{uType,rateType,uNoUnitsType,N} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   uprev2::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
-  z::uType
   z₁::uType
   z₂::uType
   tmp2::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
 end
 
@@ -444,16 +359,15 @@ function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = 1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); tmp2 = zero(u)
   atmp = similar(u,uEltypeNoUnits)
 
-  MEBDF2Cache(u,uprev,uprev2,du1,fsalfirst,k,z,z₁,z₂,tmp2,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolver)
+  MEBDF2Cache(u,uprev,uprev2,fsalfirst,z₁,z₂,tmp2,atmp,nlsolver)
 end
 
-mutable struct MEBDF2ConstantCache{F,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct MEBDF2ConstantCache{N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
 end
 
@@ -462,6 +376,5 @@ function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = 1, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  MEBDF2ConstantCache(uf,nlsolver)
+  MEBDF2ConstantCache(nlsolver)
 end

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -9,8 +9,8 @@ end
 function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//1, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   eulercache = ImplicitEulerConstantCache(uf,nlsolver)
 
@@ -51,7 +51,7 @@ function alg_cache(alg::ABDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   fsalfirstprev = zero(rate_prototype)
@@ -115,8 +115,8 @@ end
 
 function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//1, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   k2 = rate_prototype
@@ -131,7 +131,7 @@ end
 function alg_cache(alg::SBDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   order = alg.order
@@ -188,8 +188,8 @@ end
 
 function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = zero(inv((1-alg.kappa))), 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   uprev2 = u
@@ -208,7 +208,7 @@ end
 function alg_cache(alg::QNDF1,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = zero(inv((1-alg.kappa))), 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   D = Array{typeof(u)}(undef, 1, 1)
@@ -273,8 +273,8 @@ end
 
 function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = zero(inv((1-alg.kappa))), 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   uprev2 = u
@@ -295,7 +295,7 @@ end
 function alg_cache(alg::QNDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = zero(inv((1-alg.kappa))), 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   D = Array{typeof(u)}(undef, 1, 2)
@@ -364,8 +364,8 @@ end
 
 function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = one(eltype(alg.kappa)), 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   udiff = fill(zero(u), 1, 6)
@@ -385,7 +385,7 @@ end
 function alg_cache(alg::QNDF,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = one(eltype(alg.kappa)), 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   udiff = Array{typeof(u)}(undef, 1, 6)
@@ -443,7 +443,7 @@ function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); tmp2 = zero(u)
@@ -460,8 +460,8 @@ end
 function alg_cache(alg::MEBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   MEBDF2ConstantCache(uf,nlsolver)
 end

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -8,8 +8,8 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = KenCarp3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   KenCarp3ConstantCache(uf,nlsolver,tab)
@@ -47,7 +47,7 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = KenCarp3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   if typeof(f) <: SplitFunction
@@ -76,8 +76,8 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   Kvaerno4ConstantCache(uf,nlsolver,tab)
 end
@@ -111,7 +111,7 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = Kvaerno4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = z
@@ -131,8 +131,8 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   KenCarp4ConstantCache(uf,nlsolver,tab)
 end
@@ -173,7 +173,7 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = KenCarp4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   if typeof(f) <: SplitFunction
@@ -206,8 +206,8 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = Kvaerno5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   Kvaerno5ConstantCache(uf,nlsolver,tab)
@@ -244,7 +244,7 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = Kvaerno5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = zero(u)
@@ -265,8 +265,8 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   KenCarp5ConstantCache(uf,nlsolver,tab)
@@ -312,7 +312,7 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = KenCarp5Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   if typeof(f) <: SplitFunction

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -175,7 +175,6 @@ end
   u::uType
   uprev::uType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -64,7 +64,7 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  Kvaerno4ConstantCache(uf,nlsolver,tab)
+  Kvaerno4ConstantCache(nlsolver,tab)
 end
 
 @cache mutable struct Kvaerno4Cache{uType,rateType,uNoUnitsType,N,Tab} <: SDIRKMutableCache

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -1,5 +1,4 @@
-@cache mutable struct KenCarp3ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct KenCarp3ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -10,17 +9,14 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
-  KenCarp3ConstantCache(uf,nlsolver,tab)
+  KenCarp3ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct KenCarp3Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,Tab,F,kType} <: SDIRKMutableCache
+@cache mutable struct KenCarp3Cache{uType,rateType,uNoUnitsType,N,Tab,kType} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
@@ -29,15 +25,7 @@ end
   k2::kType
   k3::kType
   k4::kType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -48,7 +36,7 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   if typeof(f) <: SplitFunction
     k1 = similar(u); k2 = similar(u)
@@ -59,15 +47,13 @@ function alg_cache(alg::KenCarp3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
-  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = z
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  KenCarp3Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,k1,k2,k3,k4,dz,b,tmp,atmp,J,
-                W,uf,jac_config,linsolve,nlsolver,tab)
+  KenCarp3Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,k1,k2,k3,k4,atmp,nlsolver,tab)
 end
 
-@cache mutable struct Kvaerno4ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct Kvaerno4ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -78,30 +64,19 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
   Kvaerno4ConstantCache(uf,nlsolver,tab)
 end
 
-@cache mutable struct Kvaerno4Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,Tab,F} <: SDIRKMutableCache
+@cache mutable struct Kvaerno4Cache{uType,rateType,uNoUnitsType,N,Tab} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
   z₄::uType
   z₅::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -112,17 +87,15 @@ function alg_cache(alg::Kvaerno4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
-  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = z
+  z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  Kvaerno4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
-                W,uf,jac_config,linsolve,nlsolver,tab)
+  Kvaerno4Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,atmp,nlsolver,tab)
 end
 
-@cache mutable struct KenCarp4ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct KenCarp4ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -133,16 +106,13 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  KenCarp4ConstantCache(uf,nlsolver,tab)
+  KenCarp4ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct KenCarp4Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,Tab,F,kType} <: SDIRKMutableCache
+@cache mutable struct KenCarp4Cache{uType,rateType,uNoUnitsType,N,Tab,kType} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
@@ -155,15 +125,7 @@ end
   k4::kType
   k5::kType
   k6::kType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -174,7 +136,7 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   if typeof(f) <: SplitFunction
     k1 = similar(u); k2 = similar(u)
@@ -188,16 +150,13 @@ function alg_cache(alg::KenCarp4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   end
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = zero(u)
-  z₆ = z
+  z₆ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  KenCarp4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,k1,k2,k3,k4,k5,k6,
-                dz,b,tmp,atmp,J,
-                W,uf,jac_config,linsolve,nlsolver,tab)
+  KenCarp4Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,z₆,k1,k2,k3,k4,k5,k6,atmp,nlsolver,tab)
 end
 
-@cache mutable struct Kvaerno5ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct Kvaerno5ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -208,15 +167,13 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
-  Kvaerno5ConstantCache(uf,nlsolver,tab)
+  Kvaerno5ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct Kvaerno5Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,Tab,F} <: SDIRKMutableCache
+@cache mutable struct Kvaerno5Cache{uType,rateType,uNoUnitsType,N,Tab} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
   k::rateType
   z₁::uType
@@ -226,15 +183,7 @@ end
   z₅::uType
   z₆::uType
   z₇::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -245,18 +194,16 @@ function alg_cache(alg::Kvaerno5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u); z₅ = zero(u)
-  z₆ = zero(u); z₇ = z
+  z₆ = zero(u); z₇ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  Kvaerno5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,dz,b,tmp,atmp,J,
-                W,uf,jac_config,linsolve,nlsolver,tab)
+  Kvaerno5Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,z₆,z₇,atmp,nlsolver,tab)
 end
 
-@cache mutable struct KenCarp5ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+@cache mutable struct KenCarp5ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -267,17 +214,14 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
-  KenCarp5ConstantCache(uf,nlsolver,tab)
+  KenCarp5ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct KenCarp5Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,Tab,F,kType} <: SDIRKMutableCache
+@cache mutable struct KenCarp5Cache{uType,rateType,uNoUnitsType,N,Tab,kType} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
@@ -294,15 +238,7 @@ end
   k6::kType
   k7::kType
   k8::kType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -313,7 +249,7 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, tab.c3
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   if typeof(f) <: SplitFunction
     k1 = similar(u); k2 = similar(u)
@@ -325,15 +261,12 @@ function alg_cache(alg::KenCarp5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
     k3 = nothing; k4 = nothing
     k5 = nothing; k6 = nothing
     k7 = nothing; k8 = nothing
-    uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u)
-  z₅ = zero(u); z₆ = zero(u); z₇ = zero(u); z₈ = z
+  z₅ = zero(u); z₆ = zero(u); z₇ = zero(u); z₈ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  KenCarp5Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,
-                k1,k2,k3,k4,k5,k6,k7,k8,
-                dz,b,tmp,atmp,J,
-                W,uf,jac_config,linsolve,nlsolver,tab)
+  KenCarp5Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,
+                k1,k2,k3,k4,k5,k6,k7,k8,atmp,nlsolver,tab)
 end

--- a/src/caches/rkc_caches.jl
+++ b/src/caches/rkc_caches.jl
@@ -111,35 +111,24 @@ function alg_cache(alg::RKC,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits
   RKCConstantCache(u)
 end
 
-@cache mutable struct IRKCConstantCache{uType,rateType,F,N} <: OrdinaryDiffEqConstantCache
+@cache mutable struct IRKCConstantCache{uType,rateType,N} <: OrdinaryDiffEqConstantCache
   minm::Int64
   zprev::uType
-  uf::F
   nlsolver::N
   du₁::rateType
   du₂::rateType
 end
 
-@cache mutable struct IRKCCache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,F} <: OrdinaryDiffEqMutableCache
+@cache mutable struct IRKCCache{uType,rateType,uNoUnitsType,N} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   gprev::uType
   gprev2::uType
   fsalfirst::rateType
-  k::rateType
-  du1::rateType
   f1ⱼ₋₁::rateType
   f1ⱼ₋₂::rateType
   f2ⱼ₋₁::rateType
-  z::uType
-  dz::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   du₁::rateType
   du₂::rateType
@@ -150,32 +139,28 @@ function alg_cache(alg::IRKC,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnit
   γ, c = 1.0, 1.0
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
   zprev = u
   du₁ = rate_prototype; du₂ = rate_prototype
-  IRKCConstantCache(50,zprev,uf,nlsolver,du₁,du₂)
+  IRKCConstantCache(50,zprev,nlsolver,du₁,du₂)
 end
 
 function alg_cache(alg::IRKC,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1.0, 1.0
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
 
   gprev = similar(u)
   gprev2 = similar(u)
-  tmp = similar(u)
   atmp = similar(u,uEltypeNoUnits)
   fsalfirst = zero(rate_prototype)
-  k  = zero(rate_prototype)
   zprev = similar(u)
   f1ⱼ₋₁ = zero(rate_prototype)
   f1ⱼ₋₂ = zero(rate_prototype)
   f2ⱼ₋₁ = zero(rate_prototype)
   du₁ = zero(rate_prototype)
   du₂ = zero(rate_prototype)
-  constantcache = IRKCConstantCache(50,zprev,uf,nlsolver,du₁,du₂)
-  IRKCCache(u,uprev,gprev,gprev2,fsalfirst,k,du1,f1ⱼ₋₁,f1ⱼ₋₂,f2ⱼ₋₁,z,dz,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolver,du₁,du₂,constantcache)
+  constantcache = IRKCConstantCache(50,zprev,nlsolver,du₁,du₂)
+  IRKCCache(u,uprev,gprev,gprev2,fsalfirst,f1ⱼ₋₁,f1ⱼ₋₂,f2ⱼ₋₁,atmp,nlsolver,du₁,du₂,constantcache)
 end
 
 mutable struct ESERK4ConstantCache{T, zType} <: OrdinaryDiffEqConstantCache

--- a/src/caches/rkc_caches.jl
+++ b/src/caches/rkc_caches.jl
@@ -148,8 +148,8 @@ end
 
 function alg_cache(alg::IRKC,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1.0, 1.0
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   zprev = u
   du₁ = rate_prototype; du₂ = rate_prototype
@@ -159,7 +159,7 @@ end
 function alg_cache(alg::IRKC,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1.0, 1.0
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   gprev = similar(u)

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -24,7 +24,7 @@ function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomElt
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   atmp = similar(u,uEltypeNoUnits)
@@ -40,8 +40,8 @@ end
 function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   ImplicitEulerConstantCache(uf,nlsolver)
 end
@@ -53,8 +53,8 @@ end
 
 function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//2, 1//2
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   ImplicitMidpointConstantCache(uf,nlsolver)
 end
@@ -81,7 +81,7 @@ function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottom
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//2, 1//2
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
   ImplicitMidpointCache(u,uprev,du1,fsalfirst,k,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolver)
 end
@@ -96,8 +96,8 @@ end
 function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//2, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
 
   uprev3 = u
@@ -132,7 +132,7 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//2, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   uprev3 = zero(u)
@@ -152,8 +152,8 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = TRBDF2Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.d, tab.γ
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   TRBDF2ConstantCache(uf,nlsolver,tab)
 end
@@ -185,7 +185,7 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   tab = TRBDF2Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.d, tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   atmp = similar(u,uEltypeNoUnits); zprev = similar(u); zᵧ = similar(u)
@@ -202,8 +202,8 @@ end
 function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1, 1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   SDIRK2ConstantCache(uf,nlsolver)
 end
@@ -232,7 +232,7 @@ function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = similar(u); z₂ = z
@@ -250,8 +250,8 @@ end
 function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   γ, c = 1//4, 1//1
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   SSPSDIRK2ConstantCache(uf,nlsolver)
 end
@@ -279,7 +279,7 @@ function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
   γ, c = 1//4, 1//1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = similar(u); z₂ = z
@@ -299,8 +299,8 @@ function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = Kvaerno3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, 2tab.γ
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   Kvaerno3ConstantCache(uf,nlsolver,tab)
 end
@@ -333,7 +333,7 @@ function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   tab = Kvaerno3Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, 2tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = z
@@ -353,8 +353,8 @@ function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = Cash4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ,tab.γ
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   Cash4ConstantCache(uf,nlsolver,tab)
 end
@@ -388,7 +388,7 @@ function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   tab = Cash4Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ,tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = z
@@ -412,8 +412,8 @@ function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,
     tab = Hairer42Tableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   end
   γ, c = tab.γ, tab.γ
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   Hairer4ConstantCache(uf,nlsolver,tab)
 end
@@ -451,7 +451,7 @@ function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,
   end
   γ, c = tab.γ, tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = z
@@ -486,7 +486,7 @@ function alg_cache(alg::ESDIRK54I8L2SA,u,rate_prototype,uEltypeNoUnits,uBottomEl
   tab = ESDIRK54I8L2SATableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ, tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getiipnlsolvefields
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u)
@@ -507,8 +507,8 @@ function alg_cache(alg::ESDIRK54I8L2SA,u,rate_prototype,uEltypeNoUnits,uBottomEl
                    uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{false}})
   tab = ESDIRK54I8L2SATableau(real(uBottomEltypeNoUnits),real(tTypeNoUnits))
   γ, c = tab.γ,tab.γ
-  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
-  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @getoopnlsolvefields
   ESDIRK54I8L2SAConstantCache(uf,nlsolver,tab)
 end

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -33,8 +33,7 @@ function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomElt
   ImplicitEulerConstantCache(nlsolver)
 end
 
-mutable struct ImplicitMidpointConstantCache{F,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct ImplicitMidpointConstantCache{N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
 end
 
@@ -42,25 +41,13 @@ function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottom
   γ, c = 1//2, 1//2
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  ImplicitMidpointConstantCache(uf,nlsolver)
+  ImplicitMidpointConstantCache(nlsolver)
 end
 
-@cache mutable struct ImplicitMidpointCache{uType,rateType,JType,WType,UF,JC,F,N} <: SDIRKMutableCache
+@cache mutable struct ImplicitMidpointCache{uType,rateType,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
 end
 
@@ -69,12 +56,11 @@ function alg_cache(alg::ImplicitMidpoint,u,rate_prototype,uEltypeNoUnits,uBottom
   γ, c = 1//2, 1//2
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
-  ImplicitMidpointCache(u,uprev,du1,fsalfirst,k,z,dz,b,tmp,J,W,uf,jac_config,linsolve,nlsolver)
+  fsalfirst = zero(rate_prototype)
+  ImplicitMidpointCache(u,uprev,fsalfirst,nlsolver)
 end
 
-mutable struct TrapezoidConstantCache{F,uType,tType,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct TrapezoidConstantCache{uType,tType,N} <: OrdinaryDiffEqConstantCache
   uprev3::uType
   tprev2::tType
   nlsolver::N
@@ -85,31 +71,19 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   γ, c = 1//2, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
 
   uprev3 = u
   tprev2 = t
 
-  TrapezoidConstantCache(uf,uprev3,tprev2,nlsolver)
+  TrapezoidConstantCache(uprev3,tprev2,nlsolver)
 end
 
-@cache mutable struct TrapezoidCache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,tType,F,N} <: SDIRKMutableCache
+@cache mutable struct TrapezoidCache{uType,rateType,uNoUnitsType,tType,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
   uprev2::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   uprev3::uType
   tprev2::tType
   nlsolver::N
@@ -120,17 +94,16 @@ function alg_cache(alg::Trapezoid,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   γ, c = 1//2, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   uprev3 = zero(u)
   tprev2 = t
   atmp = similar(u,uEltypeNoUnits)
 
-  TrapezoidCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,uprev3,tprev2,nlsolver)
+  TrapezoidCache(u,uprev,uprev2,fsalfirst,atmp,uprev3,tprev2,nlsolver)
 end
 
-mutable struct TRBDF2ConstantCache{F,Tab,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct TRBDF2ConstantCache{Tab,N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -141,28 +114,16 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = tab.d, tab.γ
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  TRBDF2ConstantCache(uf,nlsolver,tab)
+  TRBDF2ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct TRBDF2Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,Tab,F,N} <: SDIRKMutableCache
+@cache mutable struct TRBDF2Cache{uType,rateType,uNoUnitsType,Tab,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   zprev::uType
   zᵧ::uType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -173,16 +134,14 @@ function alg_cache(alg::TRBDF2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = tab.d, tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   atmp = similar(u,uEltypeNoUnits); zprev = similar(u); zᵧ = similar(u)
 
-  TRBDF2Cache(u,uprev,du1,fsalfirst,k,zprev,zᵧ,z,dz,b,tmp,atmp,J,
-              W,uf,jac_config,linsolve,nlsolver,tab)
+  TRBDF2Cache(u,uprev,fsalfirst,zprev,zᵧ,atmp,nlsolver,tab)
 end
 
-mutable struct SDIRK2ConstantCache{F,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct SDIRK2ConstantCache{N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
 end
 
@@ -191,27 +150,16 @@ function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = 1, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  SDIRK2ConstantCache(uf,nlsolver)
+  SDIRK2ConstantCache(nlsolver)
 end
 
-@cache mutable struct SDIRK2Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,F,N} <: SDIRKMutableCache
+@cache mutable struct SDIRK2Cache{uType,rateType,uNoUnitsType,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
 end
 
@@ -220,17 +168,15 @@ function alg_cache(alg::SDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   γ, c = 1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
-  z₁ = similar(u); z₂ = z
+  z₁ = similar(u); z₂ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  SDIRK2Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,dz,b,tmp,atmp,J,
-              W,uf,jac_config,linsolve,nlsolver)
+  SDIRK2Cache(u,uprev,fsalfirst,z₁,z₂,atmp,nlsolver)
 end
 
-mutable struct SSPSDIRK2ConstantCache{F,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct SSPSDIRK2ConstantCache{N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
 end
 
@@ -239,26 +185,15 @@ function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   γ, c = 1//4, 1//1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  SSPSDIRK2ConstantCache(uf,nlsolver)
+  SSPSDIRK2ConstantCache(nlsolver)
 end
 
-@cache mutable struct SSPSDIRK2Cache{uType,rateType,JType,WType,UF,JC,F,N} <: SDIRKMutableCache
+@cache mutable struct SSPSDIRK2Cache{uType,rateType,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
-  dz::uType
-  b::uType
-  tmp::uType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
 end
 
@@ -267,17 +202,15 @@ function alg_cache(alg::SSPSDIRK2,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   γ, c = 1//4, 1//1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
-  z₁ = similar(u); z₂ = z
+  z₁ = similar(u); z₂ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  SSPSDIRK2Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,dz,b,tmp,J,
-                W,uf,jac_config,linsolve,nlsolver)
+  SSPSDIRK2Cache(u,uprev,fsalfirst,z₁,z₂,nlsolver)
 end
 
-mutable struct Kvaerno3ConstantCache{UF,Tab,N} <: OrdinaryDiffEqConstantCache
-  uf::UF
+mutable struct Kvaerno3ConstantCache{Tab,N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -288,29 +221,18 @@ function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, 2tab.γ
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  Kvaerno3ConstantCache(uf,nlsolver,tab)
+  Kvaerno3ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct Kvaerno3Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,Tab,F,N} <: SDIRKMutableCache
+@cache mutable struct Kvaerno3Cache{uType,rateType,uNoUnitsType,Tab,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
   z₄::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -321,17 +243,15 @@ function alg_cache(alg::Kvaerno3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   γ, c = tab.γ, 2tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = z
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  Kvaerno3Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,dz,b,tmp,atmp,J,
-                W,uf,jac_config,linsolve,nlsolver,tab)
+  Kvaerno3Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,atmp,nlsolver,tab)
 end
 
-mutable struct Cash4ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct Cash4ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -342,30 +262,19 @@ function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = tab.γ,tab.γ
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  Cash4ConstantCache(uf,nlsolver,tab)
+  Cash4ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct Cash4Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,N,Tab,F} <: SDIRKMutableCache
+@cache mutable struct Cash4Cache{uType,rateType,uNoUnitsType,N,Tab} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
   z₄::uType
   z₅::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -376,17 +285,15 @@ function alg_cache(alg::Cash4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   γ, c = tab.γ,tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = z
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  Cash4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
-              W,uf,jac_config,linsolve,nlsolver,tab)
+  Cash4Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,atmp,nlsolver,tab)
 end
 
-mutable struct Hairer4ConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct Hairer4ConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -401,30 +308,19 @@ function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,
   γ, c = tab.γ, tab.γ
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  Hairer4ConstantCache(uf,nlsolver,tab)
+  Hairer4ConstantCache(nlsolver,tab)
 end
 
-@cache mutable struct Hairer4Cache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,Tab,F,N} <: SDIRKMutableCache
+@cache mutable struct Hairer4Cache{uType,rateType,uNoUnitsType,Tab,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType
   z₂::uType
   z₃::uType
   z₄::uType
   z₅::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -439,31 +335,20 @@ function alg_cache(alg::Union{Hairer4,Hairer42},u,rate_prototype,uEltypeNoUnits,
   γ, c = tab.γ, tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
-  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = z
+  z₁ = similar(u); z₂ = similar(u); z₃ = similar(u); z₄ = similar(u); z₅ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  Hairer4Cache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,dz,b,tmp,atmp,J,
-               W,uf,jac_config,linsolve,nlsolver,tab)
+  Hairer4Cache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,atmp,nlsolver,tab)
 end
 
-@cache mutable struct ESDIRK54I8L2SACache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,Tab,F,N} <: SDIRKMutableCache
+@cache mutable struct ESDIRK54I8L2SACache{uType,rateType,uNoUnitsType,Tab,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
   z₁::uType; z₂::uType; z₃::uType; z₄::uType; z₅::uType; z₆::uType; z₇::uType; z₈::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
   tab::Tab
 end
@@ -474,18 +359,16 @@ function alg_cache(alg::ESDIRK54I8L2SA,u,rate_prototype,uEltypeNoUnits,uBottomEl
   γ, c = tab.γ, tab.γ
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   z₁ = zero(u); z₂ = zero(u); z₃ = zero(u); z₄ = zero(u)
-  z₅ = zero(u); z₆ = zero(u); z₇ = zero(u); z₈ = z
+  z₅ = zero(u); z₆ = zero(u); z₇ = zero(u); z₈ = nlsolver.z
   atmp = similar(u,uEltypeNoUnits)
 
-  ESDIRK54I8L2SACache(u,uprev,du1,fsalfirst,k,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,dz,b,tmp,atmp,J,
-               W,uf,jac_config,linsolve,nlsolver,tab)
+  ESDIRK54I8L2SACache(u,uprev,fsalfirst,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,atmp,nlsolver,tab)
 end
 
-mutable struct ESDIRK54I8L2SAConstantCache{F,N,Tab} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct ESDIRK54I8L2SAConstantCache{N,Tab} <: OrdinaryDiffEqConstantCache
   nlsolver::N
   tab::Tab
 end
@@ -496,6 +379,5 @@ function alg_cache(alg::ESDIRK54I8L2SA,u,rate_prototype,uEltypeNoUnits,uBottomEl
   γ, c = tab.γ,tab.γ
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  ESDIRK54I8L2SAConstantCache(uf,nlsolver,tab)
+  ESDIRK54I8L2SAConstantCache(nlsolver,tab)
 end

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -1,22 +1,11 @@
 abstract type SDIRKMutableCache <: OrdinaryDiffEqMutableCache end
 
-@cache mutable struct ImplicitEulerCache{uType,rateType,uNoUnitsType,JType,WType,UF,JC,F,N} <: SDIRKMutableCache
+@cache mutable struct ImplicitEulerCache{uType,rateType,uNoUnitsType,N} <: SDIRKMutableCache
   u::uType
   uprev::uType
   uprev2::uType
-  du1::rateType
   fsalfirst::rateType
-  k::rateType
-  z::uType
-  dz::uType
-  b::uType
-  tmp::uType
   atmp::uNoUnitsType
-  J::JType
-  W::WType
-  uf::UF
-  jac_config::JC
-  linsolve::F
   nlsolver::N
 end
 
@@ -25,15 +14,14 @@ function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomElt
   γ, c = 1, 1
   J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getiipnlsolvefields
+  fsalfirst = zero(rate_prototype)
 
   atmp = similar(u,uEltypeNoUnits)
 
-  ImplicitEulerCache(u,uprev,uprev2,du1,fsalfirst,k,z,dz,b,tmp,atmp,J,W,uf,jac_config,linsolve,nlsolver)
+  ImplicitEulerCache(u,uprev,uprev2,fsalfirst,atmp,nlsolver)
 end
 
-mutable struct ImplicitEulerConstantCache{F,N} <: OrdinaryDiffEqConstantCache
-  uf::F
+mutable struct ImplicitEulerConstantCache{N} <: OrdinaryDiffEqConstantCache
   nlsolver::N
 end
 
@@ -42,8 +30,7 @@ function alg_cache(alg::ImplicitEuler,u,rate_prototype,uEltypeNoUnits,uBottomElt
   γ, c = 1, 1
   J, W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  @getoopnlsolvefields
-  ImplicitEulerConstantCache(uf,nlsolver)
+  ImplicitEulerConstantCache(nlsolver)
 end
 
 mutable struct ImplicitMidpointConstantCache{F,N} <: OrdinaryDiffEqConstantCache

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -70,6 +70,31 @@ either ForwardDiff or finite difference will be used depending on the
 `jac_config` of the cache.
 """
 function calc_J!(integrator, cache::OrdinaryDiffEqMutableCache, is_compos)
+  if isdefined(cache, :nlsolver)
+    calc_J!(cache.nlsolver, integrator, cache, is_compos)
+  elseif isdefined(cache, :J)
+    calc_J_in_cache!(integrator, cache, is_compos)
+  else
+    error("No J found in the cache")
+  end
+end
+
+function calc_J!(nlsolver::NLSolver, integrator, cache::OrdinaryDiffEqMutableCache, is_compos)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack du1,uf,jac_config = nlsolver
+  J = nlsolver.cache.J
+  if DiffEqBase.has_jac(f)
+    f.jac(J, uprev, p, t)
+  else
+    uf.t = t
+    uf.p = p
+    jacobian!(J, uf, uprev, du1, integrator, jac_config)
+  end
+  integrator.destats.njacs += 1
+  is_compos && (integrator.eigen_est = opnorm(J, Inf))
+end
+
+function calc_J_in_cache!(integrator, cache::OrdinaryDiffEqMutableCache, is_compos)
   @unpack t,dt,uprev,u,f,p = integrator
   J = cache.J
   if DiffEqBase.has_jac(f)
@@ -342,9 +367,76 @@ function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_
   return nothing
 end
 
+function calc_W!(nlsolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, W_transform=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack J,W = nlsolver.cache
+  alg = unwrap_alg(integrator, true)
+  mass_matrix = integrator.f.mass_matrix
+  is_compos = integrator.alg isa CompositeAlgorithm
+  isnewton = alg isa NewtonAlgorithm
+
+  # fast pass
+  # we only want to factorize the linear operator once
+  new_jac = true
+  new_W = true
+  if (f isa ODEFunction && islinear(f.f)) || (integrator.alg isa SplitAlgorithms && f isa SplitFunction && islinear(f.f1.f))
+    new_jac = false
+    @goto J2W # Jump to W calculation directly, because we already have J
+  end
+
+  # check if we need to update J or W
+  W_dt = isnewton ? nlsolver.cache.W_dt : dt # TODO: RosW
+  new_jac = isnewton ? do_newJ(integrator, alg, cache, repeat_step) : true
+  new_W = isnewton ? do_newW(integrator, nlsolver, new_jac, W_dt) : true
+  
+  # calculate W
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing
+    isnewton || DiffEqBase.update_coefficients!(W,uprev,p,t) # we will call `update_coefficients!` in NLNewton
+    @label J2W
+    W.transform = W_transform; set_gamma!(W, dtgamma)
+  else # concrete W using jacobian from `calc_J!`
+    new_jac && calc_J!(nlsolver, integrator, cache, is_compos)
+    new_W && jacobian2W!(W, mass_matrix, dtgamma, J, W_transform)
+  end
+  if isnewton
+    set_new_W!(nlsolver, new_W) && DiffEqBase.set_W_dt!(nlsolver, dt)
+  end
+  new_W && (integrator.destats.nw += 1)
+  return nothing
+end
+
 function calc_W!(integrator, cache::OrdinaryDiffEqConstantCache, dtgamma, repeat_step, W_transform=false)
   @unpack t,uprev,p,f = integrator
   @unpack uf = cache
+  mass_matrix = integrator.f.mass_matrix
+  isarray = typeof(uprev) <: AbstractArray
+  # calculate W
+  uf.t = t
+  is_compos = typeof(integrator.alg) <: CompositeAlgorithm
+  if (f isa ODEFunction && islinear(f.f)) || (f isa SplitFunction && islinear(f.f1.f))
+    J = f.f1.f
+    W = WOperator(mass_matrix, dtgamma, J, false; transform=W_transform)
+  elseif DiffEqBase.has_jac(f)
+    J = f.jac(uprev, p, t)
+    if !isa(J, DiffEqBase.AbstractDiffEqLinearOperator)
+      J = DiffEqArrayOperator(J)
+    end
+    W = WOperator(mass_matrix, dtgamma, J, false; transform=W_transform)
+    integrator.destats.nw += 1
+  else
+    integrator.destats.nw += 1
+    J = calc_J(integrator, cache, is_compos)
+    W_full = W_transform ? -mass_matrix*inv(dtgamma) + J :
+                           -mass_matrix + dtgamma*J
+    W = W_full isa Number ? W_full : lu(W_full)
+  end
+  is_compos && (integrator.eigen_est = isarray ? opnorm(J, Inf) : abs(J))
+  W
+end
+
+function calc_W!(nlsolver, integrator, cache::OrdinaryDiffEqConstantCache, dtgamma, repeat_step, W_transform=false)
+  @unpack t,uprev,p,f = integrator
+  @unpack uf = nlsolver
   mass_matrix = integrator.f.mass_matrix
   isarray = typeof(uprev) <: AbstractArray
   # calculate W
@@ -383,14 +475,14 @@ update_W!(integrator, cache, dt, repeat_step) =
 
 function update_W!(nlsolver::NLSolver, integrator, cache::OrdinaryDiffEqMutableCache, dt, repeat_step)
   if isnewton(nlsolver)
-    calc_W!(integrator, cache, dt, repeat_step, true)
+    calc_W!(nlsolver, integrator, cache, dt, repeat_step, true)
   end
   nothing
 end
 
 function update_W!(nlsolver::NLSolver, integrator, cache::OrdinaryDiffEqConstantCache, dt, repeat_step)
   if isnewton(nlsolver)
-    DiffEqBase.set_W!(nlsolver, calc_W!(integrator, cache, dt, repeat_step, true))
+    DiffEqBase.set_W!(nlsolver, calc_W!(nlsolver, integrator, cache, dt, repeat_step, true))
   end
   nothing
 end

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -75,7 +75,7 @@ end
 
 # the ordering of the cache arrays is important!!!
 @inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqAlgorithm,cache) = (cache.tmp,)
-@inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm,cache) = (cache.tmp,cache.atmp)
+@inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm,cache) = (cache.nlsolver.tmp,cache.atmp)
 @inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqRosenbrockAdaptiveAlgorithm,cache) = (cache.tmp,cache.linsolve_tmp)
 @inline DiffEqBase.get_tmp_cache(integrator,alg::CompositeAlgorithm, cache) = get_tmp_cache(integrator, integrator.alg.algs[1], cache.caches[1])
 

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -75,6 +75,7 @@ end
 
 # the ordering of the cache arrays is important!!!
 @inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqAlgorithm,cache) = (cache.tmp,)
+@inline DiffEqBase.get_tmp_cache(integrator,alg::RadauIIA5,cache) = (cache.tmp,cache.atmp)
 @inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm,cache) = (cache.nlsolver.tmp,cache.atmp)
 @inline DiffEqBase.get_tmp_cache(integrator,alg::OrdinaryDiffEqRosenbrockAdaptiveAlgorithm,cache) = (cache.tmp,cache.linsolve_tmp)
 @inline DiffEqBase.get_tmp_cache(integrator,alg::CompositeAlgorithm, cache) = get_tmp_cache(integrator, integrator.alg.algs[1], cache.caches[1])

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -420,9 +420,10 @@ function oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
       W = u isa Number ? u : LU{LinearAlgebra.lutype(uEltypeNoUnits)}(Matrix{uEltypeNoUnits}(undef, 0, 0),
                                                                       Vector{LinearAlgebra.BlasInt}(undef, 0),
                                                                       zero(LinearAlgebra.BlasInt))
+      J = u isa Number ? u : (false .* vec(u) .* vec(u)')
     end
   end
-  W
+  J, W
 end
 
 function (integrator::ODEIntegrator)(t,deriv::Type=Val{0};idxs=nothing)

--- a/src/perform_step/adams_bashforth_moulton_perform_step.jl
+++ b/src/perform_step/adams_bashforth_moulton_perform_step.jl
@@ -1517,7 +1517,7 @@ end
 
 function perform_step!(integrator,cache::CNAB2ConstantCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack k2,uf,nlsolver = cache
+  @unpack k2,nlsolver = cache
   cnt = integrator.iter
   f1 = integrator.f.f1
   f2 = integrator.f.f2
@@ -1558,7 +1558,7 @@ end
 function initialize!(integrator, cache::CNAB2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -1568,7 +1568,8 @@ end
 
 function perform_step!(integrator, cache::CNAB2Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack uf,dz,z,k,k1,k2,du₁,b,J,W,jac_config,tmp,nlsolver = cache
+  @unpack k1,k2,du₁,nlsolver = cache
+  @unpack z,tmp,k = nlsolver
   cnt = integrator.iter
   f1 = integrator.f.f1
   f2 = integrator.f.f2
@@ -1618,7 +1619,7 @@ end
 
 function perform_step!(integrator,cache::CNLF2ConstantCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack k2,uprev2,uf,nlsolver = cache
+  @unpack k2,uprev2,nlsolver = cache
   cnt = integrator.iter
   f1 = integrator.f.f1
   f2 = integrator.f.f2
@@ -1661,7 +1662,7 @@ end
 function initialize!(integrator, cache::CNLF2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -1671,7 +1672,8 @@ end
 
 function perform_step!(integrator, cache::CNLF2Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack uprev2,uf,dz,z,k,k2,du₁,b,J,W,jac_config,tmp,nlsolver = cache
+  @unpack uprev2,k2,du₁,nlsolver = cache
+  @unpack z,k,tmp = nlsolver
   cnt = integrator.iter
   f1 = integrator.f.f1
   f2 = integrator.f.f2

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -76,7 +76,7 @@ end
 function initialize!(integrator, cache::ABDF2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -86,7 +86,8 @@ end
 
 @muladd function perform_step!(integrator, cache::ABDF2Cache, repeat_step=false)
   @unpack t,dt,f,p = integrator
-  @unpack z,k,b,J,W,tmp,atmp,dtₙ₋₁,zₙ₋₁,nlsolver = cache
+  @unpack atmp,dtₙ₋₁,zₙ₋₁,nlsolver = cache
+  @unpack z,tmp = nlsolver
   alg = unwrap_alg(integrator, true)
   uₙ,uₙ₋₁,uₙ₋₂,dtₙ = integrator.u,integrator.uprev,integrator.uprev2,integrator.dt
 
@@ -94,7 +95,8 @@ end
     cache.dtₙ₋₁ = dtₙ
     perform_step!(integrator, cache.eulercache, repeat_step)
     cache.fsalfirstprev .= integrator.fsalfirst
-    nlsolver.tmp = tmp
+    # why?
+    # nlsolver.tmp = tmp
     return
   end
 
@@ -216,7 +218,7 @@ function initialize!(integrator, cache::SBDFCache)
   @unpack f1, f2 = integrator.f
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -229,7 +231,8 @@ end
 
 function perform_step!(integrator, cache::SBDFCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack tmp,uprev2,uprev3,uprev4,k,k₁,k₂,k₃,du₁,du₂,z,nlsolver = cache
+  @unpack uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂,nlsolver = cache
+  @unpack tmp,z,k = nlsolver
   @unpack f1, f2 = integrator.f
   cnt = cache.cnt = min(alg.order, integrator.iter+1)
   integrator.iter == 1 && !integrator.u_modified && ( cnt = cache.cnt = 1 )
@@ -345,7 +348,7 @@ end
 function initialize!(integrator, cache::QNDF1Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -355,7 +358,8 @@ end
 
 function perform_step!(integrator,cache::QNDF1Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack uprev2,D,D2,R,U,dtₙ₋₁,tmp,z,W,utilde,atmp,nlsolver = cache
+  @unpack uprev2,D,D2,R,U,dtₙ₋₁,utilde,atmp,nlsolver = cache
+  @unpack tmp,z = nlsolver
   alg = unwrap_alg(integrator, true)
   cnt = integrator.iter
   k = 1
@@ -502,7 +506,7 @@ end
 function initialize!(integrator, cache::QNDF2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -512,7 +516,8 @@ end
 
 function perform_step!(integrator,cache::QNDF2Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack uprev2,uprev3,dtₙ₋₁,dtₙ₋₂,D,D2,R,U,tmp,utilde,atmp,W,nlsolver = cache
+  @unpack uprev2,uprev3,dtₙ₋₁,dtₙ₋₂,D,D2,R,U,utilde,atmp,nlsolver = cache
+  tmp = nlsolver.tmp
   alg = unwrap_alg(integrator, true)
   cnt = integrator.iter
   k = 2
@@ -728,7 +733,7 @@ end
 function initialize!(integrator, cache::QNDFCache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -738,7 +743,8 @@ end
 
 function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack udiff,dts,order,max_order,D,D2,R,U,tmp,utilde,atmp,W,nlsolver = cache
+  @unpack udiff,dts,order,max_order,D,D2,R,U,utilde,atmp,nlsolver = cache
+  tmp = nlsolver.tmp
   cnt = integrator.iter
   k = order
   κ = integrator.alg.kappa[k]
@@ -788,7 +794,7 @@ function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
     @.. ϕ += γₖ[i]*D[i]
   end
   @.. ϕ *= γ
-  tm = fill!(cache.b, zero(eltype(u)))
+  tm = fill!(nlsolver.ztmp, zero(eltype(u)))
   for i = 1:k
     @.. tm += D[i]
   end
@@ -935,7 +941,7 @@ end
 function initialize!(integrator, cache::MEBDF2Cache)
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -945,7 +951,8 @@ end
 
 @muladd function perform_step!(integrator, cache::MEBDF2Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,z₁,z₂,tmp2,tmp,nlsolver = cache
+  @unpack z₁,z₂,tmp2,nlsolver = cache
+  z = nlsolver.z
   mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   update_W!(integrator, cache, dt, repeat_step)

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -95,8 +95,7 @@ end
     cache.dtₙ₋₁ = dtₙ
     perform_step!(integrator, cache.eulercache, repeat_step)
     cache.fsalfirstprev .= integrator.fsalfirst
-    # why?
-    # nlsolver.tmp = tmp
+    nlsolver.tmp = tmp
     return
   end
 

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -23,7 +23,7 @@ function initialize!(integrator, cache::Union{Kvaerno3Cache,
                                               KenCarp5Cache})
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -96,7 +96,8 @@ end
 
 @muladd function perform_step!(integrator, cache::Kvaerno3Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack dz,z₁,z₂,z₃,z₄,k,b,tmp,atmp,nlsolver = cache
+  @unpack z₁,z₂,z₃,z₄,atmp,nlsolver = cache
+  @unpack dz,k,tmp = nlsolver
   @unpack γ,a31,a32,a41,a42,a43,btilde1,btilde2,btilde3,btilde4,c3,α31,α32 = cache.tab
   alg = unwrap_alg(integrator, true)
 
@@ -154,7 +155,7 @@ end
     @.. dz = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      cache.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -289,7 +290,8 @@ end
 
 @muladd function perform_step!(integrator, cache::KenCarp3Cache, repeat_step=false)
   @unpack t,dt,uprev,u,p = integrator
-  @unpack dz,z₁,z₂,z₃,z₄,k1,k2,k3,k4,k,b,tmp,atmp,nlsolver = cache
+  @unpack z₁,z₂,z₃,z₄,k1,k2,k3,k4,atmp,nlsolver = cache
+  @unpack dz,k,tmp = nlsolver
   @unpack γ,a31,a32,a41,a42,a43,btilde1,btilde2,btilde3,btilde4,c3,α31,α32 = cache.tab
   @unpack ea21,ea31,ea32,ea41,ea42,ea43,eb1,eb2,eb3,eb4 = cache.tab
   @unpack ebtilde1,ebtilde2,ebtilde3,ebtilde4 = cache.tab
@@ -405,7 +407,7 @@ end
     end
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      cache.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -500,7 +502,8 @@ end
 
 @muladd function perform_step!(integrator, cache::Kvaerno4Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack dz,z₁,z₂,z₃,z₄,z₅,k,b,tmp,atmp,nlsolver = cache
+  @unpack z₁,z₂,z₃,z₄,z₅,atmp,nlsolver = cache
+  @unpack dz,k,tmp = nlsolver
   @unpack γ,a31,a32,a41,a42,a43,a51,a52,a53,a54,c3,c4 = cache.tab
   @unpack α21,α31,α32,α41,α42 = cache.tab
   @unpack btilde1,btilde2,btilde3,btilde4,btilde5 = cache.tab
@@ -567,7 +570,7 @@ end
     @.. dz = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      cache.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -746,7 +749,8 @@ end
 
 @muladd function perform_step!(integrator, cache::KenCarp4Cache, repeat_step=false)
   @unpack t,dt,uprev,u,p = integrator
-  @unpack dz,z₁,z₂,z₃,z₄,z₅,z₆,k,b,tmp,atmp,nlsolver = cache
+  @unpack z₁,z₂,z₃,z₄,z₅,z₆,atmp,nlsolver = cache
+  @unpack dz,k,tmp = nlsolver
   @unpack k1,k2,k3,k4,k5,k6 = cache
   @unpack γ,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a63,a64,a65,c3,c4,c5 = cache.tab
   @unpack α31,α32,α41,α42,α51,α52,α53,α54,α61,α62,α63,α64,α65 = cache.tab
@@ -924,7 +928,7 @@ end
 
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      cache.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -1037,7 +1041,8 @@ end
 
 @muladd function perform_step!(integrator, cache::Kvaerno5Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack dz,z₁,z₂,z₃,z₄,z₅,z₆,z₇,k,b,tmp,atmp,nlsolver = cache
+  @unpack z₁,z₂,z₃,z₄,z₅,z₆,z₇,atmp,nlsolver = cache
+  @unpack dz,k,tmp = nlsolver
   @unpack γ,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,c3,c4,c5,c6 = cache.tab
   @unpack btilde1,btilde3,btilde4,btilde5,btilde6,btilde7 = cache.tab
   @unpack α31,α32,α41,α42,α43,α51,α52,α53,α61,α62,α63 = cache.tab
@@ -1133,7 +1138,7 @@ end
     end
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      cache.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -1354,8 +1359,9 @@ end
 
 @muladd function perform_step!(integrator, cache::KenCarp5Cache, repeat_step=false)
   @unpack t,dt,uprev,u,p = integrator
-  @unpack dz,z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,k,b,tmp,atmp,nlsolver = cache
+  @unpack z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,atmp,nlsolver = cache
   @unpack k1,k2,k3,k4,k5,k6,k7,k8 = cache
+  @unpack dz,k,tmp = nlsolver
   @unpack γ,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a84,a85,a86,a87,c3,c4,c5,c6,c7 = cache.tab
   @unpack α31,α32,α41,α42,α51,α52,α61,α62,α71,α72,α73,α74,α75,α81,α82,α83,α84,α85 = cache.tab
   @unpack btilde1,btilde4,btilde5,btilde6,btilde7,btilde8 = cache.tab
@@ -1584,7 +1590,7 @@ end
 
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      cache.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -653,7 +653,7 @@ function initialize!(integrator, cache::IRKCCache)
   @unpack f1, f2 = integrator.f
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -666,7 +666,8 @@ end
 
 function perform_step!(integrator, cache::IRKCCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p,alg = integrator
-  @unpack tmp,gprev,gprev2,k,f1ⱼ₋₁,f1ⱼ₋₂,f2ⱼ₋₁,du₁,du₂,z,W,atmp,nlsolver = cache
+  @unpack gprev,gprev2,f1ⱼ₋₁,f1ⱼ₋₂,f2ⱼ₋₁,du₁,du₂,atmp,nlsolver = cache
+  @unpack tmp,k,z = nlsolver
   @unpack minm = cache.constantcache
   @unpack f1, f2 = integrator.f
 
@@ -767,7 +768,7 @@ function perform_step!(integrator, cache::IRKCCache, repeat_step=false)
   if isnewton(nlsolver) && integrator.opts.adaptive
     update_W!(integrator, cache, dt, false)
     @.. gprev = dt*0.5*(du₂ - f2ⱼ₋₁) + dt*(0.5 - μs₁)*(du₁ - f1ⱼ₋₁)
-    cache.linsolve(vec(tmp),get_W(nlsolver),vec(gprev),false)
+    nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(gprev),false)
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -29,7 +29,7 @@ function initialize!(integrator, cache::Union{ImplicitEulerCache,
                                               ESDIRK54I8L2SACache})
   integrator.kshortsize = 2
   integrator.fsalfirst = cache.fsalfirst
-  integrator.fsallast = cache.k
+  integrator.fsallast = cache.nlsolver.k
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -84,7 +84,8 @@ end
 
 @muladd function perform_step!(integrator, cache::ImplicitEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack z,tmp,atmp,nlsolver = cache
+  @unpack atmp,nlsolver = cache
+  @unpack z,tmp = nlsolver
   mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   update_W!(integrator, cache, dt, repeat_step)

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -373,23 +373,20 @@ end
 
   # TODO: Add extrapolation
   @.. zᵧ = zprev
-  nlsolver.z = zᵧ
-
+  z .= zᵧ
   @.. tmp = uprev + d*zprev
   nlsolver.c = γ
-  zᵧ = nlsolve!(integrator, cache)
+  zᵧ .= nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve BDF2 Step
 
   ### Initial Guess From Shampine
   @.. z = α1*zprev + α2*zᵧ
-  nlsolver.z = z
-
   @.. tmp = uprev + ω*zprev + ω*zᵧ
   nlsolver.c = 1
   set_new_W!(nlsolver, false)
-  z = nlsolve!(integrator, cache)
+  nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + d*z

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -97,7 +97,7 @@ end
     z .= zero(eltype(u))
   end
 
-  nlsolver.tmp = uprev
+  nlsolver.tmp .= uprev
   z = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
   @.. u = uprev + z

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -1075,7 +1075,7 @@ end
 @muladd function perform_step!(integrator, cache::ESDIRK54I8L2SACache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack z₁,z₂,z₃,z₄,z₅,z₆,z₇,z₈,atmp,nlsolver = cache
-  @unpack k,tmp = cache
+  @unpack k,tmp = nlsolver
   @unpack γ,
           a31, a32,
           a41, a42, a43,

--- a/src/rkc_utils.jl
+++ b/src/rkc_utils.jl
@@ -99,7 +99,11 @@ end
 function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
   isfirst = integrator.iter == 1 || integrator.u_modified
   @unpack t, dt, uprev, u, f, p, fsalfirst = integrator
-  fz, z, atmp = cache.k, cache.tmp, cache.atmp
+  if cache isa IRKCCache
+    fz, z, atmp = cache.nlsolver.k, cache.nlsolver.tmp, cache.atmp
+  else
+    fz, z, atmp = cache.k, cache.tmp, cache.atmp
+  end
   ccache = cache.constantcache
   maxiter = (typeof(integrator.alg) <: Union{ESERK4,ESERK5,SERK2}) ? 100 : 50
   safe = (typeof(integrator.alg) <: RKCAlgs) ? 1.0 : 1.2

--- a/test/interface/utility_tests.jl
+++ b/test/interface/utility_tests.jl
@@ -28,7 +28,7 @@ end
                     mass_matrix=mm,
                     jac=(u,p,t) -> A)
   integrator = init(ODEProblem(fun,u0,tspan), ImplicitEuler(); adaptive=false, dt=dt)
-  W = calc_W!(integrator, integrator.cache, dtgamma, false)
+  W = calc_W!(integrator.cache.nlsolver, integrator, integrator.cache, dtgamma, false)
   @test convert(AbstractMatrix, W) == concrete_W
   @test W \ u0 ≈ concrete_W \ u0
 
@@ -37,9 +37,9 @@ end
                     mass_matrix=mm,
                     jac_prototype=DiffEqArrayOperator(A))
   integrator = init(ODEProblem(fun,u0,tspan), ImplicitEuler(); adaptive=false, dt=dt)
-  calc_W!(integrator, integrator.cache, dtgamma, false)
-  @test convert(AbstractMatrix, integrator.cache.W) == concrete_W
-  ldiv!(tmp, lu!(integrator.cache.W), u0); @test tmp == concrete_W \ u0
+  calc_W!(integrator.cache.nlsolver, integrator, integrator.cache, dtgamma, false)
+  @test convert(AbstractMatrix, integrator.cache.nlsolver.cache.W) == concrete_W
+  ldiv!(tmp, lu!(integrator.cache.nlsolver.cache.W), u0); @test tmp == concrete_W \ u0
 end
 
 @testset "Implicit solver with lazy W" begin


### PR DESCRIPTION
Follow up for JuliaDiffEq/DiffEqBase.jl#288, tests pass after DiffEqBase is tagged. Now I need to remove all the redundant fields from alg cache.