### PR TITLE
Allow general stats in composite solution

### DIFF
--- a/src/composite_solution.jl
+++ b/src/composite_solution.jl
@@ -1,4 +1,4 @@
-struct ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType} <: DiffEqBase.AbstractODESolution{T,N}
+struct ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE} <: DiffEqBase.AbstractODESolution{T,N}
   u::uType
   u_analytic::uType2
   errors::EType
@@ -10,7 +10,7 @@ struct ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType} <: 
   alg_choice::Vector{Int}
   dense::Bool
   tslocation::Int
-  destats::DiffEqBase.DEStats
+  destats::DE
   retcode::Symbol
 end
 (sol::ODECompositeSolution)(t,deriv::Type=Val{0};idxs=nothing,continuity=:left) = sol.interp(t,idxs,deriv,sol.prob.p,continuity)
@@ -46,27 +46,27 @@ function DiffEqBase.build_solution(
     end
 
     sol = ODECompositeSolution{T,N,typeof(u),typeof(u_analytic),typeof(errors),typeof(t),typeof(k),
-                               typeof(prob),typeof(alg),typeof(interp)}(u,u_analytic,errors,t,k,prob,alg,interp,alg_choice,dense,0,destats,retcode)
+                               typeof(prob),typeof(alg),typeof(interp),typeof(destats)}(u,u_analytic,errors,t,k,prob,alg,interp,alg_choice,dense,0,destats,retcode)
     if calculate_error
       DiffEqBase.calculate_solution_errors!(sol;timeseries_errors=timeseries_errors,dense_errors=dense_errors)
     end
     return sol
   else
     return ODECompositeSolution{T,N,typeof(u),typeof(nothing),typeof(nothing),typeof(t),typeof(k),
-                                typeof(prob),typeof(alg),typeof(interp)}(u,nothing,nothing,t,k,prob,alg,interp,alg_choice,dense,0,destats,retcode)
+                                typeof(prob),typeof(alg),typeof(interp),typeof(destats)}(u,nothing,nothing,t,k,prob,alg,interp,alg_choice,dense,0,destats,retcode)
   end
 end
 
-function DiffEqBase.solution_new_retcode(sol::ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType},retcode) where {T,N,uType,uType2,EType,tType,rateType,P,A,IType}
-  ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType}(
+function DiffEqBase.solution_new_retcode(sol::ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE},retcode) where {T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE}
+  ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE}(
                      sol.u,sol.u_analytic,sol.errors,sol.t,sol.k,sol.prob,
                      sol.alg,sol.interp,sol.alg_choice,sol.dense,sol.tslocation,
                      sol.destats,retcode)
  end
 
  function DiffEqBase.solution_new_tslocation(sol::ODECompositeSolution{
-   T,N,uType,uType2,EType,tType,rateType,P,A,IType},tslocation) where {T,N,uType,uType2,EType,tType,rateType,P,A,IType}
-   ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType}(
+   T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE},tslocation) where {T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE}
+   ODECompositeSolution{T,N,uType,uType2,EType,tType,rateType,P,A,IType,DE}(
                       sol.u,sol.u_analytic,sol.errors,sol.t,sol.k,sol.prob,
                       sol.alg,sol.interp,sol.alg_choice,sol.dense,tslocation,
                       sol.destats,sol.retcode)


### PR DESCRIPTION
This PR removes the hard-coded DEStats restriction in ODECompositeSolution and instead allows for general stats types, in the same way as done for ODESolution etc in DiffEqBase.

This is required, e.g., in DelayDiffEq where I would like to add a separate DDEStats type that tracks the fixed-point iterations and convergence failures separately (so they do not get messed up with the non-linear solver statistics).

Maybe we could include this PR in a final OrdinaryDiffeq 5.x release, before changing the non-linear solver setup? At a quick glance none of the changes in OrdinaryDiffEq since the latest release 21 days ago seem to be breaking.