### PR TITLE
Implementation of DABDF2

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -238,5 +238,5 @@ module OrdinaryDiffEq
   export AitkenNeville, ExtrapolationMidpointDeuflhard, ExtrapolationMidpointHairerWanner, ImplicitEulerExtrapolation,
          ImplicitDeuflhardExtrapolation, ImplicitHairerWannerExtrapolation
 
-  export KuttaPRK2p5, PDIRK44, DImplicitEuler
+  export KuttaPRK2p5, PDIRK44, DImplicitEuler, DABDF2
 end # module

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -55,6 +55,7 @@ isadaptive(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false
 isadaptive(alg::OrdinaryDiffEqAdaptiveAlgorithm) = true
 isadaptive(alg::OrdinaryDiffEqCompositeAlgorithm) = all(isadaptive.(alg.algs))
 isadaptive(alg::DImplicitEuler) = true
+isadaptive(alg::DABDF2) = true
 
 qmin_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1//5
 qmin_default(alg::CompositeAlgorithm) = maximum(qmin_default.(alg.algs))
@@ -85,6 +86,7 @@ alg_extrapolates(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false
 alg_extrapolates(alg::CompositeAlgorithm) = any(alg_extrapolates.(alg.algs))
 alg_extrapolates(alg::ImplicitEuler) = true
 alg_extrapolates(alg::DImplicitEuler) = true
+alg_extrapolates(alg::DABDF2) = true
 alg_extrapolates(alg::Trapezoid) = true
 alg_extrapolates(alg::ImplicitMidpoint) = true
 alg_extrapolates(alg::TRBDF2) = true
@@ -349,6 +351,7 @@ alg_order(alg::MEBDF2) = 2
 alg_order(alg::PDIRK44) = 4
 
 alg_order(alg::DImplicitEuler) = 1
+alg_order(alg::DABDF2) = 2
 
 alg_maximum_order(alg) = alg_order(alg)
 alg_maximum_order(alg::CompositeAlgorithm) = maximum(alg_order(x) for x in alg.algs)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1081,3 +1081,20 @@ DImplicitEuler(;chunk_size=0,autodiff=true,diff_type=Val{:forward},
                           DImplicitEuler{chunk_size,autodiff,typeof(linsolve),
                           typeof(nlsolve),typeof(diff_type)}(linsolve,
                           nlsolve,diff_type,extrapolant,controller)
+
+
+struct DABDF2{CS,AD,F,F2,FDT} <: DAEAlgorithm{CS,AD}
+  linsolve::F
+  nlsolve::F2
+  diff_type::FDT
+  extrapolant::Symbol
+  controller::Symbol
+end
+DABDF2(;chunk_size=0,autodiff=true,diff_type=Val{:forward},
+                          linsolve=DEFAULT_LINSOLVE,nlsolve=NLNewton(),
+                          extrapolant=:constant,
+                          controller=:Standard) =
+                          DABDF2{chunk_size,autodiff,typeof(linsolve),
+                          typeof(nlsolve),typeof(diff_type)}(linsolve,
+                          nlsolve,diff_type,extrapolant,controller)
+

--- a/src/caches/dae_caches.jl
+++ b/src/caches/dae_caches.jl
@@ -57,7 +57,6 @@ end
   uₙ₋₂::uType
   fsalfirst::rateType
   fsalfirstprev::rateType
-  zₙ₋₁::uType
   atmp::uNoUnitsType
   nlsolver::N
   eulercache::DImplicitEulerCache
@@ -77,8 +76,7 @@ function alg_cache(alg::DABDF2,du,u,res_prototype,rate_prototype,uEltypeNoUnits,
   eulercache = DImplicitEulerCache(u,uprev,uprev2,atmp,nlsolver)
 
   dtₙ₋₁ = one(dt)
-  zₙ₋₁ = zero(u)
 
-  DABDF2Cache(u,uprev,uprev2,fsalfirst,fsalfirstprev,zₙ₋₁,atmp,
+  DABDF2Cache(u,uprev,uprev2,fsalfirst,fsalfirstprev,atmp,
               nlsolver,eulercache,dtₙ₋₁)
 end

--- a/src/caches/dae_caches.jl
+++ b/src/caches/dae_caches.jl
@@ -2,7 +2,6 @@
   u::uType
   uprev::uType
   uprev2::uType
-  tmp::uType
   atmp::uNoUnitsType
   nlsolver::N
 end
@@ -28,7 +27,58 @@ function alg_cache(alg::DImplicitEuler,du,u,res_prototype,rate_prototype,uEltype
   nlsolver = build_nlsolver(alg,u,uprev,p,t,dt,f,res_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,α,Val(true))
 
   atmp = similar(u,uEltypeNoUnits)
-  tmp = similar(u)
 
-  DImplicitEulerCache(u,uprev,uprev2,tmp,atmp,nlsolver)
+  DImplicitEulerCache(u,uprev,uprev2,atmp,nlsolver)
+end
+
+@cache mutable struct DABDF2ConstantCache{N,dtType,rate_prototype} <: OrdinaryDiffEqConstantCache
+  nlsolver::N
+  eulercache::DImplicitEulerConstantCache
+  dtₙ₋₁::dtType
+  fsalfirstprev::rate_prototype
+end
+
+function alg_cache(alg::DABDF2,du,u,res_prototype,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,
+                   uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
+  γ, c = 1//1, 1
+  α = 1//1
+  nlsolver = build_nlsolver(alg,u,uprev,p,t,dt,f,res_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,α,Val(false))
+  eulercache = DImplicitEulerConstantCache(nlsolver)
+
+  dtₙ₋₁ = one(dt)
+  fsalfirstprev = rate_prototype
+
+  DABDF2ConstantCache(nlsolver, eulercache, dtₙ₋₁, fsalfirstprev)
+end
+
+@cache mutable struct DABDF2Cache{uType,rateType,uNoUnitsType,N,dtType} <: OrdinaryDiffEqMutableCache
+  uₙ::uType
+  uₙ₋₁::uType
+  uₙ₋₂::uType
+  fsalfirst::rateType
+  fsalfirstprev::rateType
+  zₙ₋₁::uType
+  atmp::uNoUnitsType
+  nlsolver::N
+  eulercache::DImplicitEulerCache
+  dtₙ₋₁::dtType
+end
+
+function alg_cache(alg::DABDF2,du,u,res_prototype,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
+                   tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  γ, c = 1//1, 1
+  α = 1//1
+  nlsolver = build_nlsolver(alg,u,uprev,p,t,dt,f,res_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,α,Val(true))
+  fsalfirst = zero(rate_prototype)
+
+  fsalfirstprev = zero(rate_prototype)
+  atmp = similar(u,uEltypeNoUnits)
+
+  eulercache = DImplicitEulerCache(u,uprev,uprev2,atmp,nlsolver)
+
+  dtₙ₋₁ = one(dt)
+  zₙ₋₁ = zero(u)
+
+  DABDF2Cache(u,uprev,uprev2,fsalfirst,fsalfirstprev,zₙ₋₁,atmp,
+              nlsolver,eulercache,dtₙ₋₁)
 end

--- a/src/perform_step/dae_perform_step.jl
+++ b/src/perform_step/dae_perform_step.jl
@@ -128,7 +128,7 @@ end
 
 @muladd function perform_step!(integrator, cache::DABDF2Cache, repeat_step=false)
   @unpack t,dt,f,p = integrator
-  @unpack atmp,dtₙ₋₁,zₙ₋₁,nlsolver = cache
+  @unpack atmp,dtₙ₋₁,nlsolver = cache
   @unpack z,tmp = nlsolver
   alg = unwrap_alg(integrator, true)
   uₙ,uₙ₋₁,uₙ₋₂,dtₙ = integrator.u,integrator.uprev,integrator.uprev2,integrator.dt
@@ -158,8 +158,8 @@ end
   integrator.destats.nf += 1
   if integrator.opts.adaptive
     btilde0 = (dtₙ₋₁+dtₙ)*1//6
-    btilde1 = 1+dtₙ/dtₙ₋₁
-    btilde2 = dtₙ/dtₙ₋₁
+    btilde1 = 1+ρ
+    btilde2 = ρ
     @.. tmp = btilde0*(integrator.fsallast - btilde1*integrator.fsalfirst + btilde2*cache.fsalfirstprev)
     calculate_residuals!(atmp, tmp, uₙ₋₁, uₙ, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
     integrator.EEst = integrator.opts.internalnorm(atmp,t)

--- a/src/perform_step/dae_perform_step.jl
+++ b/src/perform_step/dae_perform_step.jl
@@ -39,7 +39,8 @@ end
 
 @muladd function perform_step!(integrator, cache::DImplicitEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack atmp,tmp,nlsolver = cache
+  @unpack atmp,nlsolver = cache
+  @unpack tmp = nlsolver
   alg = unwrap_alg(integrator, true)
 
   @. nlsolver.z = false
@@ -69,3 +70,108 @@ end
     integrator.EEst = 1
   end
 end
+
+function initialize!(integrator, cache::DABDF2ConstantCache) end
+
+@muladd function perform_step!(integrator, cache::DABDF2ConstantCache, repeat_step=false)
+  @unpack t,f,p = integrator
+  @unpack dtₙ₋₁,nlsolver = cache
+  alg = unwrap_alg(integrator, true)
+  dtₙ, uₙ, uₙ₋₁, uₙ₋₂ = integrator.dt, integrator.u, integrator.uprev, integrator.uprev2
+
+  if integrator.iter == 1 && !integrator.u_modified
+    cache.dtₙ₋₁ = dtₙ
+    perform_step!(integrator, cache.eulercache, repeat_step)
+    integrator.fsalfirst = @.. (integrator.u - integrator.uprev) / dtₙ
+    cache.fsalfirstprev = integrator.fsalfirst
+    return
+  end
+
+  # precalculations
+  ρ = dtₙ/dtₙ₋₁
+  c1 = ρ^2/(1+2ρ)
+
+  nlsolver.γ = (1+ρ)/(1+2ρ)
+  nlsolver.α = 1//1
+
+  nlsolver.z = zero(uₙ)
+
+  nlsolver.tmp = -c1 * uₙ₋₁ + c1 * uₙ₋₂
+  z = nlsolve!(nlsolver, integrator, cache, repeat_step)
+  nlsolvefail(nlsolver) && return
+
+  uₙ = uₙ₋₁ + z
+  integrator.fsallast = @.. z/dtₙ
+
+  if integrator.opts.adaptive
+    tmp = integrator.fsallast - (1+dtₙ/dtₙ₋₁)*integrator.fsalfirst + (dtₙ/dtₙ₋₁)*cache.fsalfirstprev
+    est = (dtₙ₋₁+dtₙ)/6 * tmp
+    atmp = calculate_residuals(est, uₙ₋₁, uₙ, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
+    integrator.EEst = integrator.opts.internalnorm(atmp,t)
+  end
+
+  ################################### Finalize
+
+  if integrator.EEst < one(integrator.EEst)
+    cache.fsalfirstprev = integrator.fsalfirst
+    cache.dtₙ₋₁ = dtₙ
+  end
+
+  integrator.u = uₙ
+  return
+end
+
+function initialize!(integrator, cache::DABDF2Cache)
+  integrator.fsalfirst = cache.fsalfirst
+  integrator.fsallast = du_alias_or_new(cache.nlsolver, integrator.fsalfirst)
+end
+
+@muladd function perform_step!(integrator, cache::DABDF2Cache, repeat_step=false)
+  @unpack t,dt,f,p = integrator
+  @unpack atmp,dtₙ₋₁,zₙ₋₁,nlsolver = cache
+  @unpack z,tmp = nlsolver
+  alg = unwrap_alg(integrator, true)
+  uₙ,uₙ₋₁,uₙ₋₂,dtₙ = integrator.u,integrator.uprev,integrator.uprev2,integrator.dt
+
+  if integrator.iter == 1 && !integrator.u_modified
+    cache.dtₙ₋₁ = dtₙ
+    perform_step!(integrator, cache.eulercache, repeat_step)
+    @.. integrator.fsalfirst = (uₙ - uₙ₋₁) / dt
+    cache.fsalfirstprev .= integrator.fsalfirst
+    return
+  end
+
+  # precalculations
+  ρ = dtₙ/dtₙ₋₁
+  c1 = ρ^2/(1+2ρ)
+
+  nlsolver.γ = (1+ρ)/(1+2ρ)
+  nlsolver.α = 1//1
+  @.. nlsolver.tmp = -c1 * uₙ₋₁ + c1 * uₙ₋₂
+  nlsolver.z .= zero(eltype(z))
+  z = nlsolve!(nlsolver, integrator, cache, repeat_step)
+  nlsolvefail(nlsolver) && return
+
+  @.. uₙ = uₙ₋₁ + z
+
+  @.. integrator.fsallast = z / dtₙ
+  integrator.destats.nf += 1
+  if integrator.opts.adaptive
+    btilde0 = (dtₙ₋₁+dtₙ)*1//6
+    btilde1 = 1+dtₙ/dtₙ₋₁
+    btilde2 = dtₙ/dtₙ₋₁
+    @.. tmp = btilde0*(integrator.fsallast - btilde1*integrator.fsalfirst + btilde2*cache.fsalfirstprev)
+    calculate_residuals!(atmp, tmp, uₙ₋₁, uₙ, integrator.opts.abstol, integrator.opts.reltol,integrator.opts.internalnorm,t)
+    integrator.EEst = integrator.opts.internalnorm(atmp,t)
+  end
+
+  ################################### Finalize
+
+  if integrator.EEst < one(integrator.EEst)
+    @.. cache.fsalfirstprev = integrator.fsalfirst
+    cache.dtₙ₋₁ = dtₙ
+  end
+  return
+end
+
+

--- a/test/algconvergence/dae_convergence_tests.jl
+++ b/test/algconvergence/dae_convergence_tests.jl
@@ -20,6 +20,12 @@ prob_dae_linear_iip = DAEProblem(
 
 	sim12 = test_convergence(dts,prob,DImplicitEuler(;autodiff=false))
 	@test sim12.𝒪est[:final] ≈ 1 atol=testTol
+
+	sim13 = test_convergence(dts,prob,DABDF2())
+	@test sim11.𝒪est[:final] ≈ 1 atol=testTol
+
+	sim14 = test_convergence(dts,prob,DABDF2(;autodiff=false))
+	@test sim12.𝒪est[:final] ≈ 1 atol=testTol
 end
 
 f_dae_linear = (du, u, p, t) -> (@. du - u)
@@ -36,5 +42,11 @@ prob_dae_linear_oop = DAEProblem(
 	@test sim21.𝒪est[:final] ≈ 1 atol=testTol
 
 	sim22 = test_convergence(dts,prob,DImplicitEuler(;autodiff=false))
+	@test sim22.𝒪est[:final] ≈ 1 atol=testTol
+
+	sim23 = test_convergence(dts,prob,DABDF2())
+	@test sim21.𝒪est[:final] ≈ 1 atol=testTol
+
+	sim24 = test_convergence(dts,prob,DABDF2(;autodiff=false))
 	@test sim22.𝒪est[:final] ≈ 1 atol=testTol
 end


### PR DESCRIPTION
[1-s2.0-S1877050914002683-main.pdf](https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/files/4127787/1-s2.0-S1877050914002683-main.pdf)

Following the above attached paper for adaptive timesteps. I am not sure why this one just stops to work after a point.

```julia
using OrdinaryDiffEq
f = (res,du,u,p,t) -> @. res = du - u

prob = DAEProblem(f, [1.0], [1.0], (0.0,1.0))
sol = solve(prob,DABDF2())

@show sol
```
with output:
```
┌ Warning: dt <= dtmin. Aborting. There is either an error in your model specification or the true solution is unstable.
└ @ DiffEqBase ~/.julia/dev/DiffEqBase/src/integrator_interface.jl:333
sol = retcode: DtLessThanMin
Interpolation: 1st order linear
t: [0.0, 1.0e-6, 1.2e-6, 3.2e-6, 5.620401881917461e-6, 2.9824420701092077e-5, 0.00027186460889283825, 0.0026922664908102995, 0.02689628530998491, 0.06989029193594178, 0.08940773194159744, 0.11084484509466672, 0.14258374369752538, 0.2065332303231047, 0.284827344784837, 0.34041171112943036, 0.3964743239105096, 0.4814328368662226, 0.5760179317526234, 0.6534784822471223, 0.7316662677038883, 0.9042384190537757]
u: Array{Float64,1}[[1.0], [1.000001000001], [1.0000012000012344], [1.0000032000057024], [1.0000056204182879], [1.000029824866205], [1.0002719015702048], [1.0026958952726326], [1.0272626620870167], [1.0724064967824645], [1.093547530369399], [1.1172472111888005], [1.153284850584885], [1.2295012207548244], [1.32978056224089], [1.4058860868766831], [1.4870450033494689], [1.6191264278172222], [1.7801425663643893], [1.9238375352896016], [2.0806199802181204], [2.4746504551310258]]
```

Solution upto t = 0.9042384190537757 is correct. Non adaptive version works and convergence test work well too.
