### PR TITLE
add loop dispatches on Array: experiments with Verner

### DIFF
--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -660,8 +660,7 @@ end
   return nothing
 end
 
-#=
-@muladd function perform_step!(integrator, cache::Tsit5Cache, repeat_step=false)
+@muladd function perform_step!(integrator::DiffEqBase.AbstractODEIntegrator{algType,IIP,<:Array,tType}, cache::Tsit5Cache, repeat_step=false) where {algType,IIP,tType}
   @unpack t,dt,uprev,u,f,p = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7 = cache.tab
@@ -710,7 +709,6 @@ end
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
 end
-=#
 
 function initialize!(integrator, cache::DP5ConstantCache)
   integrator.kshortsize = 4
@@ -818,8 +816,7 @@ end
   return nothing
 end
 
-#=
-@muladd function perform_step!(integrator, cache::DP5Cache, repeat_step=false)
+@muladd function perform_step!(integrator::DiffEqBase.AbstractODEIntegrator{algType,IIP,<:Array,tType}, cache::DP5Cache, repeat_step=false) where {algType,IIP,tType}
   @unpack t,dt,uprev,u,f,p = integrator
   uidx = eachindex(integrator.uprev)
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a73,a74,a75,a76,btilde1,btilde3,btilde4,btilde5,btilde6,btilde7,c1,c2,c3,c4,c5,c6 = cache.tab
@@ -881,7 +878,6 @@ end
     end
   end
 end
-=#
 
 function initialize!(integrator,cache::KYK2014DGSSPRK_3S2_ConstantCache)
  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal

--- a/src/perform_step/verner_rk_perform_step.jl
+++ b/src/perform_step/verner_rk_perform_step.jl
@@ -140,6 +140,83 @@ end
   return nothing
 end
 
+@muladd function perform_step!(integrator::DiffEqBase.AbstractODEIntegrator{algType,IIP,<:Array,tType}, cache::Vern6Cache, repeat_step=false) where {algType,IIP,tType}
+  @unpack t,dt,uprev,u,f,p = integrator
+  uidx = eachindex(integrator.uprev)
+  @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a43,a51,a53,a54,a61,a63,a64,a65,a71,a73,a74,a75,a76,a81,a83,a84,a85,a86,a87,a91,a94,a95,a96,a97,a98,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9 = cache.tab
+  @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,utilde,tmp,atmp = cache
+  a = dt*a21
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
+  end
+  f(k2, tmp, p, t + c1*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
+  end
+  f(k3, tmp, p, t + c2*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a41*k1[i]+a43*k3[i])
+  end
+  f(k4, tmp, p, t + c3*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a51*k1[i]+a53*k3[i]+a54*k4[i])
+  end
+  f(k5, tmp, p, t + c4*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a61*k1[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
+  end
+  f(k6, tmp, p, t + c5*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a71*k1[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
+  end
+  f(k7, tmp, p, t + c6*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a81*k1[i]+a83*k3[i]+a84*k4[i]+a85*k5[i]+a86*k6[i]+a87*k7[i])
+  end
+  f(k8, tmp, p, t+dt)
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i]+dt*(a91*k1[i]+a94*k4[i]+a95*k5[i]+a96*k6[i]+a97*k7[i]+a98*k8[i])
+  end
+  f(k9, u, p, t+dt)
+  integrator.destats.nf += 8
+  if typeof(integrator.alg) <: CompositeAlgorithm
+    g9 = u
+    g8 = tmp
+    @. utilde = k9 - k8
+    ϱu = integrator.opts.internalnorm(utilde,t)
+    @. utilde = g9 - g8
+    ϱd = integrator.opts.internalnorm(utilde,t)
+    integrator.eigen_est = ϱu/ϱd
+  end
+  if integrator.opts.adaptive
+    @tight_loop_macros for i in uidx
+      @inbounds utilde[i] = dt*(btilde1*k1[i] + btilde4*k4[i] + btilde5*k5[i] + btilde6*k6[i] + btilde7*k7[i] + btilde8*k8[i] + btilde9*k9[i])
+    end
+    calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
+    integrator.EEst = integrator.opts.internalnorm(atmp,t)
+  end
+
+  alg = unwrap_alg(integrator, false)
+  if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
+    k = integrator.k
+    @unpack c10,a1001,a1004,a1005,a1006,a1007,a1008,a1009,c11,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,c12,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211 = cache.tab
+    @unpack tmp = cache
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1001*k[1][i]+a1004*k[4][i]+a1005*k[5][i]+a1006*k[6][i]+a1007*k[7][i]+a1008*k[8][i]+a1009*k[9][i])
+    end
+    f(k[10],tmp,p,t+c10*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1101*k[1][i]+a1104*k[4][i]+a1105*k[5][i]+a1106*k[6][i]+a1107*k[7][i]+a1108*k[8][i]+a1109*k[9][i]+a1110*k[10][i])
+    end
+    f(k[11],tmp,p,t+c11*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1201*k[1][i]+a1204*k[4][i]+a1205*k[5][i]+a1206*k[6][i]+a1207*k[7][i]+a1208*k[8][i]+a1209*k[9][i]+a1210*k[10][i]+a1211*k[11][i])
+    end
+    integrator.destats.nf += 3
+    f(k[12],tmp,p,t+c12*dt)
+  end
+end
+
 function initialize!(integrator, cache::Vern7ConstantCache)
   alg = unwrap_alg(integrator, false)
   alg.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 16)
@@ -280,6 +357,102 @@ end
   end
   return nothing
 end
+
+@muladd function perform_step!(integrator::DiffEqBase.AbstractODEIntegrator{algType,IIP,<:Array,tType}, cache::Vern7Cache, repeat_step=false) where {algType,IIP,tType}
+  @unpack t,dt,uprev,u,f,p = integrator
+  uidx = eachindex(integrator.uprev)
+  @unpack c2,c3,c4,c5,c6,c7,c8,a021,a031,a032,a041,a043,a051,a053,a054,a061,a063,a064,a065,a071,a073,a074,a075,a076,a081,a083,a084,a085,a086,a087,a091,a093,a094,a095,a096,a097,a098,a101,a103,a104,a105,a106,a107,b1,b4,b5,b6,b7,b8,b9,btilde1,btilde4,btilde5,btilde6,btilde7,btilde8,btilde9,btilde10= cache.tab
+  @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,utilde,tmp,atmp = cache
+  f(k1, uprev, p, t)
+  a = dt*a021
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
+  end
+  f(k2, tmp, p, t + c2*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a031*k1[i]+a032*k2[i])
+  end
+  f(k3, tmp, p, t + c3*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a041*k1[i]+a043*k3[i])
+  end
+  f(k4, tmp, p, t + c4*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a051*k1[i]+a053*k3[i]+a054*k4[i])
+  end
+  f(k5, tmp, p, t + c5*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a061*k1[i]+a063*k3[i]+a064*k4[i]+a065*k5[i])
+  end
+  f(k6, tmp, p, t + c6*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a071*k1[i]+a073*k3[i]+a074*k4[i]+a075*k5[i]+a076*k6[i])
+  end
+  f(k7, tmp, p, t + c7*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a081*k1[i]+a083*k3[i]+a084*k4[i]+a085*k5[i]+a086*k6[i]+a087*k7[i])
+  end
+  f(k8, tmp, p, t + c8*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a091*k1[i]+a093*k3[i]+a094*k4[i]+a095*k5[i]+a096*k6[i]+a097*k7[i]+a098*k8[i])
+  end
+  f(k9, tmp, p, t+dt)
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i]+dt*(a101*k1[i]+a103*k3[i]+a104*k4[i]+a105*k5[i]+a106*k6[i]+a107*k7[i])
+  end
+  f(k10, u, p, t+dt)
+  integrator.destats.nf += 10
+  if typeof(integrator.alg) <: CompositeAlgorithm
+    g10 = u
+    g9 = tmp
+    @. utilde = k10 - k9
+    ϱu = integrator.opts.internalnorm(utilde,t)
+    @. utilde = g10 - g9
+    ϱd = integrator.opts.internalnorm(utilde,t)
+    integrator.eigen_est = ϱu/ϱd
+  end
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i] + dt*(b1*k1[i] + b4*k4[i] + b5*k5[i] + b6*k6[i] + b7*k7[i] + b8*k8[i] + b9*k9[i])
+  end
+  if integrator.opts.adaptive
+    @tight_loop_macros for i in uidx
+      @inbounds utilde[i] = dt*(btilde1*k1[i] + btilde4*k4[i] + btilde5*k5[i] + btilde6*k6[i] + btilde7*k7[i] + btilde8*k8[i] + btilde9*k9[i] + btilde10*k10[i])
+    end
+    calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
+    integrator.EEst = integrator.opts.internalnorm(atmp,t)
+  end
+
+  alg = unwrap_alg(integrator, false)
+  if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
+    k = integrator.k
+    @unpack tmp = cache
+    @unpack c11,a1101,a1104,a1105,a1106,a1107,a1108,a1109,c12,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1211,c13,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1311,a1312,c14,a1401,a1404,a1405,a1406,a1407,a1408,a1409,a1411,a1412,a1413,c15,a1501,a1504,a1505,a1506,a1507,a1508,a1509,a1511,a1512,a1513,c16,a1601,a1604,a1605,a1606,a1607,a1608,a1609,a1611,a1612,a1613 = cache.tab
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1101*k[1][i]+a1104*k[4][i]+a1105*k[5][i]+a1106*k[6][i]+a1107*k[7][i]+a1108*k[8][i]+a1109*k[9][i])
+    end
+    f(k[11],tmp,p,t+c11*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1201*k[1][i]+a1204*k[4][i]+a1205*k[5][i]+a1206*k[6][i]+a1207*k[7][i]+a1208*k[8][i]+a1209*k[9][i]+a1211*k[11][i])
+    end
+    f(k[12],tmp,p,t+c12*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1301*k[1][i]+a1304*k[4][i]+a1305*k[5][i]+a1306*k[6][i]+a1307*k[7][i]+a1308*k[8][i]+a1309*k[9][i]+a1311*k[11][i]+a1312*k[12][i])
+    end
+    f(k[13],tmp,p,t+c13*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1401*k[1][i]+a1404*k[4][i]+a1405*k[5][i]+a1406*k[6][i]+a1407*k[7][i]+a1408*k[8][i]+a1409*k[9][i]+a1411*k[11][i]+a1412*k[12][i]+a1413*k[13][i])
+    end
+    f(k[14],tmp,p,t+c14*dt)
+    @tight_loop_macros for i in uidx
+      tmp[i]=  uprev[i]+dt*(a1501*k[1][i]+a1504*k[4][i]+a1505*k[5][i]+a1506*k[6][i]+a1507*k[7][i]+a1508*k[8][i]+a1509*k[9][i]+a1511*k[11][i]+a1512*k[12][i]+a1513*k[13][i])
+    end
+    f(k[15],tmp,p,t+c15*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1601*k[1][i]+a1604*k[4][i]+a1605*k[5][i]+a1606*k[6][i]+a1607*k[7][i]+a1608*k[8][i]+a1609*k[9][i]+a1611*k[11][i]+a1612*k[12][i]+a1613*k[13][i])
+    end
+    integrator.destats.nf += 6
+    f(k[16],tmp,p,t+c16*dt)
+  end
 
 function initialize!(integrator, cache::Vern8ConstantCache)
   alg = unwrap_alg(integrator, false)
@@ -436,6 +609,124 @@ end
     f(k[21],tmp,p,t+c21*dt)
   end
   return nothing
+end
+
+@muladd function perform_step!(integrator::DiffEqBase.AbstractODEIntegrator{algType,IIP,<:Array,tType}, cache::Vern8Cache, repeat_step=false) where {algType,IIP,tType}
+  @unpack t,dt,uprev,u,f,p = integrator
+  uidx = eachindex(integrator.uprev)
+  @unpack c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0804,a0805,a0806,a0807,a0901,a0904,a0905,a0906,a0907,a0908,a1001,a1004,a1005,a1006,a1007,a1008,a1009,a1101,a1104,a1105,a1106,a1107,a1108,a1109,a1110,a1201,a1204,a1205,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1304,a1305,a1306,a1307,a1308,a1309,a1310,b1,b6,b7,b8,b9,b10,b11,b12,btilde1,btilde6,btilde7,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13 = cache.tab
+  @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,utilde,tmp,atmp = cache
+  f(k1, uprev, p, t)
+  a = dt*a0201
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
+  end
+  f(k2, tmp, p, t + c2*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
+  end
+  f(k3, tmp, p, t + c3*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
+  end
+  f(k4, tmp, p, t + c4*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
+  end
+  f(k5, tmp, p, t + c5*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
+  end
+  f(k6, tmp, p, t + c6*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
+  end
+  f(k7, tmp, p, t + c7*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0804*k4[i]+a0805*k5[i]+a0806*k6[i]+a0807*k7[i])
+  end
+  f(k8, tmp, p, t + c8*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0904*k4[i]+a0905*k5[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
+  end
+  f(k9, tmp, p, t + c9*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1004*k4[i]+a1005*k5[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
+  end
+  f(k10, tmp, p, t + c10*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1104*k4[i]+a1105*k5[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
+  end
+  f(k11, tmp, p, t + c11*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1204*k4[i]+a1205*k5[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
+  end
+  f(k12, tmp, p, t+dt)
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i]+dt*(a1301*k1[i]+a1304*k4[i]+a1305*k5[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i])
+  end
+  f(k13, u, p, t+dt)
+  integrator.destats.nf += 13
+  if typeof(integrator.alg) <: CompositeAlgorithm
+    g13 = u
+    g12 = tmp
+    @. utilde = k13 - k12
+    ϱu = integrator.opts.internalnorm(utilde,t)
+    @. utilde = g13 - g12
+    ϱd = integrator.opts.internalnorm(utilde,t)
+    integrator.eigen_est = ϱu/ϱd
+  end
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i] + dt*(b1*k1[i] + b6*k6[i] + b7*k7[i] + b8*k8[i] + b9*k9[i] + b10*k10[i] + b11*k11[i] + b12*k12[i])
+  end
+  if integrator.opts.adaptive
+    @tight_loop_macros for i in uidx
+      @inbounds utilde[i] = dt*(btilde1*k1[i] + btilde6*k6[i] + btilde7*k7[i] + btilde8*k8[i] + btilde9*k9[i] + btilde10*k10[i] + btilde11*k11[i] + btilde12*k12[i] + btilde13*k13[i])
+    end
+    calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
+    integrator.EEst = integrator.opts.internalnorm(atmp,t)
+  end
+
+  alg = unwrap_alg(integrator, false)
+  if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
+    k = integrator.k
+    @unpack c14,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,c15,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1514,c16,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1614,a1615,c17,a1701,a1706,a1707,a1708,a1709,a1710,a1711,a1712,a1714,a1715,a1716,c18,a1801,a1806,a1807,a1808,a1809,a1810,a1811,a1812,a1814,a1815,a1816,a1817,c19,a1901,a1906,a1907,a1908,a1909,a1910,a1911,a1912,a1914,a1915,a1916,a1917,c20,a2001,a2006,a2007,a2008,a2009,a2010,a2011,a2012,a2014,a2015,a2016,a2017,c21,a2101,a2106,a2107,a2108,a2109,a2110,a2111,a2112,a2114,a2115,a2116,a2117 = cache.tab
+    @unpack tmp = cache
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1401*k[1][i]+a1406*k[6][i]+a1407*k[7][i]+a1408*k[8][i]+a1409*k[9][i]+a1410*k[10][i]+a1411*k[11][i]+a1412*k[12][i])
+    end
+    f(k[14],tmp,p,t+c14*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1501*k[1][i]+a1506*k[6][i]+a1507*k[7][i]+a1508*k[8][i]+a1509*k[9][i]+a1510*k[10][i]+a1511*k[11][i]+a1512*k[12][i]+a1514*k[14][i])
+    end
+    f(k[15],tmp,p,t+c15*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1601*k[1][i]+a1606*k[6][i]+a1607*k[7][i]+a1608*k[8][i]+a1609*k[9][i]+a1610*k[10][i]+a1611*k[11][i]+a1612*k[12][i]+a1614*k[14][i]+a1615*k[15][i])
+    end
+    f(k[16],tmp,p,t+c16*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1701*k[1][i]+a1706*k[6][i]+a1707*k[7][i]+a1708*k[8][i]+a1709*k[9][i]+a1710*k[10][i]+a1711*k[11][i]+a1712*k[12][i]+a1714*k[14][i]+a1715*k[15][i]+a1716*k[16][i])
+    end
+    f(k[17],tmp,p,t+c17*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1801*k[1][i]+a1806*k[6][i]+a1807*k[7][i]+a1808*k[8][i]+a1809*k[9][i]+a1810*k[10][i]+a1811*k[11][i]+a1812*k[12][i]+a1814*k[14][i]+a1815*k[15][i]+a1816*k[16][i]+a1817*k[17][i])
+    end
+    f(k[18],tmp,p,t+c18*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1901*k[1][i]+a1906*k[6][i]+a1907*k[7][i]+a1908*k[8][i]+a1909*k[9][i]+a1910*k[10][i]+a1911*k[11][i]+a1912*k[12][i]+a1914*k[14][i]+a1915*k[15][i]+a1916*k[16][i]+a1917*k[17][i])
+    end
+    f(k[19],tmp,p,t+c19*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2001*k[1][i]+a2006*k[6][i]+a2007*k[7][i]+a2008*k[8][i]+a2009*k[9][i]+a2010*k[10][i]+a2011*k[11][i]+a2012*k[12][i]+a2014*k[14][i]+a2015*k[15][i]+a2016*k[16][i]+a2017*k[17][i])
+    end
+    f(k[20],tmp,p,t+c20*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2101*k[1][i]+a2106*k[6][i]+a2107*k[7][i]+a2108*k[8][i]+a2109*k[9][i]+a2110*k[10][i]+a2111*k[11][i]+a2112*k[12][i]+a2114*k[14][i]+a2115*k[15][i]+a2116*k[16][i]+a2117*k[17][i])
+    end
+    integrator.destats.nf += 8
+    f(k[21],tmp,p,t+c21*dt)
+  end
+
 end
 
 function initialize!(integrator, cache::Vern9ConstantCache)
@@ -609,4 +900,140 @@ end
     f(k[20],tmp,p,t+c26*dt)
   end
   return nothing
+end
+
+# Faster compile
+@muladd function perform_step!(integrator::DiffEqBase.AbstractODEIntegrator{algType,IIP,<:Array,tType}, cache::Vern9Cache, repeat_step=false) where {algType,IIP,tType}
+  @unpack t,dt,uprev,u,f,p = integrator
+  uidx = eachindex(integrator.uprev)
+  @unpack c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,a0201,a0301,a0302,a0401,a0403,a0501,a0503,a0504,a0601,a0604,a0605,a0701,a0704,a0705,a0706,a0801,a0806,a0807,a0901,a0906,a0907,a0908,a1001,a1006,a1007,a1008,a1009,a1101,a1106,a1107,a1108,a1109,a1110,a1201,a1206,a1207,a1208,a1209,a1210,a1211,a1301,a1306,a1307,a1308,a1309,a1310,a1311,a1312,a1401,a1406,a1407,a1408,a1409,a1410,a1411,a1412,a1413,a1501,a1506,a1507,a1508,a1509,a1510,a1511,a1512,a1513,a1514,a1601,a1606,a1607,a1608,a1609,a1610,a1611,a1612,a1613,b1,b8,b9,b10,b11,b12,b13,b14,b15,btilde1,btilde8,btilde9,btilde10,btilde11,btilde12,btilde13,btilde14,btilde15,btilde16 = cache.tab
+  @unpack k1,k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,k14,k15,k16,utilde,tmp,atmp = cache
+  f(k1, uprev, p, t)
+  a = dt*a0201
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+a*k1[i]
+  end
+  f(k2, tmp, p, t + c1*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0301*k1[i]+a0302*k2[i])
+  end
+  f(k3, tmp, p, t + c2*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0401*k1[i]+a0403*k3[i])
+  end
+  f(k4, tmp, p, t + c3*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0501*k1[i]+a0503*k3[i]+a0504*k4[i])
+  end
+  f(k5, tmp, p, t + c4*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0601*k1[i]+a0604*k4[i]+a0605*k5[i])
+  end
+  f(k6, tmp, p, t + c5*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0701*k1[i]+a0704*k4[i]+a0705*k5[i]+a0706*k6[i])
+  end
+  f(k7, tmp, p, t + c6*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0801*k1[i]+a0806*k6[i]+a0807*k7[i])
+  end
+  f(k8, tmp, p, t + c7*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a0901*k1[i]+a0906*k6[i]+a0907*k7[i]+a0908*k8[i])
+  end
+  f(k9, tmp, p, t + c8*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1001*k1[i]+a1006*k6[i]+a1007*k7[i]+a1008*k8[i]+a1009*k9[i])
+  end
+  f(k10, tmp, p, t + c9*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1101*k1[i]+a1106*k6[i]+a1107*k7[i]+a1108*k8[i]+a1109*k9[i]+a1110*k10[i])
+  end
+  f(k11, tmp, p, t + c10*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1201*k1[i]+a1206*k6[i]+a1207*k7[i]+a1208*k8[i]+a1209*k9[i]+a1210*k10[i]+a1211*k11[i])
+  end
+  f(k12, tmp, p, t + c11*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1301*k1[i]+a1306*k6[i]+a1307*k7[i]+a1308*k8[i]+a1309*k9[i]+a1310*k10[i]+a1311*k11[i]+a1312*k12[i])
+  end
+  f(k13, tmp, p, t + c12*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1401*k1[i]+a1406*k6[i]+a1407*k7[i]+a1408*k8[i]+a1409*k9[i]+a1410*k10[i]+a1411*k11[i]+a1412*k12[i]+a1413*k13[i])
+  end
+  f(k14, tmp, p, t + c13*dt)
+  @tight_loop_macros for i in uidx
+    @inbounds tmp[i] = uprev[i]+dt*(a1501*k1[i]+a1506*k6[i]+a1507*k7[i]+a1508*k8[i]+a1509*k9[i]+a1510*k10[i]+a1511*k11[i]+a1512*k12[i]+a1513*k13[i]+a1514*k14[i])
+  end
+  f(k15, tmp, p, t+dt)
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i]+dt*(a1601*k1[i]+a1606*k6[i]+a1607*k7[i]+a1608*k8[i]+a1609*k9[i]+a1610*k10[i]+a1611*k11[i]+a1612*k12[i]+a1613*k13[i])
+  end
+  f(k16, u, p, t+dt)
+  if typeof(integrator.alg) <: CompositeAlgorithm
+    g16 = u
+    g15 = tmp
+    @. utilde = k16 - k15
+    ϱu = integrator.opts.internalnorm(utilde,t)
+    @. utilde = g16 - g15
+    ϱd = integrator.opts.internalnorm(utilde,t)
+    integrator.eigen_est = ϱu/ϱd
+  end
+  @tight_loop_macros for i in uidx
+    @inbounds u[i] = uprev[i] + dt*(b1*k1[i]+b8*k8[i]+b9*k9[i]+b10*k10[i]+b11*k11[i]+b12*k12[i]+b13*k13[i]+b14*k14[i]+b15*k15[i])
+  end
+  if integrator.opts.adaptive
+    @tight_loop_macros for i in uidx
+      @inbounds utilde[i] = dt*(btilde1*k1[i] + btilde8*k8[i] + btilde9*k9[i] + btilde10*k10[i] + btilde11*k11[i] + btilde12*k12[i] + btilde13*k13[i] + btilde14*k14[i] + btilde15*k15[i] + btilde16*k16[i])
+    end
+    calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
+    integrator.EEst = integrator.opts.internalnorm(atmp,t)
+  end
+
+  alg = unwrap_alg(integrator, false)
+  if !alg.lazy && (integrator.opts.adaptive == false || integrator.EEst <= 1.0)
+    k = integrator.k
+    @unpack tmp = cache
+    @unpack c17,a1701,a1708,a1709,a1710,a1711,a1712,a1713,a1714,a1715,c18,a1801,a1808,a1809,a1810,a1811,a1812,a1813,a1814,a1815,a1817,c19,a1901,a1908,a1909,a1910,a1911,a1912,a1913,a1914,a1915,a1917,a1918,c20,a2001,a2008,a2009,a2010,a2011,a2012,a2013,a2014,a2015,a2017,a2018,a2019,c21,a2101,a2108,a2109,a2110,a2111,a2112,a2113,a2114,a2115,a2117,a2118,a2119,a2120,c22,a2201,a2208,a2209,a2210,a2211,a2212,a2213,a2214,a2215,a2217,a2218,a2219,a2220,a2221,c23,a2301,a2308,a2309,a2310,a2311,a2312,a2313,a2314,a2315,a2317,a2318,a2319,a2320,a2321,c24,a2401,a2408,a2409,a2410,a2411,a2412,a2413,a2414,a2415,a2417,a2418,a2419,a2420,a2421,c25,a2501,a2508,a2509,a2510,a2511,a2512,a2513,a2514,a2515,a2517,a2518,a2519,a2520,a2521,c26,a2601,a2608,a2609,a2610,a2611,a2612,a2613,a2614,a2615,a2617,a2618,a2619,a2620,a2621 = cache.tab
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1701*k[1][i]+a1708*k[2][i]+a1709*k[3][i]+a1710*k[4][i]+a1711*k[5][i]+a1712*k[6][i]+a1713*k[7][i]+a1714*k[8][i]+a1715*k[9][i])
+    end
+    f(k[11],tmp,p,t+c17*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1801*k[1][i]+a1808*k[2][i]+a1809*k[3][i]+a1810*k[4][i]+a1811*k[5][i]+a1812*k[6][i]+a1813*k[7][i]+a1814*k[8][i]+a1815*k[9][i]+a1817*k[11][i])
+    end
+    f(k[12],tmp,p,t+c18*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a1901*k[1][i]+a1908*k[2][i]+a1909*k[3][i]+a1910*k[4][i]+a1911*k[5][i]+a1912*k[6][i]+a1913*k[7][i]+a1914*k[8][i]+a1915*k[9][i]+a1917*k[11][i]+a1918*k[12][i])
+    end
+    f(k[13],tmp,p,t+c19*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2001*k[1][i]+a2008*k[2][i]+a2009*k[3][i]+a2010*k[4][i]+a2011*k[5][i]+a2012*k[6][i]+a2013*k[7][i]+a2014*k[8][i]+a2015*k[9][i]+a2017*k[11][i]+a2018*k[12][i]+a2019*k[13][i])
+    end
+    f(k[14],tmp,p,t+c20*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2101*k[1][i]+a2108*k[2][i]+a2109*k[3][i]+a2110*k[4][i]+a2111*k[5][i]+a2112*k[6][i]+a2113*k[7][i]+a2114*k[8][i]+a2115*k[9][i]+a2117*k[11][i]+a2118*k[12][i]+a2119*k[13][i]+a2120*k[14][i])
+    end
+    f(k[15],tmp,p,t+c21*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2201*k[1][i]+a2208*k[2][i]+a2209*k[3][i]+a2210*k[4][i]+a2211*k[5][i]+a2212*k[6][i]+a2213*k[7][i]+a2214*k[8][i]+a2215*k[9][i]+a2217*k[11][i]+a2218*k[12][i]+a2219*k[13][i]+a2220*k[14][i]+a2221*k[15][i])
+    end
+    f(k[16],tmp,p,t+c22*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2301*k[1][i]+a2308*k[2][i]+a2309*k[3][i]+a2310*k[4][i]+a2311*k[5][i]+a2312*k[6][i]+a2313*k[7][i]+a2314*k[8][i]+a2315*k[9][i]+a2317*k[11][i]+a2318*k[12][i]+a2319*k[13][i]+a2320*k[14][i]+a2321*k[15][i])
+    end
+    f(k[17],tmp,p,t+c23*dt)
+    @tight_loop_macros for i in uidx
+      tmp[i]  = uprev[i]+dt*(a2401*k[1][i]+a2408*k[2][i]+a2409*k[3][i]+a2410*k[4][i]+a2411*k[5][i]+a2412*k[6][i]+a2413*k[7][i]+a2414*k[8][i]+a2415*k[9][i]+a2417*k[11][i]+a2418*k[12][i]+a2419*k[13][i]+a2420*k[14][i]+a2421*k[15][i])
+    end
+    f(k[18],tmp,p,t+c24*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2501*k[1][i]+a2508*k[2][i]+a2509*k[3][i]+a2510*k[4][i]+a2511*k[5][i]+a2512*k[6][i]+a2513*k[7][i]+a2514*k[8][i]+a2515*k[9][i]+a2517*k[11][i]+a2518*k[12][i]+a2519*k[13][i]+a2520*k[14][i]+a2521*k[15][i])
+    end
+    f(k[19],tmp,p,t+c25*dt)
+    @tight_loop_macros for i in uidx
+      @inbounds tmp[i] = uprev[i]+dt*(a2601*k[1][i]+a2608*k[2][i]+a2609*k[3][i]+a2610*k[4][i]+a2611*k[5][i]+a2612*k[6][i]+a2613*k[7][i]+a2614*k[8][i]+a2615*k[9][i]+a2617*k[11][i]+a2618*k[12][i]+a2619*k[13][i]+a2620*k[14][i]+a2621*k[15][i])
+    end
+    f(k[20],tmp,p,t+c26*dt)
+  end
 end


### PR DESCRIPTION
On

```julia
using OrdinaryDiffEq
using LinearAlgebra

const runs = 1000
const mu = 0.012277471

 struct Solver
    solver
    dense::Bool
    name::String
end

solvers = [Solver(Vern9(),
                  false,
                  "Verner9")]

function fire_ode(x0, ode, tspan, atol, rtol, method, prob)
    solve(prob, method, abstol=atol, reltol=rtol, timeseries_errors=false, dense_errors=false, dense=false)
end

struct ODETestResult
    final_state_error
    iom_error
    total_time
    ode_sol
end

function fire_ode_test(x0, ode, tspan, atol, rtol, method, final_state, iom, iom_func)
    prob = ODEProblem(ode, x0, tspan)
    local sol
    rtime = @elapsed for i in 1:runs
        sol = fire_ode(x0, ode, tspan, atol, rtol, method, prob)
    end
    serr = norm(sol[:, end] - final_state)
    iomsol = iom_func(sol)
    ierr = abs.(iomsol .- iom)
    ODETestResult(serr, ierr, rtime, sol)
end

function cr3bpeom(dX, X, p, t)
    @inbounds begin
        r1 = sqrt((X[1] + mu)^2 + X[2]^2)
        r2 = sqrt((X[1] - 1 + mu)^2 + X[2]^2)
        dX[1:3] .= @view X[4:6]
        dX[4] = X[1] + 2*X[5] - (1 - mu)*(X[1] + mu)/r1^3 - mu*(X[1] - 1 + mu)/r2^3
        dX[5] = X[2] - 2*X[4] - (1 - mu)*X[2]/r1^3 - mu*X[2]/r2^3
        dX[6] = 0.0
    end
end

R0 = [0.994, 0.0, 0.0]
V0 = [0.0, -2.00158510637908252240537862224, 0.0]
X0 = [R0; V0]

# Time period
Period = 17.0652165601579625588917206249

# propagate for bunch of orbits
t0 = 0.0
tf = 4.0*Period
tspan = (t0, tf)
atol = 1e-8
rtol = 1e-8
jacobi_constant = sum

for solver in solvers
    result = fire_ode_test(X0, cr3bpeom, tspan, atol, rtol, solver.solver, [R0; V0], 0.0, jacobi_constant)
    @show result.total_time
end
```

Before:

```julia
# Try 1
result.total_time = 7.88373016
result.total_time = 0.690975376
result.total_time = 0.653062158
result.total_time = 0.657904057

# Try 2
result.total_time = 8.464088262
result.total_time = 0.69373586
result.total_time = 0.740134611
result.total_time = 0.775099715
result.total_time = 1.0534367
```

After:

```julia
# Try 1
result.total_time = 9.589884085
result.total_time = 0.944127186
result.total_time = 0.987743862
result.total_time = 1.084214812

# Try 2
result.total_time = 9.563432788
result.total_time = 0.666600867
result.total_time = 0.656482691
result.total_time = 0.661531755
result.total_time = 0.664065026
```

This should document and quell any ideas of keeping loops around. Both compile time and runtime is faster with `@..`. @YingboMa did you ever test out Feagin to see if it could improve compile time?