### PR TITLE
Single Broadcast Loop in Low Storage 2N methods

### DIFF
--- a/src/caches/low_storage_rk_caches.jl
+++ b/src/caches/low_storage_rk_caches.jl
@@ -42,6 +42,7 @@ function ORK256ConstantCache(T, T2)
 end
 
 function alg_cache(alg::ORK256,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = ORK256ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -51,13 +52,12 @@ function alg_cache(alg::ORK256,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = ORK256ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -90,6 +90,7 @@ function CarpenterKennedy2N54ConstantCache(T, T2)
 end
 
 function alg_cache(alg::CarpenterKennedy2N54,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = CarpenterKennedy2N54ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -99,13 +100,12 @@ function alg_cache(alg::CarpenterKennedy2N54,u,rate_prototype,uEltypeNoUnits,uBo
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = CarpenterKennedy2N54ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -142,6 +142,7 @@ function HSLDDRK64ConstantCache(T, T2)
 end
 
 function alg_cache(alg::HSLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = HSLDDRK64ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -151,13 +152,12 @@ function alg_cache(alg::HSLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = HSLDDRK64ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -196,6 +196,7 @@ function DGLDDRK73_CConstantCache(T, T2)
 end
 
 function alg_cache(alg::DGLDDRK73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = DGLDDRK73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -205,13 +206,12 @@ function alg_cache(alg::DGLDDRK73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = DGLDDRK73_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -253,6 +253,7 @@ function DGLDDRK84_CConstantCache(T, T2)
 end
 
 function alg_cache(alg::DGLDDRK84_C,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = DGLDDRK84_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -262,13 +263,12 @@ function alg_cache(alg::DGLDDRK84_C,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = DGLDDRK84_CConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -310,6 +310,7 @@ function DGLDDRK84_FConstantCache(T, T2)
 end
 
 function alg_cache(alg::DGLDDRK84_F,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = DGLDDRK84_FConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -319,13 +320,12 @@ function alg_cache(alg::DGLDDRK84_F,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = DGLDDRK84_FConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -379,6 +379,7 @@ function NDBLSRK124ConstantCache(T, T2)
 end
 
 function alg_cache(alg::NDBLSRK124,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = NDBLSRK124ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -388,13 +389,12 @@ function alg_cache(alg::NDBLSRK124,u,rate_prototype,uEltypeNoUnits,uBottomEltype
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = NDBLSRK124ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -451,6 +451,7 @@ function NDBLSRK134ConstantCache(T, T2)
 end
 
 function alg_cache(alg::NDBLSRK134,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = NDBLSRK134ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -460,13 +461,12 @@ function alg_cache(alg::NDBLSRK134,u,rate_prototype,uEltypeNoUnits,uBottomEltype
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = NDBLSRK134ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 
@@ -526,6 +526,7 @@ function NDBLSRK144ConstantCache(T, T2)
 end
 
 function alg_cache(alg::NDBLSRK144,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  tab = NDBLSRK144ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   tmp = zero(u)
   williamson_condition = alg.williamson_condition
   if calck
@@ -535,13 +536,12 @@ function alg_cache(alg::NDBLSRK144,u,rate_prototype,uEltypeNoUnits,uBottomEltype
   else
     if williamson_condition
       k = tmp
-      wrapper = WilliamsonWrapper(tmp, dt)
+      wrapper = WilliamsonWrapper(tmp, dt, tab.A2end[1])
     else
       k = zero(rate_prototype)
       wrapper = nothing
     end
   end
-  tab = NDBLSRK144ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   LowStorageRK2NCache(u,uprev,k,tmp,tab,wrapper,williamson_condition)
 end
 

--- a/src/perform_step/low_storage_rk_perform_step.jl
+++ b/src/perform_step/low_storage_rk_perform_step.jl
@@ -60,10 +60,11 @@ end
   end
   # other stages
   for i in eachindex(A2end)
-    @.. tmp = A2end[i]*tmp
     if williamson_condition
+      wrapper.coefficient = A2end[i]
       f(wrapper, u, p, t+c2end[i]*dt)
     else
+      @.. tmp = A2end[i]*tmp
       f(k, u, p, t+c2end[i]*dt)
       @.. tmp += dt * k
     end
@@ -76,14 +77,15 @@ end
   integrator.destats.nf += 1
 end
 
-mutable struct WilliamsonWrapper{kType, dtType}
+mutable struct WilliamsonWrapper{kType, dtType, coffType}
   kref::kType
   dt::dtType
+  coefficient::coffType
 end
 
-@inline Base.setindex!(a::WilliamsonWrapper{kType, dtType}, b::bType, c::cType) where {kType, dtType, bType, cType} = (a.kref[c] += a.dt * b)
+@inline Base.setindex!(a::WilliamsonWrapper{kType, dtType}, b::bType, c::cType) where {kType, dtType, bType, cType} = (a.kref[c] = a.coefficient * a.kref[c] + a.dt * b)
 @inline Base.size(a::WilliamsonWrapper{kType, dtType}) where {kType, dtType} = size(a.kref)
-@inline Base.copyto!(a::WilliamsonWrapper{kType, dtType}, b::bType) where {kType, dtType, bType} = @.. a.kref += a.dt * b
+@inline Base.copyto!(a::WilliamsonWrapper{kType, dtType}, b::bType) where {kType, dtType, bType} = @.. a.kref = a.coefficient * a.kref + a.dt * b
 
 # 2C low storage methods
 function initialize!(integrator,cache::LowStorageRK2CConstantCache)

--- a/src/perform_step/low_storage_rk_perform_step.jl
+++ b/src/perform_step/low_storage_rk_perform_step.jl
@@ -83,9 +83,9 @@ mutable struct WilliamsonWrapper{kType, dtType, coffType}
   coefficient::coffType
 end
 
-@inline Base.setindex!(a::WilliamsonWrapper{kType, dtType}, b::bType, c::cType) where {kType, dtType, bType, cType} = (a.kref[c] = a.coefficient * a.kref[c] + a.dt * b)
-@inline Base.size(a::WilliamsonWrapper{kType, dtType}) where {kType, dtType} = size(a.kref)
-@inline Base.copyto!(a::WilliamsonWrapper{kType, dtType}, b::bType) where {kType, dtType, bType} = @.. a.kref = a.coefficient * a.kref + a.dt * b
+@inline Base.setindex!(a::WilliamsonWrapper, b, c) = (a.kref[c] = a.coefficient * a.kref[c] + a.dt * b)
+@inline Base.size(a::WilliamsonWrapper) = size(a.kref)
+@inline Base.copyto!(a::WilliamsonWrapper, b) = @.. a.kref = a.coefficient * a.kref + a.dt * b
 
 # 2C low storage methods
 function initialize!(integrator,cache::LowStorageRK2CConstantCache)


### PR DESCRIPTION
In the loop inside each time step, broadcast calls are reduced to one.

Issue: Stricter limitation on function `f`, for every index of `u`, it needs exactly one `setindex!` call i.e setting `du[i]` only once.