### PR TITLE
Commit message CI options

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,19 @@ const GROUP = get(ENV, "GROUP", "All")
 const is_APPVEYOR = Sys.iswindows() && haskey(ENV,"APPVEYOR")
 const is_TRAVIS = haskey(ENV,"TRAVIS")
 
+using LibGit2
+r = LibGit2.GitRepo("..")
+commit = LibGit2.peel(LibGit2.GitCommit, LibGit2.head(r))
+msg = LibGit2.message(commit)
+
+if msg[1:5] == "base:"
+  using Pkg
+  lastidx = findfirst(isequal(' '),msg) - 1
+  branch = msg[6:lastidx]
+  Pkg.add(PackageSpec(name="DiffEqBase", rev=branch))
+elseif msg[1:7] == "notest:"
+  exit(0)
+end
 #Start Test Script
 
 @time begin


### PR DESCRIPTION
I just made a small utility where you can tell Travis what to do with tests using commit messages.

1. If commit message starts with `base:<name-of-branch> commit message`, it will checkout a branch of DiffEqBase and then the tests will run. Forks are still a question. Though there is a way out I know of.
2. If commit message starts with `notest:` the tests will not run, saving CI time.

Might come handy at a cost of having ugly commit messages.
