### PR TITLE
comment on nlsolvers

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -46,28 +46,14 @@ jacobian update function, then it will be called for the update. Otherwise,
 either ForwardDiff or finite difference will be used depending on the
 `jac_config` of the cache.
 """
-function calc_J(integrator, cache::OrdinaryDiffEqConstantCache, is_compos)
+function calc_J(integrator, uf, cache::OrdinaryDiffEqConstantCache, is_compos)
   @unpack t,dt,uprev,u,f,p = integrator
   if DiffEqBase.has_jac(f)
     J = f.jac(uprev, p, t)
   else
     cache.uf.t = t
     cache.uf.p = p
-    J = jacobian(cache.uf,uprev,integrator)
-  end
-  integrator.destats.njacs += 1
-  is_compos && (integrator.eigen_est = opnorm(J, Inf))
-  return J
-end
-
-function calc_J(nlsolver, integrator, cache::OrdinaryDiffEqConstantCache, is_compos)
-  @unpack t,dt,uprev,u,f,p = integrator
-  if DiffEqBase.has_jac(f)
-    J = f.jac(uprev, p, t)
-  else
-    nlsolver.uf.t = t
-    nlsolver.uf.p = p
-    J = jacobian(nlsolver.uf,uprev,integrator)
+    J = jacobian(uf,uprev,integrator)
   end
   integrator.destats.njacs += 1
   is_compos && (integrator.eigen_est = opnorm(J, Inf))
@@ -403,73 +389,22 @@ function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_
   new_W = true
   if (f isa ODEFunction && islinear(f.f)) || (integrator.alg isa SplitAlgorithms && f isa SplitFunction && islinear(f.f1.f))
     new_jac = false
-    @goto J2W # Jump to W calculation directly, because we already have J
+    new_W = false
+    # But we never do a first solve
+  else
+    # check if we need to update J or W
+    W_dt = isnewton ? cache.nlsolver.cache.W_dt : dt # TODO: RosW
+    new_jac = isnewton ? do_newJ(integrator, alg, cache, repeat_step) : true
+    new_W = isnewton ? do_newW(integrator, cache.nlsolver, new_jac, W_dt) : true
   end
 
-  # check if we need to update J or W
-  W_dt = isnewton ? cache.nlsolver.cache.W_dt : dt # TODO: RosW
-  new_jac = isnewton ? do_newJ(integrator, alg, cache, repeat_step) : true
-  new_W = isnewton ? do_newW(integrator, cache.nlsolver, new_jac, W_dt) : true
-
   # calculate W
-  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing && !ArrayInterface.isstructured(f.jac_prototype)
-    isnewton || DiffEqBase.update_coefficients!(W,uprev,p,t) # we will call `update_coefficients!` in NLNewton
-    @label J2W
+  if W isa WOperator
+    !isnewton && new_jac && DiffEqBase.update_coefficients!(W,uprev,p,t) # we will call `update_coefficients!` in NLNewton
     W.transform = W_transform; set_gamma!(W, dtgamma)
   else # concrete W using jacobian from `calc_J!`
     new_jac && calc_J!(integrator, cache, is_compos)
     new_W && jacobian2W!(W, mass_matrix, dtgamma, J, W_transform)
-  end
-  if isnewton
-    set_new_W!(cache.nlsolver, new_W) && DiffEqBase.set_W_dt!(cache.nlsolver, dt)
-  end
-  new_W && (integrator.destats.nw += 1)
-  return nothing
-end
-
-function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, W_index::Int, W_transform=false)
-  @unpack t,dt,uprev,u,f,p = integrator
-  @unpack J,W = cache
-  alg = unwrap_alg(integrator, true)
-  mass_matrix = integrator.f.mass_matrix
-  is_compos = integrator.alg isa CompositeAlgorithm
-  isnewton = alg isa NewtonAlgorithm
-
-  if W_transform && DiffEqBase.has_Wfact_t(f)
-    f.Wfact_t(W[W_index], u, p, dtgamma, t)
-    is_compos && (integrator.eigen_est = opnorm(LowerTriangular(W[W_index]), Inf) + inv(dtgamma)) # TODO: better estimate
-    return nothing
-  elseif !W_transform && DiffEqBase.has_Wfact(f)
-    f.Wfact(W[W_index], u, p, dtgamma, t)
-    if is_compos
-      opn = opnorm(LowerTriangular(W[W_index]), Inf)
-      integrator.eigen_est = (opn + one(opn)) / dtgamma # TODO: better estimate
-    end
-    return nothing
-  end
-
-  # fast pass
-  # we only want to factorize the linear operator once
-  new_jac = true
-  new_W = true
-  if (f isa ODEFunction && islinear(f.f)) || (integrator.alg isa SplitAlgorithms && f isa SplitFunction && islinear(f.f1.f))
-    new_jac = false
-    @goto J2W # Jump to W calculation directly, because we already have J
-  end
-
-  # check if we need to update J or W
-  W_dt = isnewton ? cache.nlsolver.cache.W_dt : dt # TODO: RosW
-  new_jac = isnewton ? do_newJ(integrator, alg, cache, repeat_step) : true
-  new_W = isnewton ? do_newW(integrator, cache.nlsolver, new_jac, W_dt) : true
-
-  # calculate W
-  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing && !ArrayInterface.isstructured(f.jac_prototype)
-    isnewton || DiffEqBase.update_coefficients!(W[W_index],uprev,p,t) # we will call `update_coefficients!` in NLNewton
-    @label J2W
-    W[W_index].transform = W_transform; set_gamma!(W[W_index], dtgamma)
-  else # concrete W using jacobian from `calc_J!`
-    new_jac && calc_J!(integrator, cache, is_compos)
-    new_W && jacobian2W!(W[W_index], mass_matrix, dtgamma, J, W_transform)
   end
   if isnewton
     set_new_W!(cache.nlsolver, new_W) && DiffEqBase.set_W_dt!(cache.nlsolver, dt)
@@ -524,6 +459,57 @@ function calc_W!(nlsolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamm
   end
   if isnewton
     set_new_W!(nlsolver, new_W) && DiffEqBase.set_W_dt!(nlsolver, dt)
+  end
+  new_W && (integrator.destats.nw += 1)
+  return nothing
+end
+
+function calc_W!(integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, W_index::Int, W_transform=false)
+  @unpack t,dt,uprev,u,f,p = integrator
+  @unpack J,W = cache
+  alg = unwrap_alg(integrator, true)
+  mass_matrix = integrator.f.mass_matrix
+  is_compos = integrator.alg isa CompositeAlgorithm
+  isnewton = alg isa NewtonAlgorithm
+
+  if W_transform && DiffEqBase.has_Wfact_t(f)
+    f.Wfact_t(W[W_index], u, p, dtgamma, t)
+    is_compos && (integrator.eigen_est = opnorm(LowerTriangular(W[W_index]), Inf) + inv(dtgamma)) # TODO: better estimate
+    return nothing
+  elseif !W_transform && DiffEqBase.has_Wfact(f)
+    f.Wfact(W[W_index], u, p, dtgamma, t)
+    if is_compos
+      opn = opnorm(LowerTriangular(W[W_index]), Inf)
+      integrator.eigen_est = (opn + one(opn)) / dtgamma # TODO: better estimate
+    end
+    return nothing
+  end
+
+  # fast pass
+  # we only want to factorize the linear operator once
+  new_jac = true
+  new_W = true
+  if (f isa ODEFunction && islinear(f.f)) || (integrator.alg isa SplitAlgorithms && f isa SplitFunction && islinear(f.f1.f))
+    new_jac = false
+    @goto J2W # Jump to W calculation directly, because we already have J
+  end
+
+  # check if we need to update J or W
+  W_dt = isnewton ? cache.nlsolver.cache.W_dt : dt # TODO: RosW
+  new_jac = isnewton ? do_newJ(integrator, alg, cache, repeat_step) : true
+  new_W = isnewton ? do_newW(integrator, cache.nlsolver, new_jac, W_dt) : true
+
+  # calculate W
+  if DiffEqBase.has_jac(f) && f.jac_prototype !== nothing && !ArrayInterface.isstructured(f.jac_prototype)
+    isnewton || DiffEqBase.update_coefficients!(W[W_index],uprev,p,t) # we will call `update_coefficients!` in NLNewton
+    @label J2W
+    W[W_index].transform = W_transform; set_gamma!(W[W_index], dtgamma)
+  else # concrete W using jacobian from `calc_J!`
+    new_jac && calc_J!(integrator, cache, is_compos)
+    new_W && jacobian2W!(W[W_index], mass_matrix, dtgamma, J, W_transform)
+  end
+  if isnewton
+    set_new_W!(cache.nlsolver, new_W) && DiffEqBase.set_W_dt!(cache.nlsolver, dt)
   end
   new_W && (integrator.destats.nw += 1)
   return nothing


### PR DESCRIPTION
This is essentially a comment on the nlsolvers and what needs to be done. This kind of stuff should get merged into https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/912 . Generally, there is absolutely no reason to have separate branches of everything for nlsolving vs everything else: it's a ridiculous amount of code duplication that is fixed by just passing in one value in almost every single function. 

Also, the linearity handling is messed up: it should just use the fact that matrix-free operators are a `WOperator`, and know that there is another form of linearity where things are arrays. Currently it always assumes linear means `WOperator`. The go-to statements are then unnecessary.

However, when dealing with linearity, the first Jacobian update never occurs, so it needs to be tracked so that way it's done in iteration 1.