### PR TITLE
Rename tableau struct for rosenbrock methods

### DIFF
--- a/src/caches/rosenbrock_caches.jl
+++ b/src/caches/rosenbrock_caches.jl
@@ -205,7 +205,7 @@ function alg_cache(alg::ROS3P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   J,W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   tmp = zero(rate_prototype)
   atmp = similar(u, uEltypeNoUnits)
-  tab = ROS3PConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
+  tab = ROS3PTableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
   tf = DiffEqDiffTools.TimeGradientWrapper(f,uprev,p)
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   linsolve_tmp = zero(rate_prototype)
@@ -222,7 +222,7 @@ function alg_cache(alg::ROS3P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUni
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   J,W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   linsolve = alg.linsolve(Val{:init},uf,u)
-  Rosenbrock33ConstantCache(tf,uf,ROS3PConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
+  Rosenbrock33ConstantCache(tf,uf,ROS3PTableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
 end
 
 @cache mutable struct Rosenbrock34Cache{uType,rateType,uNoUnitsType,JType,WType,TabType,TFType,UFType,F,JCType,GCType} <: RosenbrockMutableCache
@@ -265,7 +265,7 @@ function alg_cache(alg::Rodas3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   J,W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   tmp = zero(rate_prototype)
   atmp = similar(u, uEltypeNoUnits)
-  tab = Rodas3ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
+  tab = Rodas3Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
 
   tf = DiffEqDiffTools.TimeGradientWrapper(f,uprev,p)
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
@@ -292,7 +292,7 @@ function alg_cache(alg::Rodas3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   J,W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   linsolve = alg.linsolve(Val{:init},uf,u)
-  Rosenbrock34ConstantCache(tf,uf,Rodas3ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
+  Rosenbrock34ConstantCache(tf,uf,Rodas3Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
 end
 
 ################################################################################
@@ -369,7 +369,7 @@ function alg_cache(alg::Rodas4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   J,W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   tmp = zero(rate_prototype)
   atmp = similar(u, uEltypeNoUnits)
-  tab = Rodas4ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
+  tab = Rodas4Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
 
   tf = DiffEqDiffTools.TimeGradientWrapper(f,uprev,p)
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
@@ -388,7 +388,7 @@ function alg_cache(alg::Rodas4,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   J,W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   linsolve = alg.linsolve(Val{:init},uf,u)
-  Rodas4ConstantCache(tf,uf,Rodas4ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
+  Rodas4ConstantCache(tf,uf,Rodas4Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
 end
 
 function alg_cache(alg::Rodas42,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
@@ -409,7 +409,7 @@ function alg_cache(alg::Rodas42,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   J,W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   tmp = zero(rate_prototype)
   atmp = similar(u, uEltypeNoUnits)
-  tab = Rodas42ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
+  tab = Rodas42Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
 
   tf = DiffEqDiffTools.TimeGradientWrapper(f,uprev,p)
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
@@ -428,7 +428,7 @@ function alg_cache(alg::Rodas42,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   J,W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   linsolve = alg.linsolve(Val{:init},uf,u)
-  Rodas4ConstantCache(tf,uf,Rodas42ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
+  Rodas4ConstantCache(tf,uf,Rodas42Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
 end
 
 function alg_cache(alg::Rodas4P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Type{Val{true}})
@@ -449,7 +449,7 @@ function alg_cache(alg::Rodas4P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   J,W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   tmp = zero(rate_prototype)
   atmp = similar(u, uEltypeNoUnits)
-  tab = Rodas4PConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
+  tab = Rodas4PTableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
 
   tf = DiffEqDiffTools.TimeGradientWrapper(f,uprev,p)
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
@@ -468,7 +468,7 @@ function alg_cache(alg::Rodas4P,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoU
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   J,W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   linsolve = alg.linsolve(Val{:init},uf,u)
-  Rodas4ConstantCache(tf,uf,Rodas4PConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
+  Rodas4ConstantCache(tf,uf,Rodas4PTableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
 end
 
 ################################################################################
@@ -536,7 +536,7 @@ function alg_cache(alg::Rodas5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   J,W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   tmp = zero(rate_prototype)
   atmp = similar(u, uEltypeNoUnits)
-  tab = Rodas5ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
+  tab = Rodas5Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
 
   tf = DiffEqDiffTools.TimeGradientWrapper(f,uprev,p)
   uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
@@ -555,7 +555,7 @@ function alg_cache(alg::Rodas5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
   J,W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
   linsolve = alg.linsolve(Val{:init},uf,u)
-  Rosenbrock5ConstantCache(tf,uf,Rodas5ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
+  Rosenbrock5ConstantCache(tf,uf,Rodas5Tableau(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits)),J,W,linsolve)
 end
 
 ################################################################################

--- a/src/generic_rosenbrock.jl
+++ b/src/generic_rosenbrock.jl
@@ -488,8 +488,8 @@ macro RosenbrockW6S4OS(part)
     tab=RosenbrockW6S4OSTableau()
     tabmask=_masktab(tab)
     algname=:RosenbrockW6S4OS
-    tabname=:RosenbrockW6S4OSConstantCache
-    tabstructname=:RosenbrockW6S4OSConstantCache
+    tabname=:RosenbrockW6S4OSTableau
+    tabstructname=:RosenbrockW6STableau
     cachename=:RosenbrockW6SCache
     constcachename=:RosenbrockW6SConstantCache
     n_normalstep=length(tab.b)-1
@@ -691,16 +691,16 @@ macro Rosenbrock4(part)
     tabmask=Ros4dummyTableau()#_masktab(tab)
     cachename=:Rosenbrock4Cache
     constcachename=:Rosenbrock4ConstantCache
-    RosShamp4tabname=:RosShamp4ConstantCache
-    Veldd4tabname=:Veldd4ConstantCache
-    Velds4tabname=:Velds4ConstantCache
-    GRK4Ttabname=:GRK4TConstantCache
-    GRK4Atabname=:GRK4AConstantCache
-    Ros4LStabname=:Ros4LStabConstantCache
+    RosShamp4tabname=:RosShamp4Tableau
+    Veldd4tabname=:Veldd4Tableau
+    Velds4tabname=:Velds4Tableau
+    GRK4Ttabname=:GRK4TTableau
+    GRK4Atabname=:GRK4ATableau
+    Ros4LStabname=:Ros4LStabTableau
     n_normalstep=2 #for the third step a4j=a3j which reduced one function call
     if part.value==:tableau
         #println("Generating tableau for Rosenbrock4")
-        tabstructexpr=gen_tableau_struct(tabmask,:Ros4ConstantCache)
+        tabstructexpr=gen_tableau_struct(tabmask,:Ros4Tableau)
         tabexprs=Array{Expr,1}()
         push!(tabexprs,tabstructexpr)
         push!(tabexprs,gen_tableau(RosShamp4Tableau(),tabstructexpr,RosShamp4tabname))
@@ -911,13 +911,13 @@ macro ROS34PW(part)
     tabmask=Ros34dummyTableau()
     cachename=:ROS34PWCache
     constcachename=:ROS34PWConstantCache
-    ROS34PW1atabname=:ROS34PW1aConstantCache
-    ROS34PW1btabname=:ROS34PW1bConstantCache
-    ROS34PW2tabname=:ROS34PW2ConstantCache
-    ROS34PW3tabname=:ROS34PW3ConstantCache
+    ROS34PW1atabname=:ROS34PW1aTableau
+    ROS34PW1btabname=:ROS34PW1bTableau
+    ROS34PW2tabname=:ROS34PW2Tableau
+    ROS34PW3tabname=:ROS34PW3Tableau
     n_normalstep=length(tabmask.b)-1
     if part.value==:tableau
-        tabstructexpr=gen_tableau_struct(tabmask,:Ros34ConstantCache)
+        tabstructexpr=gen_tableau_struct(tabmask,:Ros34Tableau)
         tabexprs=Array{Expr,1}([tabstructexpr])
         push!(tabexprs,gen_tableau(ROS34PW1aTableau(),tabstructexpr,ROS34PW1atabname))
         push!(tabexprs,gen_tableau(ROS34PW1bTableau(),tabstructexpr,ROS34PW1btabname))

--- a/src/tableaus/rosenbrock_tableaus.jl
+++ b/src/tableaus/rosenbrock_tableaus.jl
@@ -20,7 +20,7 @@ function Rosenbrock32Tableau(T::Type)
   Rosenbrock32Tableau(c₃₂,d)
 end
 
-struct ROS3PConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+struct ROS3PTableau{T,T2} <: OrdinaryDiffEqConstantCache
   a21::T
   a31::T
   a32::T
@@ -41,7 +41,7 @@ struct ROS3PConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   d3::T
 end
 
-function ROS3PConstantCache(T::Type,T2::Type)
+function ROS3PTableau(T::Type,T2::Type)
   gamma = convert(T,1/2 + sqrt(3)/6)
   igamma = inv(gamma)
   a21 = convert(T,igamma)
@@ -66,10 +66,10 @@ function ROS3PConstantCache(T::Type,T2::Type)
   d1 = convert(T,0.7886751345948129)
   d2 = convert(T,-0.2113248654051871)
   d3 = convert(T,-1.077350269189626)
-  ROS3PConstantCache(a21,a31,a32,C21,C31,C32,b1,b2,b3,btilde1,btilde2,btilde3,gamma,c2,c3,d1,d2,d3)
+  ROS3PTableau(a21,a31,a32,C21,C31,C32,b1,b2,b3,btilde1,btilde2,btilde3,gamma,c2,c3,d1,d2,d3)
 end
 
-struct Rodas3ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+struct Rodas3Tableau{T,T2} <: OrdinaryDiffEqConstantCache
   a21::T
   a31::T
   a32::T
@@ -99,7 +99,7 @@ struct Rodas3ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   d4::T
 end
 
-function Rodas3ConstantCache(T::Type,T2::Type)
+function Rodas3Tableau(T::Type,T2::Type)
   gamma = convert(T,1//2)
   a21 = convert(T,0)
   a31 = convert(T,2)
@@ -128,14 +128,14 @@ function Rodas3ConstantCache(T::Type,T2::Type)
   d2 = convert(T,3//2)
   d3 = convert(T,0)
   d4 = convert(T,0)
-  Rodas3ConstantCache(a21,a31,a32,a41,a42,a43,C21,C31,C32,C41,C42,C43,b1,b2,b3,b4,btilde1,btilde2,btilde3,btilde4,gamma,c2,c3,d1,d2,d3,d4)
+  Rodas3Tableau(a21,a31,a32,a41,a42,a43,C21,C31,C32,C41,C42,C43,b1,b2,b3,b4,btilde1,btilde2,btilde3,btilde4,gamma,c2,c3,d1,d2,d3,d4)
 end
 
 @ROS34PW(:tableau)
 
 @Rosenbrock4(:tableau)
 
-struct RodasConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+struct RodasTableau{T,T2} <: OrdinaryDiffEqConstantCache
   a21::T
   a31::T
   a32::T
@@ -181,7 +181,7 @@ struct RodasConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   h35::T
 end
 
-function Rodas4ConstantCache(T::Type,T2::Type)
+function Rodas4Tableau(T::Type,T2::Type)
   gamma=convert(T,1//4)
   #BET2P=0.0317D0
   #BET3P=0.0635D0
@@ -232,13 +232,13 @@ function Rodas4ConstantCache(T::Type,T2::Type)
   h34= convert(T,24.76722511418386)
   h35=-convert(T,6.594389125716872)
 
-  RodasConstantCache(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
+  RodasTableau(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
                     C21,C31,C32,C41,C42,C43,C51,C52,C53,C54,C61,C62,C63,C64,C65,
                     gamma,c2,c3,c4,d1,d2,d3,d4,
                     h21,h22,h23,h24,h25,h31,h32,h33,h34,h35)
 end
 
-function Rodas42ConstantCache(T::Type,T2::Type)
+function Rodas42Tableau(T::Type,T2::Type)
   gamma= convert(T,1//4)
   #BET2P=0.0317D0
   #BET3P=0.0047369D0
@@ -287,13 +287,13 @@ function Rodas42ConstantCache(T::Type,T2::Type)
   h34= convert(T,16.61359034616402)
   h35=-convert(T,0.6758691794084156)
 
-  RodasConstantCache(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
+  RodasTableau(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
                     C21,C31,C32,C41,C42,C43,C51,C52,C53,C54,C61,C62,C63,C64,C65,
                     gamma,c2,c3,c4,d1,d2,d3,d4,
                     h21,h22,h23,h24,h25,h31,h32,h33,h34,h35)
 end
 
-function Rodas4PConstantCache(T::Type,T2::Type)
+function Rodas4PTableau(T::Type,T2::Type)
   gamma = convert(T,1//4)
   #BET2P=0.D0
   #BET3P=c3*c3*(c3/6.d0-GAMMA/2.d0)/(GAMMA*GAMMA)
@@ -342,13 +342,13 @@ function Rodas4PConstantCache(T::Type,T2::Type)
   h34= convert(T,15.99253148779520)
   h35=-convert(T,1.882352941176471)
 
-  RodasConstantCache(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
+  RodasTableau(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
                     C21,C31,C32,C41,C42,C43,C51,C52,C53,C54,C61,C62,C63,C64,C65,
                     gamma,c2,c3,c4,d1,d2,d3,d4,
                     h21,h22,h23,h24,h25,h31,h32,h33,h34,h35)
 end
 
-struct Rodas5ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
+struct Rodas5Tableau{T,T2} <: OrdinaryDiffEqConstantCache
   a21::T
   a31::T
   a32::T
@@ -404,7 +404,7 @@ struct Rodas5ConstantCache{T,T2} <: OrdinaryDiffEqConstantCache
   c5::T2
 end
 
-function Rodas5ConstantCache(T::Type,T2::Type)
+function Rodas5Tableau(T::Type,T2::Type)
   gamma = convert(T2,.19)
   a21 = convert(T,2.0)
   a31 = convert(T,3.040894194418781 )
@@ -483,7 +483,7 @@ function Rodas5ConstantCache(T::Type,T2::Type)
   b8 = convert(T,1)
   =#
 
-  Rodas5ConstantCache(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
+  Rodas5Tableau(a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,
                       a61,a62,a63,a64,a65,
                       C21,C31,C32,C41,C42,C43,C51,C52,C53,C54,
                       C61,C62,C63,C64,C65,C71,C72,C73,C74,C75,C76,


### PR DESCRIPTION
Following https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/873. Methods other than Rosenbrock use tableau struct as constant cache, so no changes are made.