### PR TITLE
Fixes for changes of non-linear solvers

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -40,7 +40,7 @@ module OrdinaryDiffEq
 
   using DiffEqBase: check_error!, @def, @.. , _vec, _reshape
 
-  using DiffEqBase: nlsolvefail, isnewton, set_new_W!, get_W, iipnlsolve, oopnlsolve, @getiipnlsolvefields, @getoopnlsolvefields
+  using DiffEqBase: nlsolvefail, isnewton, set_new_W!, get_W, get_linsolve, iipnlsolve, oopnlsolve
 
   using DiffEqBase: NLSolver
 

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -40,7 +40,7 @@ module OrdinaryDiffEq
 
   using DiffEqBase: check_error!, @def, @.. , _vec, _reshape
 
-  using DiffEqBase: nlsolvefail, isnewton, set_new_W!, get_W, get_linsolve, iipnlsolve, oopnlsolve
+  using DiffEqBase: nlsolve!, nlsolvefail, isnewton, set_new_W!, get_W, get_linsolve, iipnlsolve, oopnlsolve
 
   using DiffEqBase: NLSolver
 

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -375,8 +375,6 @@ function reset_fsal!(integrator)
   # integrator.reeval_fsal = false
 end
 
-nlsolve!(integrator, cache) = DiffEqBase.nlsolve!(cache.nlsolver, integrator)
-
 DiffEqBase.nlsolve_f(f, alg::OrdinaryDiffEqAlgorithm) = f isa SplitFunction && issplit(alg) ? f.f1 : f
 DiffEqBase.nlsolve_f(f, alg::DAEAlgorithm) = f
 DiffEqBase.nlsolve_f(integrator::ODEIntegrator) =

--- a/src/perform_step/adams_bashforth_moulton_perform_step.jl
+++ b/src/perform_step/adams_bashforth_moulton_perform_step.jl
@@ -1542,7 +1542,7 @@ function perform_step!(integrator,cache::CNAB2ConstantCache,repeat_step=false)
   nlsolver.z = z = zprev # Constant extrapolation
 
   nlsolver.tmp += γ*zprev
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + 1//2*z
 
@@ -1591,7 +1591,7 @@ function perform_step!(integrator, cache::CNAB2Cache, repeat_step=false)
   # initial guess
   @.. z = dt*du₁
   @.. tmp += γ*z
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = tmp + 1//2*z
 
@@ -1645,7 +1645,7 @@ function perform_step!(integrator,cache::CNLF2ConstantCache,repeat_step=false)
   zprev = dt*du₁
   nlsolver.z = z = zprev # Constant extrapolation
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + γ*z
 
@@ -1696,7 +1696,7 @@ function perform_step!(integrator, cache::CNLF2Cache, repeat_step=false)
 
   # initial guess
   @.. z = dt*du₁
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = tmp + γ*z
 

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -46,7 +46,7 @@ end
   nlsolver.z = z
 
   nlsolver.tmp = d1*uₙ₋₁ + d2*uₙ₋₂ + d3*zₙ₋₁
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   uₙ = nlsolver.tmp + d*z
@@ -120,7 +120,7 @@ end
   end
 
   @.. tmp = d1*uₙ₋₁ + d2*uₙ₋₂ + d3*zₙ₋₁
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. uₙ = tmp + d*z
@@ -195,7 +195,7 @@ function perform_step!(integrator,cache::SBDFConstantCache,repeat_step=false)
   end
   nlsolver.z = z
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + γ*z
 
@@ -258,7 +258,7 @@ function perform_step!(integrator, cache::SBDFCache, repeat_step=false)
     @.. z = zero(eltype(u))
   end
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = tmp + γ*z
 
@@ -319,7 +319,7 @@ function perform_step!(integrator,cache::QNDF1ConstantCache,repeat_step=false)
   nlsolver.z = dt*integrator.fsalfirst
   nlsolver.γ = γ
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + γ*z
 
@@ -385,7 +385,7 @@ function perform_step!(integrator,cache::QNDF1Cache,repeat_step=false)
   # initial guess
   @.. z = dt*integrator.fsalfirst
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = tmp + γ*z
 
@@ -466,7 +466,7 @@ function perform_step!(integrator,cache::QNDF2ConstantCache,repeat_step=false)
   # initial guess
   nlsolver.z = dt*integrator.fsalfirst
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + γ*z
 
@@ -559,7 +559,7 @@ function perform_step!(integrator,cache::QNDF2Cache,repeat_step=false)
   # initial guess
   @.. nlsolver.z = dt*integrator.fsalfirst
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = tmp + γ*z
 
@@ -663,7 +663,7 @@ function perform_step!(integrator,cache::QNDFConstantCache,repeat_step=false)
   # initial guess
   nlsolver.z = dt*integrator.fsalfirst
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + γ*z
 
@@ -804,7 +804,7 @@ function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
   # initial guess
   @.. nlsolver.z = dt*integrator.fsalfirst
 
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = nlsolver.tmp + γ*z
 
@@ -910,21 +910,21 @@ end
 
 ### STEP 1
   nlsolver.tmp = uprev
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   z₁ = nlsolver.tmp + z
 ### STEP 2
   nlsolver.tmp = z₁
   nlsolver.c = 2
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   z₂ = z₁ + z
 ### STEP 3
   tmp2 = 0.5uprev + z₁ - 0.5z₂
   nlsolver.tmp = tmp2
   nlsolver.c = 1
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = tmp2 + z
 
@@ -964,14 +964,14 @@ end
 
 ### STEP 1
  nlsolver.tmp = uprev
- z = nlsolve!(integrator, cache)
+ z = nlsolve!(nlsolver, integrator)
  nlsolvefail(nlsolver) && return
  @.. z₁ = uprev + z
 ### STEP 2
  nlsolver.tmp = z₁
  nlsolver.c = 2
  isnewton(nlsolver) && set_new_W!(nlsolver, false)
- z = nlsolve!(integrator, cache)
+ z = nlsolve!(nlsolver, integrator)
  nlsolvefail(nlsolver) && return
  @.. z₂ = z₁ + z
 ### STEP 3
@@ -979,7 +979,7 @@ end
  @.. tmp2 = 0.5uprev + z₁ - 0.5z₂
  nlsolver.tmp = tmp2
  nlsolver.c = 1
- z = nlsolve!(integrator, cache)
+ z = nlsolve!(nlsolver, integrator)
  nlsolvefail(nlsolver) && return
  @.. u = tmp2 + z
 

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -916,7 +916,7 @@ end
 ### STEP 2
   nlsolver.tmp = z₁
   nlsolver.c = 2
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
   z = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
   z₂ = z₁ + z
@@ -924,7 +924,6 @@ end
   tmp2 = 0.5uprev + z₁ - 0.5z₂
   nlsolver.tmp = tmp2
   nlsolver.c = 1
-  set_new_W!(nlsolver, false)
   z = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
   u = tmp2 + z
@@ -971,7 +970,7 @@ end
 ### STEP 2
  nlsolver.tmp = z₁
  nlsolver.c = 2
- set_new_W!(nlsolver, false)
+ isnewton(nlsolver) && set_new_W!(nlsolver, false)
  z = nlsolve!(integrator, cache)
  nlsolvefail(nlsolver) && return
  @.. z₂ = z₁ + z
@@ -980,7 +979,6 @@ end
  @.. tmp2 = 0.5uprev + z₁ - 0.5z₂
  nlsolver.tmp = tmp2
  nlsolver.c = 1
- set_new_W!(nlsolver, false)
  z = nlsolve!(integrator, cache)
  nlsolvefail(nlsolver) && return
  @.. u = tmp2 + z

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -50,7 +50,7 @@ end
 
   nlsolver.tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -60,7 +60,7 @@ end
 
   nlsolver.tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -69,7 +69,7 @@ end
 
   nlsolver.tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = 1
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₄
@@ -117,7 +117,7 @@ end
 
   @.. tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -129,7 +129,7 @@ end
 
   @.. tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -144,7 +144,7 @@ end
 
   @.. tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = 1
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₄
@@ -209,7 +209,7 @@ end
   end
 
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -229,7 +229,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = c3
 
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -249,7 +249,7 @@ end
   nlsolver.c = 1
   nlsolver.tmp = tmp
 
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₄
@@ -337,7 +337,7 @@ end
   end
 
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -360,7 +360,7 @@ end
   nlsolver.z = z₃
 
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -382,7 +382,7 @@ end
   nlsolver.z = z₄
 
   nlsolver.c = 1
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₄
@@ -449,7 +449,7 @@ end
 
   nlsolver.tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -458,7 +458,7 @@ end
 
   nlsolver.tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -467,7 +467,7 @@ end
 
   nlsolver.tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -477,7 +477,7 @@ end
 
   nlsolver.tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = 1
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₅
@@ -528,7 +528,7 @@ end
 
   @.. tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -539,7 +539,7 @@ end
 
   @.. tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -550,7 +550,7 @@ end
 
   @.. tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -561,7 +561,7 @@ end
 
   @.. tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = 1
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₅
@@ -632,7 +632,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = γ
 
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -652,7 +652,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = c3
 
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -671,7 +671,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = c4
 
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -691,7 +691,7 @@ end
   nlsolver.c = c5
 
   u = nlsolver.tmp + γ*z₅
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -710,7 +710,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = 1
 
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₆
@@ -804,7 +804,7 @@ end
   end
 
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -829,7 +829,7 @@ end
   nlsolver.z = z₃
 
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -850,7 +850,7 @@ end
   nlsolver.z = z₄
 
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -876,7 +876,7 @@ end
   nlsolver.z = z₅
 
   nlsolver.c = c5
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -901,7 +901,7 @@ end
   nlsolver.z = z₆
 
   nlsolver.c = 1
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₆
@@ -972,7 +972,7 @@ end
 
   nlsolver.tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -981,7 +981,7 @@ end
 
   nlsolver.tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -990,7 +990,7 @@ end
 
   nlsolver.tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -999,7 +999,7 @@ end
 
   nlsolver.tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = c5
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -1008,7 +1008,7 @@ end
 
   nlsolver.tmp = uprev + a61*z₁ + a63*z₃ + a64*z₄ + a65*z₅
   nlsolver.c = c6
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 7
@@ -1018,7 +1018,7 @@ end
 
   nlsolver.tmp = uprev + a71*z₁ + a73*z₃ + a74*z₄ + a75*z₅ + a76*z₆
   nlsolver.c = 1
-  z₇ = nlsolve!(integrator, cache)
+  z₇ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₇
@@ -1069,7 +1069,7 @@ end
 
   @.. tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -1080,7 +1080,7 @@ end
 
   @.. tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -1091,7 +1091,7 @@ end
 
   @.. tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -1101,7 +1101,7 @@ end
 
   @.. tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = c5
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -1111,7 +1111,7 @@ end
 
   @.. tmp = uprev + a61*z₁ + a63*z₃ + a64*z₄ + a65*z₅
   nlsolver.c = c6
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 7
@@ -1128,7 +1128,7 @@ end
     @inbounds tmp[i] = uprev[i] + a71*z₁[i] + a73*z₃[i] + a74*z₄[i] + a75*z₅[i] + a76*z₆[i]
   end
   nlsolver.c = 1
-  z₇ = nlsolve!(integrator, cache)
+  z₇ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₇
@@ -1205,7 +1205,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = γ
 
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -1227,7 +1227,7 @@ end
   nlsolver.c = c3
   nlsolver.tmp = tmp
 
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -1246,7 +1246,7 @@ end
   nlsolver.c = c4
   nlsolver.tmp = tmp
 
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -1265,7 +1265,7 @@ end
   nlsolver.c = c5
   nlsolver.tmp = tmp
 
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -1284,7 +1284,7 @@ end
   nlsolver.c = c6
   nlsolver.tmp = tmp
 
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 7
@@ -1303,7 +1303,7 @@ end
   nlsolver.c = c7
   nlsolver.tmp = tmp
 
-  z₇ = nlsolve!(integrator, cache)
+  z₇ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 8
@@ -1322,7 +1322,7 @@ end
   nlsolver.c = 1
   nlsolver.tmp = tmp
 
-  z₈ = nlsolve!(integrator, cache)
+  z₈ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₈
@@ -1418,7 +1418,7 @@ end
   end
 
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -1443,7 +1443,7 @@ end
   nlsolver.z = z₃
 
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -1464,7 +1464,7 @@ end
   nlsolver.z = z₄
 
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -1485,7 +1485,7 @@ end
   nlsolver.z = z₅
 
   nlsolver.c = c5
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -1509,7 +1509,7 @@ end
   nlsolver.z = z₆
 
   nlsolver.c = c6
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 7
@@ -1536,7 +1536,7 @@ end
   nlsolver.z = z₇
 
   nlsolver.c = c7
-  z₇ = nlsolve!(integrator, cache)
+  z₇ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 8
@@ -1563,7 +1563,7 @@ end
   nlsolver.z = z₈
 
   nlsolver.c = 1
-  z₈ = nlsolve!(integrator, cache)
+  z₈ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₈

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -119,7 +119,7 @@ end
   nlsolver.c = γ
   z₂ = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
   ################################## Solve Step 3
 
@@ -155,7 +155,8 @@ end
     @.. dz = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      linsolve = get_linsolve(nlsolver)
+      linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -338,7 +339,7 @@ end
   nlsolver.c = γ
   z₂ = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
   ################################## Solve Step 3
 
@@ -407,7 +408,8 @@ end
     end
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      linsolve = get_linsolve(nlsolver)
+      linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -528,7 +530,7 @@ end
   nlsolver.c = γ
   z₂ = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
   ################################## Solve Step 3
 
@@ -570,7 +572,8 @@ end
     @.. dz = btilde1*z₁ + btilde2*z₂ + btilde3*z₃ + btilde4*z₄ + btilde5*z₅
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      linsolve = get_linsolve(nlsolver)
+      linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -803,7 +806,7 @@ end
   nlsolver.c = γ
   z₂ = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
   ################################## Solve Step 3
 
@@ -928,7 +931,8 @@ end
 
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      linsolve = get_linsolve(nlsolver)
+      linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -1067,7 +1071,7 @@ end
   nlsolver.c = γ
   z₂ = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
   ################################## Solve Step 3
 
@@ -1138,7 +1142,8 @@ end
     end
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      linsolve = get_linsolve(nlsolver)
+      linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end
@@ -1415,7 +1420,7 @@ end
   nlsolver.c = γ
   z₂ = nlsolve!(integrator, cache)
   nlsolvefail(nlsolver) && return
-  set_new_W!(nlsolver, false)
+  isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
   ################################## Solve Step 3
 
@@ -1590,7 +1595,8 @@ end
 
     if isnewton(nlsolver) && alg.smooth_est # From Shampine
       integrator.destats.nsolve += 1
-      nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
+      linsolve = get_linsolve(nlsolver)
+      linsolve(vec(tmp),get_W(nlsolver),vec(dz),false)
     else
       tmp .= dz
     end

--- a/src/perform_step/pdirk_perform_step.jl
+++ b/src/perform_step/pdirk_perform_step.jl
@@ -28,7 +28,7 @@ function initialize!(integrator, cache::PDIRK44ConstantCache) end
         nlsolver[i].c = cs[2+i]
         nlsolver[i].z = zero(u)
         nlsolver[i].tmp = uprev + α1[i] * k1[1] + α2[i] * k1[2]
-        k2[i] = DiffEqBase.nlsolve!(nlsolver[i], nlsolver[i].cache, integrator)
+        k2[i] = nlsolve!(nlsolver[i], integrator)
       end
     end
     nlsolvefail(nlsolver[1]) && return

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -576,7 +576,7 @@ function perform_step!(integrator,cache::IRKCConstantCache,repeat_step=false)
   nlsolver.tmp = uprev + dt*μs₁*du₂
   nlsolver.γ   = μs₁
   nlsolver.c   = μs
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   # nlsolvefail(nlsolver) && return
   gprev = nlsolver.tmp + μs₁*z
 
@@ -608,7 +608,7 @@ function perform_step!(integrator,cache::IRKCConstantCache,repeat_step=false)
     nlsolver.tmp = (1-μ-ν)*uprev + μ*gprev + ν*gprev2 + dt*μs*f2ⱼ₋₁ + dt*νs*du₂ + (νs - (1 -μ-ν)*μs₁)*dt*du₁ - ν*μs₁*dt*f1ⱼ₋₂
     nlsolver.z   = dt*f1ⱼ₋₁
     nlsolver.c   = Cⱼ
-    z = nlsolve!(integrator, cache)
+    z = nlsolve!(nlsolver, integrator)
     # ignoring newton method's convergence failure
     # nlsolvefail(nlsolver) && return
     u = nlsolver.tmp + μs₁*z
@@ -704,7 +704,7 @@ function perform_step!(integrator, cache::IRKCCache, repeat_step=false)
   @.. nlsolver.tmp = uprev + dt*μs₁*du₂
   nlsolver.γ   = μs₁
   nlsolver.c   = μs
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   # ignoring newton method's convergence failure
   # nlsolvefail(nlsolver) && return
   @.. gprev = nlsolver.tmp + μs₁*nlsolver.z
@@ -738,7 +738,7 @@ function perform_step!(integrator, cache::IRKCCache, repeat_step=false)
     @.. nlsolver.z   = dt*f1ⱼ₋₁
     nlsolver.c = Cⱼ
 
-    z = nlsolve!(integrator, cache)
+    z = nlsolve!(nlsolver, integrator)
     # nlsolvefail(nlsolver) && return
     @.. u = nlsolver.tmp + μs₁*nlsolver.z
     if (iter < mdeg)

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -768,7 +768,8 @@ function perform_step!(integrator, cache::IRKCCache, repeat_step=false)
   if isnewton(nlsolver) && integrator.opts.adaptive
     update_W!(integrator, cache, dt, false)
     @.. gprev = dt*0.5*(du₂ - f2ⱼ₋₁) + dt*(0.5 - μs₁)*(du₁ - f1ⱼ₋₁)
-    nlsolver.linsolve(vec(tmp),get_W(nlsolver),vec(gprev),false)
+    linsolve = get_linsolve(nlsolver)
+    linsolve(vec(tmp),get_W(nlsolver),vec(gprev),false)
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -51,7 +51,7 @@ end
   end
 
   nlsolver.tmp = uprev
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + z
 
@@ -98,7 +98,7 @@ end
   end
 
   nlsolver.tmp .= uprev
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = uprev + z
 
@@ -140,7 +140,7 @@ end
   end
 
   nlsolver.tmp = uprev
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + z
 
@@ -168,7 +168,7 @@ end
   end
 
   nlsolver.tmp = uprev
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = nlsolver.tmp + z
 
@@ -190,7 +190,7 @@ end
   nlsolver.z = zprev # Constant extrapolation
 
   nlsolver.tmp = uprev + γdt*integrator.fsalfirst
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   u = nlsolver.tmp + 1//2*z
 
@@ -254,7 +254,7 @@ end
   # initial guess
   @.. z = dt*integrator.fsalfirst
   @.. tmp = uprev + γdt*integrator.fsalfirst
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   @.. u = tmp + 1//2*z
 
@@ -320,7 +320,7 @@ end
   nlsolver.c = γ
 
   nlsolver.tmp = uprev + d*zprev
-  zᵧ = nlsolve!(integrator, cache)
+  zᵧ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve BDF2 Step
@@ -331,7 +331,7 @@ end
   nlsolver.c = 1
 
   nlsolver.tmp = uprev + ω*zprev + ω*zᵧ
-  z = nlsolve!(integrator, cache)
+  z = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + d*z
@@ -375,7 +375,7 @@ end
   z .= zᵧ
   @.. tmp = uprev + d*zprev
   nlsolver.c = γ
-  zᵧ .= nlsolve!(integrator, cache)
+  zᵧ .= nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve BDF2 Step
@@ -385,7 +385,7 @@ end
   @.. tmp = uprev + ω*zprev + ω*zᵧ
   nlsolver.c = 1
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
-  nlsolve!(integrator, cache)
+  nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + d*z
@@ -425,14 +425,14 @@ end
   end
 
   nlsolver.tmp = uprev
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ### Initial Guess Is α₁ = c₂/γ, c₂ = 0 => z₂ = α₁z₁ = 0
   z₂ = zero(u)
   nlsolver.z = z₂
   nlsolver.tmp = uprev - z₁
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = uprev + z₁/2 + z₂/2
@@ -478,7 +478,7 @@ end
 
   ##### Step 1
   nlsolver.tmp = uprev
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 2
@@ -489,7 +489,7 @@ end
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
   @.. tmp = uprev - z₁
   nlsolver.tmp = tmp
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = uprev + z₁/2 + z₂/2
@@ -541,7 +541,7 @@ end
 
   nlsolver.c = 1
   nlsolver.tmp = uprev
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 2
@@ -552,7 +552,7 @@ end
 
   nlsolver.tmp = uprev + z₁/2
   nlsolver.c = 1
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + z₂/2
@@ -589,7 +589,7 @@ end
   nlsolver.tmp = uprev
 
   ##### Step 1
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 2
@@ -601,7 +601,7 @@ end
   @.. tmp = uprev + z₁/2
   nlsolver.tmp = tmp
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + z₂/2
@@ -628,7 +628,7 @@ end
 
   nlsolver.c = γ
   nlsolver.tmp = uprev
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ##### Step 2
@@ -639,7 +639,7 @@ end
 
   nlsolver.tmp = uprev + a21*z₁
   nlsolver.c = c2
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -650,7 +650,7 @@ end
 
   nlsolver.tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -661,7 +661,7 @@ end
 
   nlsolver.tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -672,7 +672,7 @@ end
 
   nlsolver.tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = 1
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₅
@@ -723,7 +723,7 @@ end
   nlsolver.tmp = uprev
 
   # initial step of NLNewton iteration
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ##### Step 2
@@ -736,7 +736,7 @@ end
   nlsolver.tmp = tmp
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
   nlsolver.c = c2
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -746,7 +746,7 @@ end
   nlsolver.z = z₃
   @.. tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -757,7 +757,7 @@ end
 
   @.. tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -767,7 +767,7 @@ end
   nlsolver.z = z₅
   @.. tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = 1
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₅
@@ -814,7 +814,7 @@ end
   z₁ = zero(u)
   nlsolver.z, nlsolver.tmp = z₁, uprev
   nlsolver.c = γ
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ##### Step 2
@@ -823,7 +823,7 @@ end
   nlsolver.z = z₂
   nlsolver.tmp = uprev + a21*z₁
   nlsolver.c = c2
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -832,7 +832,7 @@ end
   nlsolver.z = z₃
   nlsolver.tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -841,7 +841,7 @@ end
   nlsolver.z = z₄
   nlsolver.tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -851,7 +851,7 @@ end
   nlsolver.z = z₅
   nlsolver.tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = 1
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₅
@@ -901,7 +901,7 @@ end
   ##### Step 1
 
   nlsolver.c = γ
-  z₁ = nlsolve!(integrator, cache)
+  z₁ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ##### Step 2
@@ -912,7 +912,7 @@ end
   nlsolver.tmp = tmp
   nlsolver.c = c2
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -921,7 +921,7 @@ end
   nlsolver.z = z₃
   @.. tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -931,7 +931,7 @@ end
   nlsolver.z = z₄
   @.. tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -941,7 +941,7 @@ end
   nlsolver.z = z₅
   @.. tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = 1
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₅
@@ -998,7 +998,7 @@ end
 
   nlsolver.tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 3
@@ -1007,7 +1007,7 @@ end
 
   nlsolver.tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -1016,7 +1016,7 @@ end
 
   nlsolver.tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -1025,7 +1025,7 @@ end
 
   nlsolver.tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = c5
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -1034,7 +1034,7 @@ end
 
   nlsolver.tmp = uprev + a61*z₁ + a62*z₂+ a63*z₃ + a64*z₄ + a65*z₅
   nlsolver.c = c6
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 7
@@ -1043,7 +1043,7 @@ end
 
   nlsolver.tmp = uprev + a71*z₁ + a72*z₂ + a73*z₃ + a74*z₄ + a75*z₅ + a76*z₆
   nlsolver.c = c7
-  z₇ = nlsolve!(integrator, cache)
+  z₇ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 8
@@ -1052,7 +1052,7 @@ end
 
   nlsolver.tmp = uprev + a81*z₁ + a82*z₂ + a83*z₃ + a84*z₄ + a85*z₅ + a86*z₆ + a87*z₇
   nlsolver.c = 1
-  z₈ = nlsolve!(integrator, cache)
+  z₈ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   u = nlsolver.tmp + γ*z₈
@@ -1103,7 +1103,7 @@ end
 
   @.. tmp = uprev + γ*z₁
   nlsolver.c = γ
-  z₂ = nlsolve!(integrator, cache)
+  z₂ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
   isnewton(nlsolver) && set_new_W!(nlsolver, false)
 
@@ -1113,7 +1113,7 @@ end
 
   @.. tmp = uprev + a31*z₁ + a32*z₂
   nlsolver.c = c3
-  z₃ = nlsolve!(integrator, cache)
+  z₃ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 4
@@ -1123,7 +1123,7 @@ end
 
   @.. tmp = uprev + a41*z₁ + a42*z₂ + a43*z₃
   nlsolver.c = c4
-  z₄ = nlsolve!(integrator, cache)
+  z₄ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 5
@@ -1132,7 +1132,7 @@ end
 
   @.. tmp = uprev + a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄
   nlsolver.c = c5
-  z₅ = nlsolve!(integrator, cache)
+  z₅ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 6
@@ -1141,7 +1141,7 @@ end
 
   @.. tmp = uprev + a61*z₁ + a62*z₂ + a63*z₃ + a64*z₄ + a65*z₅
   nlsolver.c = c6
-  z₆ = nlsolve!(integrator, cache)
+  z₆ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 7
@@ -1150,7 +1150,7 @@ end
 
   @.. tmp = uprev + a71*z₁ + a72*z₂ + a73*z₃ + a74*z₄ + a75*z₅ + a76*z₆
   nlsolver.c = c7
-  z₇ = nlsolve!(integrator, cache)
+  z₇ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   ################################## Solve Step 8
@@ -1159,7 +1159,7 @@ end
 
   @.. nlsolver.tmp = uprev + a81*z₁ + a82*z₂ + a83*z₃ + a84*z₄ + a85*z₅ + a86*z₆ + a87*z₇
   nlsolver.c = oneunit(nlsolver.c)
-  z₈ = nlsolve!(integrator, cache)
+  z₈ = nlsolve!(nlsolver, integrator)
   nlsolvefail(nlsolver) && return
 
   @.. u = tmp + γ*z₈


### PR DESCRIPTION
This PR contains fixes for upstream changes in https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/315.

It should be easy to remove the duplicated implementations of `calc_J` etc in `derivative_utils.jl` by just passing the ODE cache or the NLSolver cache but I think it's better to do that in a separate PR.