### PR TITLE
Use only BinaryMinHeap to fix type instability

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -84,12 +84,12 @@ full_cache(integrator::ODEIntegrator) = full_cache(integrator.cache)
 
 function add_tstop!(integrator::ODEIntegrator,t)
   integrator.tdir * (t - integrator.t) < 0 && error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
-  push!(integrator.opts.tstops,t)
+  push!(integrator.opts.tstops, integrator.tdir * t)
 end
 
 function DiffEqBase.add_saveat!(integrator::ODEIntegrator,t)
   integrator.tdir * (t - integrator.t) < 0 && error("Tried to add a saveat that is behind the current time. This is strictly forbidden")
-  push!(integrator.opts.saveat,t)
+  push!(integrator.opts.saveat, integrator.tdir * t)
 end
 
 resize!(integrator::ODEIntegrator,i::Int) = resize!(integrator,integrator.cache,i)
@@ -223,9 +223,9 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
   integrator.t = t0
   integrator.tprev = t0
 
+  tType = typeof(integrator.t)
   tstops_internal, saveat_internal, d_discontinuities_internal =
-    tstop_saveat_disc_handling(tstops,saveat,d_discontinuities,
-    integrator.tdir,(t0,tf),typeof(integrator.t))
+    tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, (tType(t0), tType(tf)))
 
   integrator.opts.tstops = tstops_internal
   integrator.opts.saveat = saveat_internal

--- a/src/iterator_interface.jl
+++ b/src/iterator_interface.jl
@@ -1,6 +1,6 @@
 @inline function step!(integrator::ODEIntegrator)
   if integrator.opts.advance_to_tstop
-    @inbounds while integrator.tdir*integrator.t < integrator.tdir*top(integrator.opts.tstops)
+    @inbounds while integrator.tdir * integrator.t < top(integrator.opts.tstops)
       loopheader!(integrator)
       check_error!(integrator) != :Success && return
       perform_step!(integrator,integrator.cache)


### PR DESCRIPTION
Currently `init` is type unstable due to the type instability of `tstop_saveat_disc_handling`. This PR provides a radical fix by using only BinaryMinHeap's for `saveat`, `tstops`, and `d_discontinuities`, in which not times `t` but `tdir * t` values are saved.

This definitely breaks DelayDiffEq and probably affects other downstream packages that access `tstops`, `saveat` and `d_discontinuities` directly.

On master, I get (with Julia 1.3, but reproducible on Julia 1.1 as well)
```julia
julia> @code_warntype init(ODEProblemLibrary.prob_ode_linear, Tsit5())
Variables
  #self#::Core.Compiler.Const(DiffEqBase.init, false)
  prob::ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem}
  args::Core.Compiler.Const((Tsit5(),), false)

Body::OrdinaryDiffEq.ODEIntegrator{Tsit5,false,Float64,Float64,Float64,Float64,Float64,Float64,Array{Float64,1},ODESolution{Float64,1,Array{Float64,1},Array{Float64,1},Dict{Symbol,Float64},Array{Float64,1},Array{Array{Float64,1},1},ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem},Tsit5,OrdinaryDiffEq.InterpolationData{ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},DiffEqBase.DEStats},ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},_A,Float64,Float64,Nothing} where _A
1 ─ %1 = Core.NamedTuple()::Core.Compiler.Const(NamedTuple(), false)
│   %2 = Base.pairs(%1)::Core.Compiler.Const(Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}(), false)
│   %3 = Core.tuple(%2, #self#, prob)::Core.Compiler.PartialStruct(Tuple{Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},typeof(init),ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem}}, Any[Core.Compiler.Const(Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}(), false), Core.Compiler.Const(DiffEqBase.init, false), ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem}])
│   %4 = Core._apply(DiffEqBase.:(#init#380), %3, args)::OrdinaryDiffEq.ODEIntegrator{Tsit5,false,Float64,Float64,Float64,Float64,Float64,Float64,Array{Float64,1},ODESolution{Float64,1,Array{Float64,1},Array{Float64,1},Dict{Symbol,Float64},Array{Float64,1},Array{Array{Float64,1},1},ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem},Tsit5,OrdinaryDiffEq.InterpolationData{ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},DiffEqBase.DEStats},ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},_A,Float64,Float64,Nothing} where _A
└──      return %4
```

whereas with this PR:

```julia
julia> @code_warntype init(ODEProblemLibrary.prob_ode_linear, Tsit5())
Variables
  #self#::Core.Compiler.Const(DiffEqBase.init, false)
  prob::ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem}                                                                                                     
  args::Core.Compiler.Const((Tsit5(),), false)

Body::OrdinaryDiffEq.ODEIntegrator{Tsit5,false,Float64,Float64,Float64,Float64,Float64,Float64,Array{Float64,1},ODESolution{Float64,1,Array{Float64,1},Array{Float64,1},Dict{Symbol,Float64},Array{Float64,1},Array{Array{Float64,1},1},ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem},Tsit5,OrdinaryDiffEq.InterpolationData{ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},DiffEqBase.DEStats},ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,typeof(DiffEqBase.ODE_DEFAULT_NORM),typeof(LinearAlgebra.opnorm),CallbackSet{Tuple{},Tuple{}},typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN),typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE),typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK),DataStructures.BinaryHeap{Float64,DataStructures.LessThan},DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Nothing,Nothing,Int64,Array{Float64,1},Array{Float64,1},Array{Float64,1}},Float64,Float64,Nothing}           
1 ─ %1 = Core.NamedTuple()::Core.Compiler.Const(NamedTuple(), false)
│   %2 = Base.pairs(%1)::Core.Compiler.Const(Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}(), false)
│   %3 = Core.tuple(%2, #self#, prob)::Core.Compiler.PartialStruct(Tuple{Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},typeof(init),ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem}}, Any[Core.Compiler.Const(Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}(), false), Core.Compiler.Const(DiffEqBase.init, false), ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem}])                                                            
│   %4 = Core._apply(DiffEqBase.:(#init#380), %3, args)::OrdinaryDiffEq.ODEIntegrator{Tsit5,false,Float64,Float64,Float64,Float64,Float64,Float64,Array{Float64,1},ODESolution{Float64,1,Array{Float64,1},Array{Float64,1},Dict{Symbol,Float64},Array{Float64,1},Array{Array{Float64,1},1},ODEProblem{Float64,Tuple{Float64,Float64},false,Float64,ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Nothing,DiffEqBase.StandardODEProblem},Tsit5,OrdinaryDiffEq.InterpolationData{ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Array{Float64,1},Array{Float64,1},Array{Array{Float64,1},1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},DiffEqBase.DEStats},ODEFunction{false,getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##1#2")),LinearAlgebra.UniformScaling{Bool},getfield(DiffEqProblemLibrary.ODEProblemLibrary, Symbol("##3#4")),Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,typeof(DiffEqBase.ODE_DEFAULT_NORM),typeof(LinearAlgebra.opnorm),CallbackSet{Tuple{},Tuple{}},typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN),typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE),typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK),DataStructures.BinaryHeap{Float64,DataStructures.LessThan},DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Nothing,Nothing,Int64,Array{Float64,1},Array{Float64,1},Array{Float64,1}},Float64,Float64,Nothing}
└──      return %4
```