### PR TITLE
Fix inability to use sparse Jacobian with colorvec for OOP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ArrayInterface = "1.1, 2.0"
 DataStructures = "0.17"
-DiffEqBase = "6.17.1"
+DiffEqBase = "6.19"
 ExponentialUtilities = "1.2"
 FiniteDiff = "2"
 ForwardDiff = "0.10.3"

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
 ArrayInterface = "1.1, 2.0"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
 ArrayInterface = "1.1, 2.0"

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -5,7 +5,7 @@ module OrdinaryDiffEq
 
   using Logging
 
-  using MuladdMacro, SparseArrays
+  using MuladdMacro, SparseArrays, SuiteSparse
 
   using LinearAlgebra
 

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -5,7 +5,7 @@ module OrdinaryDiffEq
 
   using Logging
 
-  using MuladdMacro, SparseArrays, SuiteSparse
+  using MuladdMacro, SparseArrays
 
   using LinearAlgebra
 

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -531,7 +531,11 @@ function build_J_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits,::Val{IIP}) where IIP
     end
     W = WOperator(f.mass_matrix, dt, J, IIP)
   else
-    J = false .* _vec(u) .* _vec(u)'
+    J = if f.jac_prototype === nothing
+      false .* _vec(u) .* _vec(u)'
+    else
+      deepcopy(f.jac_prototype)
+    end
     isdae = alg isa DAEAlgorithm
     W = if isdae
       J

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -543,9 +543,18 @@ function build_J_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits,::Val{IIP}) where IIP
       elseif u isa Number
         u
       else
-        LU{LinearAlgebra.lutype(uEltypeNoUnits)}(Matrix{uEltypeNoUnits}(undef, 0, 0),
-                                                     Vector{LinearAlgebra.BlasInt}(undef, 0),
-                                                     zero(LinearAlgebra.BlasInt))
+        # TODO: make this more general, maybe by running calc_W and use its returned value
+        if f.jac_prototype isa SparseMatrixCSC
+          SuiteSparse.UMFPACK.UmfpackLU(Ptr{Cvoid}(), Ptr{Cvoid}(), 1, 1,
+                                        f.jac_prototype.colptr[1:1],
+                                        f.jac_prototype.rowval[1:1],
+                                        f.jac_prototype.nzval[1:1],
+                                        0)
+        else
+          LU{LinearAlgebra.lutype(uEltypeNoUnits)}(Matrix{uEltypeNoUnits}(undef, 0, 0),
+                                                   Vector{LinearAlgebra.BlasInt}(undef, 0),
+                                                   zero(LinearAlgebra.BlasInt))
+        end
       end
     end # end W
   end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -542,18 +542,8 @@ function build_J_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits,::Val{IIP}) where IIP
     elseif IIP
       similar(J)
     else
-      if u isa StaticArray
-        lu(J)
-      elseif u isa Number
-        u
-      elseif f.jac_prototype===nothing
-        LU{LinearAlgebra.lutype(uEltypeNoUnits)}(Matrix{uEltypeNoUnits}(undef, 0, 0),
-                                                 Vector{LinearAlgebra.BlasInt}(undef, 0),
-                                                 zero(LinearAlgebra.BlasInt))
-      else
-        ArrayInterface.lu_instance(f.jac_prototype)
-      end
-    end # end W
+      ArrayInterface.lu_instance(J)
+    end
   end
   return J, W
 end

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -39,7 +39,7 @@ end
 jacobian_autodiff(f, x, odefun) = (ForwardDiff.derivative(f,x),1)
 function jacobian_autodiff(f, x::AbstractArray, odefun)
   colorvec = DiffEqBase.has_colorvec(odefun) ? odefun.colorvec : 1:length(x)
-  sparsity = odefun.jac_prototype
+  sparsity = odefun.sparsity
   jac_prototype = odefun.jac_prototype
   maxcolor = maximum(colorvec)
   chunksize = getsize(default_chunk_size(maxcolor))
@@ -72,7 +72,7 @@ function jacobian(f, x, integrator)
       J, tmp = jacobian_autodiff(f, x, integrator.f)
     else
       colorvec = DiffEqBase.has_colorvec(integrator.f) ? integrator.f.colorvec : 1:length(x)
-      sparsity = integrator.f.jac_prototype
+      sparsity = integrator.f.sparsity
       jac_prototype = integrator.f.jac_prototype
       dir = diffdir(integrator)
       J, tmp = jacobian_finitediff(f, x, alg.diff_type, dir, colorvec, sparsity, jac_prototype)
@@ -83,10 +83,10 @@ end
 
 jacobian_finitediff_forward!(J,f,x,jac_config,forwardcache,integrator,colorvec)=
   (FiniteDiff.finite_difference_jacobian!(J,f,x,jac_config,forwardcache,
-    dir=diffdir(integrator),colorvec=colorvec,sparsity=integrator.f.jac_prototype);maximum(colorvec))
+    dir=diffdir(integrator),colorvec=colorvec,sparsity=integrator.f.sparsity);maximum(colorvec))
 jacobian_finitediff!(J,f,x,jac_config,integrator,colorvec)=
   (FiniteDiff.finite_difference_jacobian!(J,f,x,jac_config,
-    dir=diffdir(integrator),colorvec=colorvec,sparsity=integrator.f.jac_prototype);2*maximum(colorvec))
+    dir=diffdir(integrator),colorvec=colorvec,sparsity=integrator.f.sparsity);2*maximum(colorvec))
 
 function jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number}, fx::AbstractArray{<:Number}, integrator::DiffEqBase.DEIntegrator, jac_config)
     alg = unwrap_alg(integrator, true)
@@ -113,7 +113,7 @@ function DiffEqBase.build_jac_config(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgor
   if !DiffEqBase.has_jac(f) && ((!transform && !DiffEqBase.has_Wfact(f)) || (transform && !DiffEqBase.has_Wfact_t(f)))
     if alg_autodiff(alg)
       colorvec = DiffEqBase.has_colorvec(f) ? f.colorvec : 1:length(uprev)
-      sparsity = f.jac_prototype
+      sparsity = f.sparsity
       jac_prototype = f.jac_prototype
       jac_config = ForwardColorJacCache(uf,uprev,colorvec=colorvec,sparsity=sparsity)
     else

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -41,7 +41,7 @@ function jacobian_autodiff(f, x::AbstractArray, odefun)
   if DiffEqBase.has_colorvec(odefun)
     colorvec = odefun.colorvec
     sparsity = odefun.jac_prototype
-    jac_prototype = nothing
+    jac_prototype = odefun.jac_prototype
   else
     colorvec = 1:length(x)
     sparsity = nothing
@@ -71,7 +71,6 @@ jacobian_finitediff(f, x, diff_type, dir, colorvec, sparsity, jac_prototype) =
 jacobian_finitediff(f, x::AbstractArray, diff_type, dir, colorvec, sparsity, jac_prototype) =
     (FiniteDiff.finite_difference_jacobian(f, x, diff_type, eltype(x), diff_type==Val{:forward} ? f(x) : similar(x),
       dir = dir, colorvec = colorvec, sparsity = sparsity, jac_prototype = jac_prototype),_nfcount(maximum(colorvec),diff_type))
-
 function jacobian(f, x, integrator)
     alg = unwrap_alg(integrator, true)
     local tmp

--- a/test/interface/sparsediff_tests.jl
+++ b/test/interface/sparsediff_tests.jl
@@ -72,7 +72,6 @@ for f in [f_oop, f_ip]
             (f, Solver) == (f_oop, KenCarp4) ||
             (f, Solver) == (f_ip, KenCarp4)
           )
-          # @show i
           sol=solve(prob,Solver(autodiff=ad),reltol=tol,abstol=tol)
           @test sol.retcode==:Success
           if tol !=nothing

--- a/test/interface/sparsediff_tests.jl
+++ b/test/interface/sparsediff_tests.jl
@@ -55,7 +55,6 @@ for f in [f_oop, f_ip]
   for ad in [true, false]
     for Solver in [Rodas5, Trapezoid, KenCarp4]
       for tol in [nothing, 1e-10]
-        # @show f,ad,Solver,tol
         sol_std=solve(prob_std,Solver(autodiff=ad),reltol=tol,abstol=tol)
         @test sol_std.retcode==:Success
         for (i,prob) in enumerate(map(f->ODEProblem(f,u0,tspan),
@@ -63,6 +62,8 @@ for f in [f_oop, f_ip]
                          ODEFunction(f,jac_prototype=jac_sp),
                          ODEFunction(f,colorvec=colors)
                          ]))
+          # TODO: these broken test-cases need to be investigated.
+          #       Note they only happen for prob=ODEFunction(f,colorvec=colors).
           isbroken = i==3 && (
             (f, ad, tol) == (f_oop, true, nothing) ||
             (f, ad, Solver, tol) == (f_oop, false, Trapezoid, nothing) ||


### PR DESCRIPTION
As discussed on slack, this allows to use a sparse jacobian for out-of-place objective functions.  This works for my case but probably could be done more general.

The solve time of https://gist.github.com/mauro3/e85c85a4257a46ed73999b08f9b80ec2 (a FD PDE code) improves from >100s to <1s with this PR.