### PR TITLE
Correctly recognize failed nonlinear solves

### DIFF
--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -1,7 +1,7 @@
 get_status(nlsolver::AbstractNLSolver) = nlsolver.status
 
 nlsolvefail(nlsolver::AbstractNLSolver) = nlsolvefail(get_status(nlsolver))
-nlsolvefail(status::NLStatus) = Int8(status) < 0
+nlsolvefail(status::NLStatus) = Int8(status) <= 0
 
 isnewton(nlsolver::AbstractNLSolver) = isnewton(nlsolver.cache)
 isnewton(::AbstractNLSolverCache) = false
@@ -101,7 +101,8 @@ function build_nlsolver(alg,nlalg::Union{NLFunctional,NLAnderson,NLNewton},u,upr
 
   NLSolver{typeof(nlalg),true,typeof(u),uTolType,tTypeNoUnits,typeof(nlcache)}(
     z,tmp,ztmp,uTolType(γ),tTypeNoUnits(c),nlalg,uTolType(nlalg.κ),
-    uTolType(nlalg.fast_convergence_cutoff),ηold,10_000,nlalg.max_iter,Convergence,nlcache)
+    uTolType(nlalg.fast_convergence_cutoff),ηold,10_000,nlalg.max_iter,SlowConvergence,
+    nlcache)
 end
 
 function build_nlsolver(alg,nlalg::Union{NLFunctional,NLAnderson,NLNewton},u,uprev,p,t,dt,
@@ -147,7 +148,8 @@ function build_nlsolver(alg,nlalg::Union{NLFunctional,NLAnderson,NLNewton},u,upr
 
   NLSolver{typeof(nlalg),false,typeof(u),uTolType,tTypeNoUnits,typeof(nlcache)}(
     z,tmp,ztmp,uTolType(γ),tTypeNoUnits(c),nlalg,uTolType(nlalg.κ),
-    uTolType(nlalg.fast_convergence_cutoff),ηold,10_000,nlalg.max_iter,Convergence,nlcache)
+    uTolType(nlalg.fast_convergence_cutoff),ηold,10_000,nlalg.max_iter,SlowConvergence,
+    nlcache)
 end
 
 ## Anderson acceleration


### PR DESCRIPTION
This PR fixes a possible issue of the current implementation in which `nlsolvefail(nlsolver) = false` might occur even if `fail_convergence = true`, since `nlsolver.status` was only set in case of convergence, divergence, and very slow convergence but kept unchanged if the maximum number of iterations was exceeded.

In my tests with the Jacobian and mass matrix tests (see https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/920#issue-314477109), the errors and statistics are not affected by these changes. This change might lead to a early exit of `perform_step!` now (as intended), but that would not be captured by these simple tests. For other problems and algorithms it might even change the statistics and number of accepted/rejected steps.