### PR TITLE
Pass LogLevel(-1) to at-logmsg rather than a bare Int

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -129,7 +129,7 @@ function _postamble!(integrator)
     resize!(integrator.sol.k,integrator.saveiter_dense)
   end
   if integrator.opts.progress
-    @logmsg(-1,
+    @logmsg(LogLevel(-1),
     integrator.opts.progress_name,
     _id = :OrdinaryDiffEq,
     message=integrator.opts.progress_message(integrator.dt,integrator.u,integrator.p,integrator.t),
@@ -220,7 +220,7 @@ function _loopfooter!(integrator)
     handle_callbacks!(integrator)
   end
   if integrator.opts.progress && integrator.iter%integrator.opts.progress_steps==0
-    @logmsg(-1,
+    @logmsg(LogLevel(-1),
     integrator.opts.progress_name,
     _id = :OrdinaryDiffEq,
     message=integrator.opts.progress_message(integrator.dt,integrator.u,integrator.p,integrator.t),

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -86,7 +86,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     @warn("Dense output is incompatible with saveat. Please use the SavingCallback from the Callback Library to mix the two behaviors.")
   end
 
-  progress && @logmsg(-1,progress_name,_id=_id = :OrdinaryDiffEq,progress=0)
+  progress && @logmsg(LogLevel(-1),progress_name,_id=_id = :OrdinaryDiffEq,progress=0)
 
   tType = eltype(prob.tspan)
   tspan = prob.tspan


### PR DESCRIPTION
solves https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/510

You can get progress output via the terminal logger like this with this patch

```
julia> ENV["JULIA_DEBUG"] = "OrdinaryDiffEq"
"OrdinaryDiffEq"

julia> solve(ODEProblem((u,p,t)->u,1.0,nothing), Tsit5(); tspan=(0.0, 1.0), progress=true)
┌ LogLevel(-1): ODE
│   progress = 0
└ @ OrdinaryDiffEq ~/.julia/dev/OrdinaryDiffEq/src/solve.jl:89
┌ LogLevel(-1): ODE
│   message = "dt=0.31694741205307064\nt=1.0\nmax u=2.7182817087739934"
│   progress = "done"
└ @ OrdinaryDiffEq ~/.julia/dev/OrdinaryDiffEq/src/integrators/integrator_utils.jl:132
retcode: Success
Interpolation: specialized 4th order "free" interpolation
t: 5-element Array{Float64,1}:
 0.0
 0.10001999200479662
 0.3480207301142381
 0.6830525879469294
 1.0
u: 5-element Array{Float64,1}:
 1.0
 1.105193012902056
 1.4162616068141611
 1.9799123187558105
 2.7182817087739934
```