### PR TITLE
Fix undefined variable in test

### DIFF
--- a/test/integrators/ode_cache_tests.jl
+++ b/test/integrators/ode_cache_tests.jl
@@ -82,7 +82,7 @@ function f2(du,u,p,t)
     if t > 10
       du[i] = -10000*u[i]
     else
-      du[i] = α*u[i]
+      du[i] = 0.3*u[i]
     end
   end
   return du


### PR DESCRIPTION
This PR specifies an undefined variable that was not copied from https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/965. Should fix current test errors (see, e.g., https://travis-ci.org/JuliaDiffEq/OrdinaryDiffEq.jl/jobs/613599420).