### PR TITLE
some inbounds and common interpolation performance improvements

### DIFF
--- a/src/dense/interpolants.jl
+++ b/src/dense/interpolants.jl
@@ -16,9 +16,14 @@ Hairer Norsett Wanner Solving Ordinary Differential Euations I - Nonstiff Proble
   b40 = @evalpoly(Θ, 0, 0, 1, -2, 1)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::DP5ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @dp5pre0
-  @.. y₀ + dt*(k[1]*b10 + k[2]*b20 + k[3]*b30 + k[4]*b40)
+  @inbounds y₀ + dt*(k[1]*b10 + k[2]*b20 + k[3]*b30 + k[4]*b40)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::DP5Cache,idxs::Nothing,T::Type{Val{0}})
+  @dp5pre0
+  @inbounds @.. y₀ + dt*(k[1]*b10 + k[2]*b20 + k[3]*b30 + k[4]*b40)
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs,T::Type{Val{0}})
@@ -28,7 +33,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP5Cache,idxs::Nothing,T::Type{Val{0}})
   @dp5pre0
-  @.. out = y₀ + dt*(k[1]*b10 + k[2]*b20 + k[3]*b30 + k[4]*b40)
+  @inbounds @.. out = y₀ + dt*(k[1]*b10 + k[2]*b20 + k[3]*b30 + k[4]*b40)
   out
 end
 
@@ -46,7 +51,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs::Nothing,T::Type{Val{1}})
   @dp5pre1
-  @.. k[1] + k[2]*b20diff + k[3]*b30diff + k[4]*b40diff
+  @inbounds @.. k[1] + k[2]*b20diff + k[3]*b30diff + k[4]*b40diff
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs,T::Type{Val{1}})
@@ -56,7 +61,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP5Cache,idxs::Nothing,T::Type{Val{1}})
   @dp5pre1
-  @.. out = k[1] + k[2]*b20diff + k[3]*b30diff + k[4]*b40diff
+  @inbounds @.. out = k[1] + k[2]*b20diff + k[3]*b30diff + k[4]*b40diff
   out
 end
 
@@ -75,7 +80,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs::Nothing,T::Type{Val{2}})
   @dp5pre2
-  @.. (k[2]*b20diff2 + k[3]*b30diff2 + k[4]*b40diff2)*invdt
+  @inbounds @.. (k[2]*b20diff2 + k[3]*b30diff2 + k[4]*b40diff2)*invdt
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs,T::Type{Val{2}})
@@ -85,7 +90,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP5Cache,idxs::Nothing,T::Type{Val{2}})
   @dp5pre2
-  @.. out = (k[2]*b20diff2 + k[3]*b30diff2 + k[4]*b40diff2)*invdt
+  @inbounds @.. out = (k[2]*b20diff2 + k[3]*b30diff2 + k[4]*b40diff2)*invdt
   out
 end
 
@@ -103,7 +108,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs::Nothing,T::Type{Val{3}})
   @dp5pre3
-  @.. (k[3]*b30diff3 + k[4]*b40diff3)*invdt2
+  @inbounds @.. (k[3]*b30diff3 + k[4]*b40diff3)*invdt2
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs,T::Type{Val{3}})
@@ -113,7 +118,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP5Cache,idxs::Nothing,T::Type{Val{3}})
   @dp5pre3
-  @.. out = (k[3]*b30diff3 + k[4]*b40diff3)*invdt2
+  @inbounds @.. out = (k[3]*b30diff3 + k[4]*b40diff3)*invdt2
   out
 end
 
@@ -129,7 +134,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs::Nothing,T::Type{Val{4}})
   @dp5pre4
-  @.. k[4]*b40diff4invdt3
+  @inbounds @.. k[4]*b40diff4invdt3
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP5ConstantCache,DP5Cache},idxs,T::Type{Val{4}})
@@ -139,7 +144,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP5Cache,idxs::Nothing,T::Type{Val{4}})
   @dp5pre4
-  @.. out = k[4]*b40diff4invdt3
+  @inbounds @.. out = k[4]*b40diff4invdt3
   out
 end
 
@@ -162,7 +167,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK22Cache,SSPRK33ConstantCache,SSPRK33Cache,SSPRK432ConstantCache,SSPRK432Cache},idxs::Nothing,T::Type{Val{0}})
   @ssprkpre0
-  @.. y₀*c00 + y₁*c10 + k[1]*b10dt
+  @inbounds @.. y₀*c00 + y₁*c10 + k[1]*b10dt
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK22Cache,SSPRK33ConstantCache,SSPRK33Cache,SSPRK432ConstantCache,SSPRK432Cache},idxs,T::Type{Val{0}})
@@ -172,7 +177,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{SSPRK22Cache,SSPRK33Cache,SSPRK432Cache},idxs::Nothing,T::Type{Val{0}})
   @ssprkpre0
-  @.. out = y₀*c00 + y₁*c10 + k[1]*b10dt
+  @inbounds @.. out = y₀*c00 + y₁*c10 + k[1]*b10dt
   out
 end
 
@@ -189,7 +194,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK22Cache,SSPRK33ConstantCache,SSPRK33Cache,SSPRK432ConstantCache,SSPRK432Cache},idxs::Nothing,T::Type{Val{1}})
   @ssprkpre1
-  @.. (y₁ - y₀)*c10diffinvdt + k[1]*b10diff
+  @inbounds @.. (y₁ - y₀)*c10diffinvdt + k[1]*b10diff
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK22Cache,SSPRK33ConstantCache,SSPRK33Cache,SSPRK432ConstantCache,SSPRK432Cache},idxs,T::Type{Val{1}})
@@ -199,7 +204,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{SSPRK22Cache,SSPRK33Cache,SSPRK432Cache},idxs::Nothing,T::Type{Val{1}})
   @ssprkpre1
-  @.. out = (y₁ - y₀)*c10diffinvdt + k[1]*b10diff
+  @inbounds @.. out = (y₁ - y₀)*c10diffinvdt + k[1]*b10diff
   out
 end
 
@@ -217,7 +222,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK22Cache,SSPRK33ConstantCache,SSPRK33Cache,SSPRK432ConstantCache,SSPRK432Cache},idxs::Nothing,T::Type{Val{2}})
   @ssprkpre2
-  @.. (y₁ - y₀)*c10diff2invdt2 + k[1]*b10diff2invdt
+  @inbounds @.. (y₁ - y₀)*c10diff2invdt2 + k[1]*b10diff2invdt
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{SSPRK22ConstantCache,SSPRK22Cache,SSPRK33ConstantCache,SSPRK33Cache,SSPRK432ConstantCache,SSPRK432Cache},idxs,T::Type{Val{2}})
@@ -227,7 +232,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Union{SSPRK22Cache,SSPRK33Cache,SSPRK432Cache},idxs::Nothing,T::Type{Val{2}})
   @ssprkpre2
-  @.. out = (y₁ - y₀)*c10diff2invdt2 + k[1]*b10diff2invdt
+  @inbounds @.. out = (y₁ - y₀)*c10diff2invdt2 + k[1]*b10diff2invdt
   out
 end
 
@@ -262,10 +267,16 @@ end
   b7Θ = @evalpoly(Θ, 0,   0, r72, r73, r74)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Tsit5ConstantCache,Tsit5Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Tsit5ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @tsit5pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
-  return y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ +
+  return @inbounds y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ +
+                  k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{0}})
+  @tsit5pre0
+  return @inbounds @.. y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ +
                   k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
 end
 
@@ -277,7 +288,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{0}})
   @tsit5pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ)
   #@inbounds for i in eachindex(out)
   #  out[i] = y₀[i] + dt*(k[1][i]*b1Θ + k[2][i]*b2Θ + k[3][i]*b3Θ + k[4][i]*b4Θ + k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ)
   #end
@@ -304,11 +315,16 @@ end
   b7Θdiff = @evalpoly(Θ,   0, 2*r72, 3*r73, 4*r74)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Tsit5ConstantCache,Tsit5Cache},idxs::Nothing,T::Type{Val{1}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Tsit5ConstantCache,idxs::Nothing,T::Type{Val{1}})
   @tsit5pre1
   # return @.. k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
-  return k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff +
+  return @inbounds k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff +
     k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{1}})
+  @tsit5pre1
+  return @inbounds @.. k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Tsit5ConstantCache,Tsit5Cache},idxs,T::Type{Val{1}})
@@ -321,7 +337,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{1}})
   @tsit5pre1
-  @.. out = k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff
   #@inbounds for i in eachindex(out)
   #  out[i] = k[1][i]*b1Θdiff + k[2][i]*b2Θdiff + k[3][i]*b3Θdiff + k[4][i]*b4Θdiff + k[5][i]*b5Θdiff + k[6][i]*b6Θdiff + k[7][i]*b7Θdiff
   #end
@@ -352,7 +368,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Tsit5ConstantCache,Tsit5Cache},idxs::Nothing,T::Type{Val{2}})
   @tsit5pre2
   # return @.. k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 + k[6]*b6Θdiff2 + k[7]*b7Θdiff2
-  return (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 +
+  return @inbounds (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 +
           k[5]*b5Θdiff2 + k[6]*b6Θdiff2 + k[7]*b7Θdiff2)*invdt
 end
 
@@ -366,7 +382,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{2}})
   @tsit5pre2
-  @.. out = (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 + k[6]*b6Θdiff2 + k[7]*b7Θdiff2)*invdt
+  @inbounds @.. out = (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 + k[6]*b6Θdiff2 + k[7]*b7Θdiff2)*invdt
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff2 + k[2][i]*b2Θdiff2 + k[3][i]*b3Θdiff2 + k[4][i]*b4Θdiff2 + k[5][i]*b5Θdiff2 + k[6][i]*b6Θdiff2 + k[7][i]*b7Θdiff2)*invdt
   #end
@@ -397,7 +413,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Tsit5ConstantCache,Tsit5Cache},idxs::Nothing,T::Type{Val{3}})
   @tsit5pre3
   # return @.. k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3 + k[7]*b7Θdiff3
-  return (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 +
+  return @inbounds (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 +
           k[5]*b5Θdiff3 + k[6]*b6Θdiff3 + k[7]*b7Θdiff3)*invdt2
 end
 
@@ -411,7 +427,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{3}})
   @tsit5pre3
-  @.. out = (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3 + k[7]*b7Θdiff3)*invdt2
+  @inbounds @.. out = (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3 + k[7]*b7Θdiff3)*invdt2
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff3 + k[2][i]*b2Θdiff3 + k[3][i]*b3Θdiff3 + k[4][i]*b4Θdiff3 + k[5][i]*b5Θdiff3 + k[6][i]*b6Θdiff3 + k[7][i]*b7Θdiff3)*invdt2
   #end
@@ -442,7 +458,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Tsit5ConstantCache,Tsit5Cache},idxs::Nothing,T::Type{Val{4}})
   @tsit5pre4
   # return @.. k[1]*b1Θdiff4 + k[2]*b2Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 + k[6]*b6Θdiff4 + k[7]*b7Θdiff4
-  return (k[1]*b1Θdiff4 + k[2]*b2Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 +
+  return @inbounds (k[1]*b1Θdiff4 + k[2]*b2Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 +
           k[5]*b5Θdiff4 + k[6]*b6Θdiff4 + k[7]*b7Θdiff4)*invdt3
 end
 
@@ -456,7 +472,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Tsit5Cache,idxs::Nothing,T::Type{Val{4}})
   @tsit5pre4
-  @.. out = (k[1]*b1Θdiff4 + k[2]*b2Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 + k[6]*b6Θdiff4 + k[7]*b7Θdiff4)*invdt3
+  @inbounds @.. out = (k[1]*b1Θdiff4 + k[2]*b2Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 + k[6]*b6Θdiff4 + k[7]*b7Θdiff4)*invdt3
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff4 + k[2][i]*b2Θdiff4 + k[3][i]*b3Θdiff4 + k[4][i]*b4Θdiff4 + k[5][i]*b5Θdiff4 + k[6][i]*b6Θdiff4 + k[7][i]*b7Θdiff4)*invdt3
   #end
@@ -493,7 +509,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs::Nothing,T::Type{Val{0}})
   @owrenzen3pre0
-  @.. y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
+  @inbounds @.. y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs,T::Type{Val{0}})
@@ -504,7 +520,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen3Cache,idxs::Nothing,T::Type{Val{0}})
   @owrenzen3pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ  + k[2]*b2Θ + k[3]*b3Θ + k[4]*b4Θ)
   out
 end
 
@@ -524,7 +540,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs::Nothing,T::Type{Val{1}})
   @owrenzen3pre1
-  @.. k[1]*b1Θdiff  + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff
+  @inbounds @.. k[1]*b1Θdiff  + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs,T::Type{Val{1}})
@@ -534,7 +550,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen3Cache,idxs::Nothing,T::Type{Val{1}})
   @owrenzen3pre1
-  @.. out = k[1]*b1Θdiff  + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff  + k[2]*b2Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff
   out
 end
 
@@ -555,7 +571,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs::Nothing,T::Type{Val{2}})
   @owrenzen3pre2
-  @.. (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2)*invdt
+  @inbounds @.. (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2)*invdt
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs,T::Type{Val{2}})
@@ -565,7 +581,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen3Cache,idxs::Nothing,T::Type{Val{2}})
   @owrenzen3pre2
-  @.. out = (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2)*invdt
+  @inbounds @.. out = (k[1]*b1Θdiff2 + k[2]*b2Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2)*invdt
   out
 end
 
@@ -586,7 +602,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs::Nothing,T::Type{Val{3}})
   @owrenzen3pre3
-  @.. (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3)*invdt2
+  @inbounds @.. (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3)*invdt2
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen3ConstantCache,OwrenZen3Cache},idxs,T::Type{Val{3}})
@@ -596,7 +612,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen3Cache,idxs::Nothing,T::Type{Val{3}})
   @owrenzen3pre3
-  @.. out = (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3)*invdt2
+  @inbounds @.. out = (k[1]*b1Θdiff3 + k[2]*b2Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3)*invdt2
   out
 end
 
@@ -629,7 +645,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen4ConstantCache,OwrenZen4Cache},idxs::Nothing,T::Type{Val{0}})
   @owrenzen4pre0
   # return @.. y₀ + dt*(k[1]*b1Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
-  return y₀ + dt*(k[1]*b1Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
+  return @inbounds y₀ + dt*(k[1]*b1Θ + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen4ConstantCache,OwrenZen4Cache},idxs,T::Type{Val{0}})
@@ -642,7 +658,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen4Cache,idxs::Nothing,T::Type{Val{0}})
   @owrenzen4pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ)
   #@inbounds for i in eachindex(out)
   #  out[i] = y₀[i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ +
   #                       k[5][i]*b5Θ + k[6][i]*b6Θ)
@@ -652,7 +668,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen4Cache,idxs,T::Type{Val{0}})
   @owrenzen4pre0
-  @.. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
+  @inbounds @.. out = y₀[idxs] + dt*(k[1][idxs]*b1Θ  + k[3][idxs]*b3Θ +
                            k[4][idxs]*b4Θ + k[5][idxs]*b5Θ + k[6][idxs]*b6Θ)
   #@inbounds for (j,i) in enumerate(idxs)
   #  out[j] = y₀[i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ +
@@ -672,7 +688,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen4ConstantCache,OwrenZen4Cache},idxs::Nothing,T::Type{Val{1}})
   @owrenzen4pre1
-  @.. k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff
+  @inbounds @.. k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen4ConstantCache,OwrenZen4Cache},idxs,T::Type{Val{1}})
@@ -683,7 +699,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen4Cache,idxs::Nothing,T::Type{Val{1}})
   @owrenzen4pre1
-  @.. out = k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff
   out
 end
 
@@ -717,7 +733,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen4Cache,idxs::Nothing,T::Type{Val{2}})
   @owrenzen4pre2
-  @.. out = (k[1]*b1Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 + k[6]*b6Θdiff2)*invdt
+  @inbounds @.. out = (k[1]*b1Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 + k[6]*b6Θdiff2)*invdt
   out
 end
 
@@ -740,7 +756,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen4ConstantCache,OwrenZen4Cache},idxs::Nothing,T::Type{Val{3}})
   @owrenzen4pre3
-  @.. (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3)*invdt2
+  @inbounds @.. (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3)*invdt2
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen4ConstantCache,OwrenZen4Cache},idxs,T::Type{Val{3}})
@@ -751,7 +767,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen4Cache,idxs::Nothing,T::Type{Val{3}})
   @owrenzen4pre3
-  @.. out = (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3)*invdt2
+  @inbounds @.. out = (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 + k[6]*b6Θdiff3)*invdt2
   out
 end
 
@@ -785,7 +801,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen4Cache,idxs::Nothing,T::Type{Val{4}})
   @owrenzen4pre4
-  @.. out = (k[1]*b1Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 + k[6]*b6Θdiff4)*invdt3
+  @inbounds @.. out = (k[1]*b1Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 + k[6]*b6Θdiff4)*invdt3
   out
 end
 
@@ -822,7 +838,7 @@ end
   @owrenzen5pre0
   # return @.. y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
   #                    k[7]*b7Θ + k[8]*b8Θ)
-  return y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+  return @inbounds y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
                   k[7]*b7Θ + k[8]*b8Θ)
 end
 
@@ -838,7 +854,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen5Cache,idxs::Nothing,T::Type{Val{0}})
   @owrenzen5pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ +
                            k[7]*b7Θ + k[8]*b8Θ)
   #@inbounds for i in eachindex(out)
   #  out[i] = y₀[i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ +
@@ -872,7 +888,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen5ConstantCache,OwrenZen5Cache},idxs::Nothing,T::Type{Val{1}})
   @owrenzen5pre1
-  return k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff +
+  return @inbounds k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff +
     k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff
 end
 
@@ -884,7 +900,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen5Cache,idxs::Nothing,T::Type{Val{1}})
   @owrenzen5pre1
-  @.. out = k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff +
+  @inbounds @.. out = k[1]*b1Θdiff + k[3]*b3Θdiff + k[4]*b4Θdiff +
         k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff
   #@inbounds for i in eachindex(out)
   #  out[i] = k[1][i]*b1Θdiff + k[3][i]*b3Θdiff + k[4][i]*b4Θdiff +
@@ -918,7 +934,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen5ConstantCache,OwrenZen5Cache},idxs::Nothing,T::Type{Val{2}})
   @owrenzen5pre2
-  return (k[1]*b1Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 +
+  return @inbounds (k[1]*b1Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 + k[5]*b5Θdiff2 +
     k[6]*b6Θdiff2 + k[7]*b7Θdiff2 + k[8]*b8Θdiff2)*invdt
 end
 
@@ -930,7 +946,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen5Cache,idxs::Nothing,T::Type{Val{2}})
   @owrenzen5pre2
-  @.. out = (k[1]*b1Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 +
+  @inbounds @.. out = (k[1]*b1Θdiff2 + k[3]*b3Θdiff2 + k[4]*b4Θdiff2 +
             k[5]*b5Θdiff2 + k[6]*b6Θdiff2 + k[7]*b7Θdiff2 + k[8]*b8Θdiff2)*invdt
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff2 + k[3][i]*b3Θdiff2 + k[4][i]*b4Θdiff2 +
@@ -964,7 +980,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen5ConstantCache,OwrenZen5Cache},idxs::Nothing,T::Type{Val{3}})
   @owrenzen5pre3
-  return (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 +
+  return @inbounds (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 + k[5]*b5Θdiff3 +
     k[6]*b6Θdiff3 + k[7]*b7Θdiff3 + k[8]*b8Θdiff3)*invdt2
 end
 
@@ -976,7 +992,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen5Cache,idxs::Nothing,T::Type{Val{3}})
   @owrenzen5pre3
-  @.. out = (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 +
+  @inbounds @.. out = (k[1]*b1Θdiff3 + k[3]*b3Θdiff3 + k[4]*b4Θdiff3 +
             k[5]*b5Θdiff3 + k[6]*b6Θdiff3 + k[7]*b7Θdiff3 + k[8]*b8Θdiff3)*invdt2
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff3 + k[3][i]*b3Θdiff3 + k[4][i]*b4Θdiff3 +
@@ -1010,7 +1026,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen5ConstantCache,OwrenZen5Cache},idxs::Nothing,T::Type{Val{4}})
   @owrenzen5pre4
-  return (k[1]*b1Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 +
+  return @inbounds (k[1]*b1Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 + k[5]*b5Θdiff4 +
     k[6]*b6Θdiff4 + k[7]*b7Θdiff4 + k[8]*b8Θdiff4)*invdt3
 end
 
@@ -1022,7 +1038,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen5Cache,idxs::Nothing,T::Type{Val{4}})
   @owrenzen5pre4
-  @.. out = (k[1]*b1Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 +
+  @inbounds @.. out = (k[1]*b1Θdiff4 + k[3]*b3Θdiff4 + k[4]*b4Θdiff4 +
             k[5]*b5Θdiff4 + k[6]*b6Θdiff4 + k[7]*b7Θdiff4 + k[8]*b8Θdiff4)*invdt3
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff4 + k[3][i]*b3Θdiff4 + k[4][i]*b4Θdiff4 +
@@ -1056,7 +1072,7 @@ end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{OwrenZen5ConstantCache,OwrenZen5Cache},idxs::Nothing,T::Type{Val{5}})
   @owrenzen5pre5
-  return (k[1]*b1Θdiff5 + k[3]*b3Θdiff5 + k[4]*b4Θdiff5 + k[5]*b5Θdiff5 +
+  return @inbounds (k[1]*b1Θdiff5 + k[3]*b3Θdiff5 + k[4]*b4Θdiff5 + k[5]*b5Θdiff5 +
     k[6]*b6Θdiff5 + k[7]*b7Θdiff5 + k[8]*b8Θdiff5)*invdt4
 end
 
@@ -1068,7 +1084,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::OwrenZen5Cache,idxs::Nothing,T::Type{Val{5}})
   @owrenzen5pre5
-  @.. out = (k[1]*b1Θdiff5 + k[3]*b3Θdiff5 + k[4]*b4Θdiff5 +
+  @inbounds @.. out = (k[1]*b1Θdiff5 + k[3]*b3Θdiff5 + k[4]*b4Θdiff5 +
             k[5]*b5Θdiff5 + k[6]*b6Θdiff5 + k[7]*b7Θdiff5 + k[8]*b8Θdiff5)*invdt4
   #@inbounds for i in eachindex(out)
   #  out[i] = (k[1][i]*b1Θdiff5 + k[3][i]*b3Θdiff5 + k[4][i]*b4Θdiff5 +
@@ -1116,7 +1132,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{BS5ConstantCache,BS5Cache},idxs::Nothing,T::Type{Val{0}})
   @bs5pre0
   # return @.. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
-  return y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ +
+  return @inbounds y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ +
                               k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
 end
 
@@ -1132,7 +1148,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::BS5Cache,idxs::Nothing,T::Type{Val{0}})
   @bs5pre0
-  @.. out = y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
+  @inbounds @.. out = y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
   #@inbounds for i in eachindex(out)
   #  out[i] = y₀[i] + dt*Θ*k[1][i] + dt*(k[1][i]*b1Θ  + k[3][i]*b3Θ + k[4][i]*b4Θ  + k[5][i]*b5Θ + k[6][i]*b6Θ + k[7][i]*b7Θ + k[8][i]*b8Θ + k[9][i]*b9Θ + k[10][i]*b10Θ + k[11][i]*b11Θ)
   #end
@@ -1165,7 +1181,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{BS5ConstantCache,BS5Cache},idxs::Nothing,T::Type{Val{1}})
   @bs5pre1
   # return @.. k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
-  return k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff +
+  return @inbounds k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff +
     k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff +
     k[10]*b10Θdiff + k[11]*b11Θdiff
 end
@@ -1176,7 +1192,7 @@ end
   #     k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff +
   #     k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff +
   #     k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff
-  return k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff +
+  return @inbounds k[1][idxs] + k[1][idxs]*b1Θdiff  + k[3][idxs]*b3Θdiff +
     k[4][idxs]*b4Θdiff  + k[5][idxs]*b5Θdiff + k[6][idxs]*b6Θdiff +
     k[7][idxs]*b7Θdiff + k[8][idxs]*b8Θdiff + k[9][idxs]*b9Θdiff +
     k[10][idxs]*b10Θdiff + k[11][idxs]*b11Θdiff
@@ -1184,7 +1200,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::BS5Cache,idxs::Nothing,T::Type{Val{1}})
   @bs5pre1
-  @.. out = k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
+  @inbounds @.. out = k[1] + k[1]*b1Θdiff  + k[3]*b3Θdiff + k[4]*b4Θdiff  + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff
   #@inbounds for i in eachindex(out)
   #  out[i] = k[1][i] + k[1][i]*b1Θdiff  + k[3][i]*b3Θdiff + k[4][i]*b4Θdiff  + k[5][i]*b5Θdiff + k[6][i]*b6Θdiff + k[7][i]*b7Θdiff + k[8][i]*b8Θdiff + k[9][i]*b9Θdiff + k[10][i]*b10Θdiff + k[11][i]*b11Θdiff
   #end
@@ -1223,7 +1239,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern6ConstantCache,Vern6Cache},idxs::Nothing,T::Type{Val{0}})
   @vern6pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
-  return y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
+  return @inbounds y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
                   k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
 end
 
@@ -1236,7 +1252,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern6Cache,idxs::Nothing,T::Type{Val{0}})
   @vern6pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
   out
 end
 
@@ -1263,7 +1279,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern6ConstantCache,Vern6Cache},idxs::Nothing,T::Type{Val{1}})
   @vern6pre1
   #@.. k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff
-  return k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff +
+  return @inbounds k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff +
     k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff +
     k[11]*b11Θdiff + k[12]*b12Θdiff
 end
@@ -1278,7 +1294,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern6Cache,idxs::Nothing,T::Type{Val{1}})
   @vern6pre1
-  @.. out = k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff
   out
 end
 
@@ -1313,7 +1329,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern7ConstantCache,Vern7Cache},idxs::Nothing,T::Type{Val{0}})
   @vern7pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
-  return y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
+  return @inbounds y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
                   k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ +
                   k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
 end
@@ -1328,7 +1344,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern7Cache,idxs::Nothing,T::Type{Val{0}})
   @vern7pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
   out
 end
 
@@ -1358,7 +1374,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern7ConstantCache,Vern7Cache},idxs::Nothing,T::Type{Val{1}})
   @vern7pre1
   #@.. k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff
-  return k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff +
+  return @inbounds k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff +
     k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff +
     k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff +
     k[16]*b16Θdiff
@@ -1375,7 +1391,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern7Cache,idxs::Nothing,T::Type{Val{1}})
   @vern7pre1
-  @.. out = k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff + k[4]*b4Θdiff + k[5]*b5Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[13]*b13Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff
   out
 end
 
@@ -1413,7 +1429,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern8ConstantCache,Vern8Cache},idxs::Nothing,T::Type{Val{0}})
   @vern8pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
-  return y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ +
+  return @inbounds y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ +
                   k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ +
                   k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ +
                   k[21]*b21Θ)
@@ -1431,7 +1447,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern8Cache,idxs::Nothing,T::Type{Val{0}})
   @vern8pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
   out
 end
 
@@ -1464,7 +1480,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern8ConstantCache,Vern8Cache},idxs::Nothing,T::Type{Val{1}})
   @vern8pre1
   #@.. k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
-  return k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff +
+  return @inbounds k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff +
     k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff +
     k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff +
     k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
@@ -1481,7 +1497,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern8Cache,idxs::Nothing,T::Type{Val{1}})
   @vern8pre1
-  @.. out = k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff + k[6]*b6Θdiff + k[7]*b7Θdiff + k[8]*b8Θdiff + k[9]*b9Θdiff + k[10]*b10Θdiff + k[11]*b11Θdiff + k[12]*b12Θdiff + k[14]*b14Θdiff + k[15]*b15Θdiff + k[16]*b16Θdiff + k[17]*b17Θdiff + k[18]*b18Θdiff + k[19]*b19Θdiff + k[20]*b20Θdiff + k[21]*b21Θdiff
   out
 end
 
@@ -1522,7 +1538,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern9ConstantCache,Vern9Cache},idxs::Nothing,T::Type{Val{0}})
   @vern9pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ + k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ + k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ + k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
-  return y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ +
+  return @inbounds y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ +
                   k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ +
                   k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ +
                   k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
@@ -1540,7 +1556,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern9Cache,idxs::Nothing,T::Type{Val{0}})
   @vern9pre0
-  @.. out = y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ + k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ + k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ + k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
+  @inbounds @.. out = y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ + k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ + k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ + k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
   out
 end
 
@@ -1576,7 +1592,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern9ConstantCache,Vern9Cache},idxs::Nothing,T::Type{Val{1}})
   @vern9pre1
   #@.. k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff
-  return k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
+  return @inbounds k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
     k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff +
     k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff +
     k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff +
@@ -1598,7 +1614,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern9Cache,idxs::Nothing,T::Type{Val{1}})
   @vern9pre1
-  @.. out = k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff
+  @inbounds @.. out = k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff
   out
 end
 
@@ -1635,7 +1651,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern9ConstantCache,Vern9Cache},idxs::Nothing,T::Type{Val{2}})
   @vern9pre2
   #@.. k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff
-  return (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
+  return @inbounds (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
           k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff +
           k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff +
           k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff +
@@ -1657,7 +1673,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern9Cache,idxs::Nothing,T::Type{Val{2}})
   @vern9pre2
-  @.. out = (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff)*invdt
+  @inbounds @.. out = (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff)*invdt
   out
 end
 
@@ -1694,7 +1710,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern9ConstantCache,Vern9Cache},idxs::Nothing,T::Type{Val{3}})
   @vern9pre3
   #@.. k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff
-  return (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
+  return @inbounds (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
           k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff +
           k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff +
           k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff +
@@ -1716,7 +1732,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern9Cache,idxs::Nothing,T::Type{Val{3}})
   @vern9pre3
-  @.. out = (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff)*invdt2
+  @inbounds @.. out = (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff)*invdt2
   out
 end
 
@@ -1753,7 +1769,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern9ConstantCache,Vern9Cache},idxs::Nothing,T::Type{Val{4}})
   @vern9pre4
   #@.. k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff
-  return (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
+  return @inbounds (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff +
           k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff +
           k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff +
           k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff +
@@ -1775,7 +1791,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::Vern9Cache,idxs::Nothing,T::Type{Val{4}})
   @vern9pre4
-  @.. out = (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff)*invdt3
+  @inbounds @.. out = (k[1]*b1Θdiff + k[2]*b8Θdiff + k[3]*b9Θdiff + k[4]*b10Θdiff + k[5]*b11Θdiff + k[6]*b12Θdiff + k[7]*b13Θdiff + k[8]*b14Θdiff + k[9]*b15Θdiff + k[11]*b17Θdiff + k[12]*b18Θdiff + k[13]*b19Θdiff + k[14]*b20Θdiff + k[15]*b21Θdiff + k[16]*b22Θdiff + k[17]*b23Θdiff + k[18]*b24Θdiff + k[19]*b25Θdiff + k[20]*b26Θdiff)*invdt3
   out
 end
 
@@ -1791,7 +1807,7 @@ end
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP8ConstantCache,DP8Cache},idxs::Nothing,T::Type{Val{0}})
   Θ1 = 1-Θ
   # return @.. y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
-  return y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
+  return @inbounds y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP8ConstantCache,DP8Cache},idxs,T::Type{Val{0}})
@@ -1802,7 +1818,7 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DP8Cache,idxs::Nothing,T::Type{Val{0}})
   Θ1 = 1-Θ
-  @.. out = y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
+  @inbounds @.. out = y₀ + dt*Θ*(k[1] + Θ1*(k[2] + Θ*(k[3]+Θ1*(k[4] + Θ*(k[5] + Θ1*(k[6]+Θ*k[7]))))))
   #@inbounds for i in eachindex(out)
   #  out[i] = y₀[i] + dt*Θ*(k[1][i] + Θ1*(k[2][i] + Θ*(k[3][i]+Θ1*(k[4][i] + Θ*(k[5][i] + Θ1*(k[6][i]+Θ*k[7][i]))))))
   #end
@@ -1819,13 +1835,13 @@ end
 end
 
 @muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{DP8ConstantCache,DP8Cache},idxs::Nothing,T::Type{Val{1}})
-  b1diff = @.. k[1] + k[2]
-  b2diff = @.. -2*k[2] + 2*k[3] + 2*k[4]
-  b3diff = @.. -3*k[3] - 6*k[4] + 3*k[5] + 3*k[6]
-  b4diff = @.. 4*k[4] - 8*k[5] - 12*k[6] + 4*k[7]
-  b5diff = @.. 5*k[5] + 15*k[6] - 15*k[7]
-  b6diff = @.. -6*k[6] + 18*k[7]
-  b7diff = @.. -7*k[7]
+  @inbounds b1diff = @.. k[1] + k[2]
+  @inbounds b2diff = @.. -2*k[2] + 2*k[3] + 2*k[4]
+  @inbounds b3diff = @.. -3*k[3] - 6*k[4] + 3*k[5] + 3*k[6]
+  @inbounds b4diff = @.. 4*k[4] - 8*k[5] - 12*k[6] + 4*k[7]
+  @inbounds b5diff = @.. 5*k[5] + 15*k[6] - 15*k[7]
+  @inbounds b6diff = @.. -6*k[6] + 18*k[7]
+  @inbounds b7diff = @.. -7*k[7]
   # return @.. b1diff + Θ*(b2diff + Θ*(b3diff + Θ*(b4diff + Θ*(b5diff + Θ*(b6diff + Θ*b7diff)))))
   return b1diff + Θ*(b2diff + Θ*(b3diff + Θ*(b4diff + Θ*(b5diff + Θ*(b6diff + Θ*b7diff)))))
 end
@@ -1924,10 +1940,10 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DPRKN6Cache,idxs::Nothing,T::Type{Val{0}})
   @dprkn6pre0
-  @.. out.x[2]  = uprev + dt*Θ*(duprev + dt*Θ*(b1Θ*k1 +
+  @inbounds @.. out.x[2]  = uprev + dt*Θ*(duprev + dt*Θ*(b1Θ*k1 +
                                                     b3Θ*k3 +
                                                     b4Θ*k4 + b5Θ*k5 + b6Θ*k6))
-  @.. out.x[1] =  duprev + dt*Θ*(bp1Θ*k1 + bp3Θ*k3 +
+  @inbounds @.. out.x[1] =  duprev + dt*Θ*(bp1Θ*k1 + bp3Θ*k3 +
                                    bp4Θ*k4 + bp5Θ*k5 + bp6Θ*k6)
   #for i in eachindex(out.x[1])
   #  out.x[2][i]  = uprev[i] + dt*Θ*(duprev[i] + dt*Θ*(b1Θ*k1[i] +
@@ -1941,10 +1957,10 @@ end
 
 @muladd function _ode_interpolant!(out,Θ,dt,y₀,y₁,k,cache::DPRKN6Cache,idxs,T::Type{Val{0}})
   @dprkn6pre0
-  @.. out.x[2]  = uprev[idxs] + dt*Θ*(duprev[idxs] + dt*Θ*(b1Θ*k1[idxs] +
+  @inbounds @.. out.x[2]  = uprev[idxs] + dt*Θ*(duprev[idxs] + dt*Θ*(b1Θ*k1[idxs] +
                                                     b3Θ*k3[idxs] +
                                                     b4Θ*k4[idxs] + b5Θ*k5[idxs] + b6Θ*k6[idxs]))
-  @.. out.x[1] = duprev[idxs] + dt*Θ*(bp1Θ*k1[idxs] + bp3Θ*k3[idxs] +
+  @inbounds @.. out.x[1] = duprev[idxs] + dt*Θ*(bp1Θ*k1[idxs] + bp3Θ*k3[idxs] +
                                   bp4Θ*k4[idxs] + bp5Θ*k5[idxs] + bp6Θ*k6[idxs])
   #for (j,i) in enumerate(idxs)
   #  out.x[2][j]  = uprev[i] + dt*Θ*(duprev[i] + dt*Θ*(b1Θ*k1[i] +

--- a/src/dense/interpolants.jl
+++ b/src/dense/interpolants.jl
@@ -1129,10 +1129,17 @@ end
   b11Θ = @evalpoly(Θ, 0, 0, r112, r113, r114, r115, r116)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{BS5ConstantCache,BS5Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::BS5ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @bs5pre0
   # return @.. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
   return @inbounds y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ +
+                              k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::BS5Cache,idxs::Nothing,T::Type{Val{0}})
+  @bs5pre0
+  # return @.. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
+  return @inbounds @.. y₀ + dt*Θ*k[1] + dt*(k[1]*b1Θ  + k[3]*b3Θ + k[4]*b4Θ  + k[5]*b5Θ +
                               k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ)
 end
 
@@ -1236,10 +1243,17 @@ end
   b12Θ = @evalpoly(Θ, 0,    0, r122, r123, r124, r125, r126)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern6ConstantCache,Vern6Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern6ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @vern6pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
   return @inbounds y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
+                  k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern6Cache,idxs::Nothing,T::Type{Val{0}})
+  @vern6pre0
+  #@.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
+  return @inbounds @.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
                   k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ)
 end
 
@@ -1326,10 +1340,18 @@ end
   b16Θ = @evalpoly(Θ, 0,    0, r162, r163, r164, r165, r166, r167)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern7ConstantCache,Vern7Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern7ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @vern7pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
   return @inbounds y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
+                  k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ +
+                  k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern7Cache,idxs::Nothing,T::Type{Val{0}})
+  @vern7pre0
+  #@.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
+  return @inbounds @.. y₀ + dt*(k[1]*b1Θ + k[4]*b4Θ + k[5]*b5Θ + k[6]*b6Θ + k[7]*b7Θ +
                   k[8]*b8Θ + k[9]*b9Θ + k[11]*b11Θ + k[12]*b12Θ + k[13]*b13Θ +
                   k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ)
 end
@@ -1426,10 +1448,19 @@ end
   b21Θ = @evalpoly(Θ, 0,    0, r212, r213, r214, r215, r216, r217, r218)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern8ConstantCache,Vern8Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern8ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @vern8pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
   return @inbounds y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ +
+                  k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ +
+                  k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ +
+                  k[21]*b21Θ)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern8Cache,idxs::Nothing,T::Type{Val{0}})
+  @vern8pre0
+  #@.. y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ + k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ + k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ + k[21]*b21Θ)
+  return @inbounds @.. y₀ + dt*(k[1]*b1Θ + k[6]*b6Θ + k[7]*b7Θ + k[8]*b8Θ + k[9]*b9Θ +
                   k[10]*b10Θ + k[11]*b11Θ + k[12]*b12Θ + k[14]*b14Θ + k[15]*b15Θ +
                   k[16]*b16Θ + k[17]*b17Θ + k[18]*b18Θ + k[19]*b19Θ + k[20]*b20Θ +
                   k[21]*b21Θ)
@@ -1535,10 +1566,19 @@ end
   b26Θ = @evalpoly(Θ, 0,    0, r262, r263, r264, r265, r266, r267, r268, r269)
 end
 
-@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Union{Vern9ConstantCache,Vern9Cache},idxs::Nothing,T::Type{Val{0}})
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern9ConstantCache,idxs::Nothing,T::Type{Val{0}})
   @vern9pre0
   #@.. y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ + k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ + k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ + k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
   return @inbounds y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ +
+                  k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ +
+                  k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ +
+                  k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
+end
+
+@muladd function _ode_interpolant(Θ,dt,y₀,y₁,k,cache::Vern9Cache,idxs::Nothing,T::Type{Val{0}})
+  @vern9pre0
+  #@.. y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ + k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ + k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ + k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)
+  return @inbounds @.. y₀ + dt*(k[1]*b1Θ + k[2]*b8Θ + k[3]*b9Θ + k[4]*b10Θ + k[5]*b11Θ +
                   k[6]*b12Θ + k[7]*b13Θ + k[8]*b14Θ + k[9]*b15Θ + k[11]*b17Θ +
                   k[12]*b18Θ + k[13]*b19Θ + k[14]*b20Θ + k[15]*b21Θ + k[16]*b22Θ +
                   k[17]*b23Θ + k[18]*b24Θ + k[19]*b25Θ + k[20]*b26Θ)


### PR DESCRIPTION
Works around some issues in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/985#issuecomment-561423105 in common cases. I assume StaticArrays broadcast will be fixed sooner or later, so I didn't spend the time to do the derivative of every single method, but at least common cases should be more optimized.